### PR TITLE
refactor: rename binary from claude-hooks to cadence-hooks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -63,8 +63,8 @@ jobs:
           MATRIX_NAME: ${{ matrix.name }}
         run: |
           VERSION="${GITHUB_REF_NAME}"
-          ARCHIVE="claude-hooks-${VERSION}-${MATRIX_NAME}.tar.gz"
-          tar -czf "${ARCHIVE}" -C "target/${TARGET}/release" claude-hooks
+          ARCHIVE="cadence-hooks-${VERSION}-${MATRIX_NAME}.tar.gz"
+          tar -czf "${ARCHIVE}" -C "target/${TARGET}/release" cadence-hooks
           echo "ARCHIVE=${ARCHIVE}" >> "${GITHUB_ENV}"
 
       - name: Upload artifact
@@ -84,17 +84,17 @@ jobs:
           merge-multiple: true
 
       - name: Generate checksums
-        run: sha256sum claude-hooks-*.tar.gz > checksums.txt
+        run: sha256sum cadence-hooks-*.tar.gz > checksums.txt
 
       - name: Attest build provenance
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: claude-hooks-*.tar.gz
+          subject-path: cadence-hooks-*.tar.gz
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |
-            claude-hooks-*.tar.gz
+            cadence-hooks-*.tar.gz
             checksums.txt

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - Initial implementation: 19 hooks across 4 plugin crates
-- Core protocol library (`claude-hooks-core`) with `Check` trait, JSON parsing, exit codes
+- Core protocol library (`cadence-hooks-core`) with `Check` trait, JSON parsing, exit codes
 - **cadence** hooks: terminology, orphaned-todos, prevent-secret-leaks, prevent-secret-writes, memory-guard, git-safety, line-endings, env-vars, warn-untracked, markdown-lint
 - **guardrails** hooks: guard-push-remote, guard-gh-write, guard-gh-dangerous, guard-git-init, warn-main-branch, check-idle-return
 - **rules** hooks: validate-frontmatter, security-patterns

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,12 +1,12 @@
 # Contributing
 
-Thank you for your interest in claude-hooks. This project is currently maintained as a personal tool, but contributions are welcome.
+Thank you for your interest in cadence-hooks. This project is currently maintained as a personal tool, but contributions are welcome.
 
 ## Getting Started
 
 ```bash
-git clone https://github.com/cameronsjo/claude-hooks.git
-cd claude-hooks
+git clone https://github.com/cameronsjo/cadence-hooks.git
+cd cadence-hooks
 make ci    # Run fmt check, clippy, and tests
 ```
 
@@ -24,7 +24,7 @@ Requires Rust 2024 edition (1.85+).
 - **Conventional Commits**: `type(scope): description` (e.g., `fix(cadence): scope safe-template check to target`)
 - **cargo fmt** and **cargo clippy** must pass with zero warnings
 - Tests are in-file `#[cfg(test)] mod tests` blocks, not separate files
-- Each check implements the `Check` trait from `claude-hooks-core`
+- Each check implements the `Check` trait from `cadence-hooks-core`
 
 ## Adding a New Hook
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
 
 [[package]]
+name = "cadence-hooks"
+version = "0.1.0"
+dependencies = [
+ "cadence-hooks-cadence",
+ "cadence-hooks-core",
+ "cadence-hooks-guardrails",
+ "cadence-hooks-obsidian",
+ "cadence-hooks-rules",
+ "clap",
+]
+
+[[package]]
+name = "cadence-hooks-cadence"
+version = "0.1.0"
+dependencies = [
+ "cadence-hooks-core",
+ "regex",
+ "tempfile",
+]
+
+[[package]]
+name = "cadence-hooks-core"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "cadence-hooks-guardrails"
+version = "0.1.0"
+dependencies = [
+ "cadence-hooks-core",
+ "regex",
+]
+
+[[package]]
+name = "cadence-hooks-obsidian"
+version = "0.1.0"
+dependencies = [
+ "cadence-hooks-core",
+ "serde_json",
+]
+
+[[package]]
+name = "cadence-hooks-rules"
+version = "0.1.0"
+dependencies = [
+ "cadence-hooks-core",
+ "regex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -118,59 +171,6 @@ name = "clap_lex"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
-
-[[package]]
-name = "claude-hooks"
-version = "0.1.0"
-dependencies = [
- "clap",
- "claude-hooks-cadence",
- "claude-hooks-core",
- "claude-hooks-guardrails",
- "claude-hooks-obsidian",
- "claude-hooks-rules",
-]
-
-[[package]]
-name = "claude-hooks-cadence"
-version = "0.1.0"
-dependencies = [
- "claude-hooks-core",
- "regex",
- "tempfile",
-]
-
-[[package]]
-name = "claude-hooks-core"
-version = "0.1.0"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "claude-hooks-guardrails"
-version = "0.1.0"
-dependencies = [
- "claude-hooks-core",
- "regex",
-]
-
-[[package]]
-name = "claude-hooks-obsidian"
-version = "0.1.0"
-dependencies = [
- "claude-hooks-core",
- "serde_json",
-]
-
-[[package]]
-name = "claude-hooks-rules"
-version = "0.1.0"
-dependencies = [
- "claude-hooks-core",
- "regex",
-]
 
 [[package]]
 name = "colorchoice"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ version = "0.1.0"
 edition = "2024"
 license = "BSL-1.1"
 authors = ["Cameron Sjo"]
-repository = "https://github.com/cameronsjo/claude-hooks"
+repository = "https://github.com/cameronsjo/cadence-hooks"
 
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
@@ -15,14 +15,14 @@ serde_json = "1"
 regex = "1"
 clap = { version = "4", features = ["derive"] }
 
-claude-hooks-core = { path = "crates/core" }
-claude-hooks-cadence = { path = "crates/cadence" }
-claude-hooks-guardrails = { path = "crates/guardrails" }
-claude-hooks-rules = { path = "crates/rules" }
-claude-hooks-obsidian = { path = "crates/obsidian" }
+cadence-hooks-core = { path = "crates/core" }
+cadence-hooks-cadence = { path = "crates/cadence" }
+cadence-hooks-guardrails = { path = "crates/guardrails" }
+cadence-hooks-rules = { path = "crates/rules" }
+cadence-hooks-obsidian = { path = "crates/obsidian" }
 
 [package]
-name = "claude-hooks"
+name = "cadence-hooks"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
@@ -31,13 +31,13 @@ repository.workspace = true
 description = "Compiled Claude Code hooks for cadence, git-guardrails, rules, and obsidian plugins"
 
 [[bin]]
-name = "claude-hooks"
+name = "cadence-hooks"
 path = "src/main.rs"
 
 [dependencies]
 clap.workspace = true
-claude-hooks-core.workspace = true
-claude-hooks-cadence.workspace = true
-claude-hooks-guardrails.workspace = true
-claude-hooks-rules.workspace = true
-claude-hooks-obsidian.workspace = true
+cadence-hooks-core.workspace = true
+cadence-hooks-cadence.workspace = true
+cadence-hooks-guardrails.workspace = true
+cadence-hooks-rules.workspace = true
+cadence-hooks-obsidian.workspace = true

--- a/LICENSE
+++ b/LICENSE
@@ -6,7 +6,7 @@ License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
 Parameters
 
 Licensor:             Cameron Sjo
-Licensed Work:        claude-hooks
+Licensed Work:        cadence-hooks
                       The Licensed Work is (c) 2025 Cameron Sjo.
 Additional Use Grant: You may use the Licensed Work for personal,
                       non-commercial purposes.

--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
-# claude-hooks — compiled Claude Code hooks
+# cadence-hooks — compiled Claude Code hooks
 # Run `make` or `make help` to see available targets
 
 CARGO := cargo
-BINARY := claude-hooks
+BINARY := cadence-hooks
 
 .DEFAULT_GOAL := help
 
@@ -61,6 +61,6 @@ install:
 .PHONY: help
 ## Show this help
 help:
-	@printf "\n\033[1mclaude-hooks\033[0m — compiled Claude Code hooks\n\n"
+	@printf "\n\033[1mcadence-hooks\033[0m — compiled Claude Code hooks\n\n"
 	@awk '/^## / { section = substr($$0, 4) } /^\.PHONY:/ { target = $$2 } /^## [^─]/ && target { printf "  \033[36m%-16s\033[0m %s\n", target, substr($$0, 4); target = "" }' $(MAKEFILE_LIST)
 	@printf "\n"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# claude-hooks
+# cadence-hooks
 
 Compiled [Claude Code](https://docs.anthropic.com/en/docs/claude-code) hooks in Rust. A single binary replaces dozens of shell and Node.js hook scripts across multiple plugins, with sub-millisecond cold starts and zero runtime dependencies.
 
@@ -65,29 +65,29 @@ Each subcommand reads this JSON, runs its check, and exits. No network calls, no
 
 ### From release (recommended)
 
-Download the latest binary from [Releases](https://github.com/cameronsjo/claude-hooks/releases):
+Download the latest binary from [Releases](https://github.com/cameronsjo/cadence-hooks/releases):
 
 ```bash
 # macOS (Apple Silicon)
-curl -sL https://github.com/cameronsjo/claude-hooks/releases/latest/download/claude-hooks-v0.1.0-macos-aarch64.tar.gz | tar xz
-mv claude-hooks ~/.local/bin/
+curl -sL https://github.com/cameronsjo/cadence-hooks/releases/latest/download/cadence-hooks-v0.1.0-macos-aarch64.tar.gz | tar xz
+mv cadence-hooks ~/.local/bin/
 
 # Linux (x86_64)
-curl -sL https://github.com/cameronsjo/claude-hooks/releases/latest/download/claude-hooks-v0.1.0-linux-x86_64.tar.gz | tar xz
-mv claude-hooks ~/.local/bin/
+curl -sL https://github.com/cameronsjo/cadence-hooks/releases/latest/download/cadence-hooks-v0.1.0-linux-x86_64.tar.gz | tar xz
+mv cadence-hooks ~/.local/bin/
 ```
 
 ### From source
 
 ```bash
-cargo install --git https://github.com/cameronsjo/claude-hooks.git
+cargo install --git https://github.com/cameronsjo/cadence-hooks.git
 ```
 
 ### Verify
 
 ```bash
-claude-hooks --version
-claude-hooks --help
+cadence-hooks --version
+cadence-hooks --help
 ```
 
 ## Usage
@@ -97,11 +97,11 @@ Each hook is a subcommand:
 ```bash
 # Run a specific hook (normally called by Claude Code, not manually)
 echo '{"tool_name":"Write","tool_input":{"file_path":"src/main.rs","content":"..."}}' \
-  | claude-hooks cadence terminology
+  | cadence-hooks cadence terminology
 
 # List available subcommands
-claude-hooks cadence --help
-claude-hooks guardrails --help
+cadence-hooks cadence --help
+cadence-hooks guardrails --help
 ```
 
 ### Configuring in Claude Code
@@ -114,12 +114,12 @@ Reference the binary in your plugin's `hooks.json`:
     {
       "type": "preToolUse",
       "matcher": "Write|Edit",
-      "command": "claude-hooks cadence terminology"
+      "command": "cadence-hooks cadence terminology"
     },
     {
       "type": "preToolUse",
       "matcher": "Bash",
-      "command": "claude-hooks guardrails guard-push-remote"
+      "command": "cadence-hooks guardrails guard-push-remote"
     }
   ]
 }
@@ -138,7 +138,7 @@ Some hooks require configuration:
 ## Architecture
 
 ```
-claude-hooks (binary)
+cadence-hooks (binary)
 ├── crates/core        — Hook protocol: JSON parsing, Check trait, exit codes
 ├── crates/cadence     — Cadence plugin hooks (10 checks)
 ├── crates/guardrails  — Git guardrails hooks (6 checks)

--- a/crates/cadence/Cargo.toml
+++ b/crates/cadence/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
-name = "claude-hooks-cadence"
+name = "cadence-hooks-cadence"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Cadence plugin hooks: enforcement, memory guard, session management"
 
 [dependencies]
-claude-hooks-core.workspace = true
+cadence-hooks-core.workspace = true
 regex.workspace = true
 tempfile = "3"

--- a/crates/cadence/src/block_orphaned_todos.rs
+++ b/crates/cadence/src/block_orphaned_todos.rs
@@ -3,7 +3,7 @@
 //! Enforces the format `MARKER(#issue): description` so every tracked item
 //! has a corresponding issue for discoverability and lifecycle management.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -197,7 +197,7 @@ mod tests {
     fn make_check_input(path: Option<&str>, content: &str) -> HookInput {
         HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: path.map(String::from),
                 path: None,
                 command: None,
@@ -213,21 +213,21 @@ mod tests {
     fn run_blocks_orphaned_in_code() {
         let input = make_check_input(Some("src/main.rs"), &make_marker("TODO", false));
         let result = OrphanedTodoGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn run_allows_exempt_path() {
         let input = make_check_input(Some("docs/guide.md"), &make_marker("TODO", false));
         let result = OrphanedTodoGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn run_allows_no_content() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("src/main.rs".into()),
                 path: None,
                 command: None,
@@ -238,14 +238,14 @@ mod tests {
             cwd: None,
         };
         let result = OrphanedTodoGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn run_allows_clean_code() {
         let input = make_check_input(Some("src/main.rs"), "fn main() {}");
         let result = OrphanedTodoGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -354,7 +354,7 @@ mod tests {
             "fn foo() {}\n// TODO: fix\nfn bar() {}\n// HACK: workaround\n",
         );
         let result = OrphanedTodoGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         let msg = result.message.unwrap();
         assert!(msg.contains("L2"));
         assert!(msg.contains("L4"));
@@ -365,7 +365,7 @@ mod tests {
         // No path but has orphaned markers — should still block
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: None,
@@ -376,7 +376,7 @@ mod tests {
             cwd: None,
         };
         let result = OrphanedTodoGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]

--- a/crates/cadence/src/git_safety.rs
+++ b/crates/cadence/src/git_safety.rs
@@ -4,7 +4,7 @@
 //! destructive commands are blocked. Less dangerous operations like
 //! `rebase`, `reset`, and `branch -d` trigger warnings.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Commands that are always blocked — destructive with no undo.
 const BLOCKED_COMMANDS: &[&str] = &[
@@ -111,7 +111,7 @@ mod tests {
     fn make_bash_input(command: &str) -> HookInput {
         HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some(command.into()),
@@ -126,43 +126,43 @@ mod tests {
     #[test]
     fn normal_git_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git push origin feature-branch"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn force_push_main_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push --force origin main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn reset_hard_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git reset --hard"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rebase_main_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git rebase main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn amend_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git commit --amend"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn force_push_feature_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git push --force origin feature"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn non_git_command_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("ls -la"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -173,109 +173,109 @@ mod tests {
             cwd: None,
         };
         let result = GitSafetyGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn force_push_master_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push --force origin master"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn force_push_short_flag_main_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push -f origin main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn checkout_dot_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git checkout -- ."));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn clean_fd_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git clean -fd"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn clean_f_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git clean -f"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn branch_delete_main_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git branch -D main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn branch_delete_master_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git branch -D master"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rebase_master_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git rebase master"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn reflog_expire_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git reflog expire --expire=now --all"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn gc_prune_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git gc --prune=now"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn stash_drop_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git stash drop"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn stash_clear_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git stash clear"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn branch_delete_feature_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git branch -D my-feature"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn remote_remove_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git remote remove upstream"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn normal_push_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git push origin main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn normal_commit_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git commit -m 'feat: add thing'"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn embedded_in_chain_detected() {
         let result = GitSafetyGuard.run(&make_bash_input("cd /tmp && git reset --hard"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     // --- Unhappy path: bypass scenarios ---
@@ -283,96 +283,96 @@ mod tests {
     #[test]
     fn force_push_flag_after_remote_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push origin main --force"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn force_push_short_flag_after_remote_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push origin main -f"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn force_push_master_short_flag_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push -f origin master"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn force_push_master_flag_after_remote_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push origin master --force"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn force_push_master_short_after_remote_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git push origin master -f"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn clean_df_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git clean -df"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rebase_master_interactive_blocked() {
         // Contains both "git rebase" and "master"
         let result = GitSafetyGuard.run(&make_bash_input("git rebase -i master"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn case_insensitive_force_push_blocked() {
         // Early exit now lowercases before checking for "git"
         let result = GitSafetyGuard.run(&make_bash_input("GIT PUSH --FORCE ORIGIN MAIN"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn reset_soft_warned() {
         // "git reset" without --hard is a warning, not a block
         let result = GitSafetyGuard.run(&make_bash_input("git reset HEAD~1"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn rebase_feature_warned() {
         // Rebase on a non-main branch is warned
         let result = GitSafetyGuard.run(&make_bash_input("git rebase feature-branch"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn remote_rm_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git remote rm origin"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn branch_delete_uppercase_d_blocked() {
         // -D is lowercased to -d, matching the blocked command
         let result = GitSafetyGuard.run(&make_bash_input("git branch -D main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn branch_delete_master_uppercase_d_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git branch -D master"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn branch_delete_long_form_main_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git branch --delete main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn branch_delete_long_form_master_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git branch --delete master"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
@@ -380,56 +380,56 @@ mod tests {
         let result = GitSafetyGuard.run(&make_bash_input(
             "git reflog expire --expire=now --all && git gc --prune=now",
         ));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn git_log_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git log --oneline -10"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn git_diff_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git diff HEAD~1"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn git_fetch_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git fetch origin"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn git_pull_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git pull origin main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn git_add_allowed() {
         let result = GitSafetyGuard.run(&make_bash_input("git add src/main.rs"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn blocked_precedes_warn() {
         // When a command matches both block and warn patterns, block wins
         let result = GitSafetyGuard.run(&make_bash_input("git push --force origin main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn checkout_specific_file_allowed() {
         // Only "git checkout -- ." is blocked, not file-specific checkout
         let result = GitSafetyGuard.run(&make_bash_input("git checkout -- src/main.rs"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn branch_delete_long_form_feature_warned() {
         let result = GitSafetyGuard.run(&make_bash_input("git branch --delete my-feature"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 }

--- a/crates/cadence/src/markdown_lint.rs
+++ b/crates/cadence/src/markdown_lint.rs
@@ -3,7 +3,7 @@
 //! Shells out to `markdownlint` CLI if available. Skips silently when
 //! the tool is not installed, so this hook degrades gracefully.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use std::io::Write;
 use std::process::Command;
 

--- a/crates/cadence/src/memory_guard.rs
+++ b/crates/cadence/src/memory_guard.rs
@@ -3,7 +3,7 @@
 //! MEMORY.md is loaded into every session's context window, so it must stay
 //! under 200 lines. Topic files have a softer 300-line guideline.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 const MEMORY_HARD_LIMIT: usize = 200;
 const MEMORY_SOFT_LIMIT: usize = 180;
@@ -83,7 +83,7 @@ mod tests {
         let content: String = (0..lines).map(|i| format!("Line {i}\n")).collect();
         HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -99,35 +99,35 @@ mod tests {
     fn non_memory_path_allowed() {
         let input = make_input("/project/src/main.rs", 500);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn memory_md_under_limit_allowed() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 100);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn memory_md_at_soft_limit_warns() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 185);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn memory_md_over_hard_limit_blocks() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 250);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn topic_file_over_soft_limit_warns() {
         let input = make_input("/home/user/.claude/projects/foo/memory/debugging.md", 350);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
@@ -135,49 +135,49 @@ mod tests {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 200);
         let result = MemoryGuard.run(&input);
         // 200 >= MEMORY_SOFT_LIMIT (180), so warns
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn memory_md_exactly_at_soft_limit_warns() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 180);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn memory_md_one_under_soft_limit_allowed() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 179);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn memory_md_at_201_blocked() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 201);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn topic_file_at_300_allowed() {
         let input = make_input("/home/user/.claude/projects/foo/memory/debugging.md", 300);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn topic_file_at_301_warns() {
         let input = make_input("/home/user/.claude/projects/foo/memory/debugging.md", 301);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn empty_memory_md_allowed() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 0);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -188,7 +188,7 @@ mod tests {
             cwd: None,
         };
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     // --- Unhappy path: edge cases ---
@@ -199,14 +199,14 @@ mod tests {
         let input = make_input("/project/src/in_memory_cache.rs", 500);
         let result = MemoryGuard.run(&input);
         // Contains "/memory/" check — "in_memory_cache" does NOT contain "/memory/"
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn topic_file_under_limit_allowed() {
         let input = make_input("/home/user/.claude/projects/foo/memory/patterns.md", 100);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -240,13 +240,13 @@ mod tests {
     fn single_line_memory_md() {
         let input = make_input("/home/user/.claude/projects/foo/memory/MEMORY.md", 1);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn large_topic_file() {
         let input = make_input("/home/user/.claude/projects/foo/memory/debugging.md", 1000);
         let result = MemoryGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 }

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -4,7 +4,7 @@
 //! Blocks Bash commands that would cat/source/dump secrets.
 //! Safe templates (.env.example, .env.test) are always allowed.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Safe template suffixes that are always allowed to read.
 const SAFE_SUFFIXES: &[&str] = &[
@@ -245,7 +245,7 @@ mod tests {
     fn make_read_input(path: &str) -> HookInput {
         HookInput {
             tool_name: Some("Read".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -260,7 +260,7 @@ mod tests {
     fn make_bash_input(command: &str) -> HookInput {
         HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some(command.into()),
@@ -275,43 +275,43 @@ mod tests {
     #[test]
     fn read_env_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_env_example_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_normal_file_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/src/main.rs"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_cat_env_blocked() {
         let result = SecretLeaksGuard.run(&make_bash_input("cat .env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_cat_env_example_allowed() {
         let result = SecretLeaksGuard.run(&make_bash_input("cat .env.example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_env_dump_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("printenv"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     fn make_grep_input(path: &str) -> HookInput {
         HookInput {
             tool_name: Some("Grep".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -326,103 +326,103 @@ mod tests {
     #[test]
     fn grep_env_blocked() {
         let result = SecretLeaksGuard.run(&make_grep_input("/project/.env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn grep_env_example_allowed() {
         let result = SecretLeaksGuard.run(&make_grep_input("/project/.env.example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn grep_normal_file_allowed() {
         let result = SecretLeaksGuard.run(&make_grep_input("/project/src/main.rs"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_credentials_json_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/credentials.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_id_rsa_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.ssh/id_rsa"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_id_ed25519_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.ssh/id_ed25519"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_key_file_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/server.key"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_pem_ambiguous_warned() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/cert.pem"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn read_private_pem_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/server-key.pem"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_pub_key_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.ssh/id_rsa.pub"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_source_env_blocked() {
         let result = SecretLeaksGuard.run(&make_bash_input("source .env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_head_env_blocked() {
         let result = SecretLeaksGuard.run(&make_bash_input("head -5 .env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_tail_env_blocked() {
         let result = SecretLeaksGuard.run(&make_bash_input("tail .env.local"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_echo_secret_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("echo $SECRET_TOKEN"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn bash_echo_password_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("printf '%s' $PASSWORD"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn bash_export_p_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("export -p"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn bash_normal_command_allowed() {
         let result = SecretLeaksGuard.run(&make_bash_input("cargo test"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -433,7 +433,7 @@ mod tests {
             cwd: None,
         };
         let result = SecretLeaksGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -444,19 +444,19 @@ mod tests {
             cwd: None,
         };
         let result = SecretLeaksGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_service_account_json_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/service-account-prod.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_docker_config_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.docker/config.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     // --- Unhappy path: bypass scenarios ---
@@ -464,226 +464,226 @@ mod tests {
     #[test]
     fn bash_less_env_blocked() {
         let result = SecretLeaksGuard.run(&make_bash_input("less .env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_more_env_blocked() {
         let result = SecretLeaksGuard.run(&make_bash_input("more .env.production"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_bat_env_blocked() {
         let result = SecretLeaksGuard.run(&make_bash_input("bat .env.local"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_dot_source_env_blocked() {
         // `. .env` is equivalent to `source .env`
         let result = SecretLeaksGuard.run(&make_bash_input(". .env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_source_env_example_allowed() {
         let result = SecretLeaksGuard.run(&make_bash_input("source .env.example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_env_as_standalone_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn bash_declare_x_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("declare -x"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn bash_echo_credential_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("echo $CREDENTIAL"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn bash_echo_auth_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("echo $AUTH_TOKEN"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn bash_printf_key_warned() {
         let result = SecretLeaksGuard.run(&make_bash_input("printf '%s' $API_KEY"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn read_env_staging_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.staging"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_env_development_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.development"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_env_secret_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.secret"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_env_keys_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.keys"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_secrets_json_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/secrets.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_id_ecdsa_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.ssh/id_ecdsa"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_id_dsa_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.ssh/id_dsa"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_pypirc_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.pypirc"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_npmrc_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.npmrc"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_netrc_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/home/user/.netrc"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_p12_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/cert.p12"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_pfx_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/cert.pfx"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_keystore_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/app.keystore"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_jks_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/app.jks"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_underscore_key_pem_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/server_key.pem"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_private_pem_suffix_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/server.private.pem"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_p8_ambiguous_warned() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/signing.p8"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn read_gcloud_credentials_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/gcloud-credentials.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn read_template_suffix_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.template"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_sample_suffix_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/credentials.json.sample"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_test_suffix_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.test"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_ci_suffix_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.ci"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_defaults_suffix_allowed() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env.defaults"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn grep_blocked_extension_blocked() {
         let result = SecretLeaksGuard.run(&make_grep_input("/etc/ssl/server.key"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn grep_safe_template_allowed() {
         let result = SecretLeaksGuard.run(&make_grep_input("/project/.env.example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn grep_ambiguous_not_warned() {
         // Grep doesn't warn on ambiguous — only blocks on definite secrets
         let result = SecretLeaksGuard.run(&make_grep_input("/etc/ssl/cert.pem"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_no_command_allowed() {
         let input = HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: None,
@@ -694,14 +694,14 @@ mod tests {
             cwd: None,
         };
         let result = SecretLeaksGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn read_no_path_allowed() {
         let input = HookInput {
             tool_name: Some("Read".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: None,
@@ -712,14 +712,14 @@ mod tests {
             cwd: None,
         };
         let result = SecretLeaksGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn grep_no_path_allowed() {
         let input = HookInput {
             tool_name: Some("Grep".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: None,
@@ -730,39 +730,39 @@ mod tests {
             cwd: None,
         };
         let result = SecretLeaksGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn case_insensitive_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.ENV"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn case_insensitive_safe_template() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/.ENV.EXAMPLE"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn no_extension_not_ambiguous() {
         // File without extension should not be flagged as ambiguous
         let result = SecretLeaksGuard.run(&make_read_input("/project/Makefile"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_cat_env_example_pipe_allowed() {
         // Operand is .env.example (safe template), even though command mentions .env
         let result = SecretLeaksGuard.run(&make_bash_input("cat .env.example | grep KEY"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_cat_env_with_example_in_pipe_blocked() {
         // cat .env piped to grep — operand is .env which is dangerous
         let result = SecretLeaksGuard.run(&make_bash_input("cat .env | grep example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 }

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -4,7 +4,7 @@
 //! Blocks Bash commands that redirect to or `rm` secret files.
 //! Safe templates (.env.example, .env.test) are always allowed.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Safe template suffixes that are always allowed.
 const SAFE_SUFFIXES: &[&str] = &[
@@ -355,7 +355,7 @@ mod tests {
     fn make_write_input(path: &str) -> HookInput {
         HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -370,7 +370,7 @@ mod tests {
     fn make_edit_input(path: &str) -> HookInput {
         HookInput {
             tool_name: Some("Edit".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -385,7 +385,7 @@ mod tests {
     fn make_bash_input(command: &str) -> HookInput {
         HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some(command.into()),
@@ -400,50 +400,50 @@ mod tests {
     #[test]
     fn write_env_blocked() {
         let result = SecretWritesGuard.run(&make_write_input("/project/.env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn edit_env_blocked() {
         let result = SecretWritesGuard.run(&make_edit_input("/project/.env.local"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn write_env_example_allowed() {
         let result = SecretWritesGuard.run(&make_write_input("/project/.env.example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn write_pem_warned() {
         let result = SecretWritesGuard.run(&make_write_input("/etc/ssl/cert.pem"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn write_normal_file_allowed() {
         let result = SecretWritesGuard.run(&make_write_input("/project/src/main.rs"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_env_redirect_blocked_via_run() {
         let result = SecretWritesGuard.run(&make_bash_input("echo KEY=val > .env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_normal_command_allowed_via_run() {
         let result = SecretWritesGuard.run(&make_bash_input("cargo build"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn unknown_tool_allowed() {
         let input = HookInput {
             tool_name: Some("Read".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("/project/.env".into()),
                 path: None,
                 command: None,
@@ -454,7 +454,7 @@ mod tests {
             cwd: None,
         };
         let result = SecretWritesGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -465,7 +465,7 @@ mod tests {
             cwd: None,
         };
         let result = SecretWritesGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     // --- Unhappy path: bypass scenarios ---
@@ -475,14 +475,14 @@ mod tests {
         // Known gap: tee/cp/dd bypass not detected by current implementation
         let result = SecretWritesGuard.run(&make_bash_input("echo SECRET | tee .env"));
         // tee doesn't use > or rm, so it won't be caught
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_cp_env_not_detected() {
         // Known gap: cp bypass
         let result = SecretWritesGuard.run(&make_bash_input("cp source.txt .env"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -498,92 +498,92 @@ mod tests {
     #[test]
     fn edit_key_file_blocked() {
         let result = SecretWritesGuard.run(&make_edit_input("/etc/ssl/server.key"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn edit_private_pem_blocked() {
         let result = SecretWritesGuard.run(&make_edit_input("/etc/ssl/server-key.pem"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn write_id_rsa_blocked() {
         let result = SecretWritesGuard.run(&make_write_input("/home/user/.ssh/id_rsa"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn write_credentials_json_blocked() {
         let result = SecretWritesGuard.run(&make_write_input("/project/credentials.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn write_secrets_json_blocked() {
         let result = SecretWritesGuard.run(&make_write_input("/project/secrets.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn write_jks_blocked() {
         let result = SecretWritesGuard.run(&make_write_input("/project/app.jks"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn write_p8_warned() {
         let result = SecretWritesGuard.run(&make_write_input("/etc/ssl/signing.p8"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn write_gcloud_credentials_blocked() {
         let result = SecretWritesGuard.run(&make_write_input("/project/gcloud-credentials.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn write_service_account_blocked() {
         let result = SecretWritesGuard.run(&make_write_input("/project/service-account.json"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn edit_env_example_allowed() {
         let result = SecretWritesGuard.run(&make_edit_input("/project/.env.example"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn edit_env_template_allowed() {
         let result = SecretWritesGuard.run(&make_edit_input("/project/.env.template"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn write_env_test_allowed() {
         let result = SecretWritesGuard.run(&make_write_input("/project/.env.test"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn write_env_ci_allowed() {
         let result = SecretWritesGuard.run(&make_write_input("/project/.env.ci"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn write_pub_key_allowed() {
         let result = SecretWritesGuard.run(&make_write_input("/home/user/.ssh/id_rsa.pub"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_no_command_allowed() {
         let input = HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: None,
@@ -594,14 +594,14 @@ mod tests {
             cwd: None,
         };
         let result = SecretWritesGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn write_no_path_allowed() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: None,
@@ -612,7 +612,7 @@ mod tests {
             cwd: None,
         };
         let result = SecretWritesGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -3,7 +3,7 @@
 //! Detects prohibited terms and suggests neutral alternatives.
 //! Case-insensitive with word-boundary matching to avoid false positives.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::RegexSet;
 use std::sync::LazyLock;
 
@@ -62,7 +62,7 @@ pub fn check_terminology(content: &str) -> Vec<(String, String)> {
 fn is_excluded_path(path: &str) -> bool {
     let lower = path.to_lowercase();
     lower.ends_with("claude.md")
-        || path.contains("claude-hooks/")
+        || path.contains("cadence-hooks/")
         || path.contains(".claude/hooks/")
         || path.contains(".claude/rules/")
 }
@@ -145,7 +145,7 @@ mod tests {
     fn excluded_paths_allowed() {
         assert!(is_excluded_path("/project/CLAUDE.md"));
         assert!(is_excluded_path(
-            "/home/dev/claude-hooks/crates/cadence/src/foo.rs"
+            "/home/dev/cadence-hooks/crates/cadence/src/foo.rs"
         ));
         assert!(is_excluded_path(
             "/home/dev/.claude/hooks/enforcement/foo.sh"
@@ -157,7 +157,7 @@ mod tests {
     fn blocks_on_violation_in_normal_file() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("/project/src/main.rs".into()),
                 path: None,
                 command: None,
@@ -168,7 +168,7 @@ mod tests {
             cwd: None,
         };
         let result = TerminologyGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     // --- Unhappy path: bypass scenarios ---
@@ -204,7 +204,7 @@ mod tests {
     fn no_content_returns_allow() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("/project/src/main.rs".into()),
                 path: None,
                 command: None,
@@ -215,14 +215,14 @@ mod tests {
             cwd: None,
         };
         let result = TerminologyGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn excluded_path_with_violations_allowed() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("/home/dev/.claude/rules/terminology.md".into()),
                 path: None,
                 command: None,
@@ -233,14 +233,14 @@ mod tests {
             cwd: None,
         };
         let result = TerminologyGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn block_message_includes_path() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("/project/src/config.rs".into()),
                 path: None,
                 command: None,
@@ -251,7 +251,7 @@ mod tests {
             cwd: None,
         };
         let result = TerminologyGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         assert!(result.message.unwrap().contains("config.rs"));
     }
 

--- a/crates/cadence/src/validate_env_vars.rs
+++ b/crates/cadence/src/validate_env_vars.rs
@@ -3,7 +3,7 @@
 //! Detects bare names like `DEBUG`, `PORT`, `VERBOSE` that should use
 //! tool-prefixed forms (`MYAPP_DEBUG`, `SERVICE_PORT`) to avoid collisions.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -94,7 +94,7 @@ mod tests {
     fn make_input(path: &str, content: &str) -> HookInput {
         HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -110,42 +110,42 @@ mod tests {
     fn prefixed_env_var_passes() {
         let input = make_input("src/app.ts", "const debug = process.env.MYAPP_DEBUG;");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn generic_env_var_warns() {
         let input = make_input("src/app.ts", "const debug = process.env.DEBUG;");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn non_code_files_skipped() {
         let input = make_input("README.md", "process.env.DEBUG");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn python_env_access_detected() {
         let input = make_input("src/main.py", "os.getenv(\"PORT\")");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn ruby_env_access_detected() {
         let input = make_input("src/app.rb", "ENV['DEBUG']");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn rust_env_var_detected() {
         let input = make_input("src/main.rs", "std::env::var(\"VERBOSE\")");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
@@ -156,14 +156,14 @@ mod tests {
             cwd: None,
         };
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn no_path_allowed() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: None,
@@ -174,14 +174,14 @@ mod tests {
             cwd: None,
         };
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn no_content_allowed() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("src/app.ts".into()),
                 path: None,
                 command: None,
@@ -192,7 +192,7 @@ mod tests {
             cwd: None,
         };
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -212,7 +212,7 @@ mod tests {
         let content = "const a = process.env.DEBUG;\nconst b = process.env.PORT;";
         let input = make_input("src/app.ts", content);
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
         let msg = result.message.unwrap();
         assert!(msg.contains("DEBUG"));
         assert!(msg.contains("PORT"));
@@ -222,7 +222,7 @@ mod tests {
     fn prefixed_var_not_matched() {
         let input = make_input("src/app.ts", "process.env.MYAPP_PORT");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     // --- Unhappy path: edge cases ---
@@ -235,7 +235,7 @@ mod tests {
             let result = EnvVarGuard.run(&input);
             assert_eq!(
                 result.outcome,
-                claude_hooks_core::Outcome::Warn,
+                cadence_hooks_core::Outcome::Warn,
                 "{var} should be detected"
             );
         }
@@ -249,7 +249,7 @@ mod tests {
             let result = EnvVarGuard.run(&input);
             assert_eq!(
                 result.outcome,
-                claude_hooks_core::Outcome::Warn,
+                cadence_hooks_core::Outcome::Warn,
                 "{var} should be detected in Python"
             );
         }
@@ -260,14 +260,14 @@ mod tests {
         // Non-code files should never warn
         let input = make_input("config.yaml", "DEBUG: true");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn dockerfile_skipped() {
         let input = make_input("Dockerfile", "ENV PORT=8080");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -304,21 +304,21 @@ mod tests {
         // as a substring of `process.env.DEBUGGING`.
         let input = make_input("src/app.ts", "process.env.DEBUGGING");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn mjs_extension_detected() {
         let input = make_input("src/utils.mjs", "process.env.DEBUG");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn cjs_extension_detected() {
         let input = make_input("src/config.cjs", "process.env.VERBOSE");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
@@ -326,7 +326,7 @@ mod tests {
         // Edit tool puts content in new_string — content() returns new_string when content is None
         let input = HookInput {
             tool_name: Some("Edit".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("src/app.ts".into()),
                 path: None,
                 command: None,
@@ -337,7 +337,7 @@ mod tests {
             cwd: None,
         };
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
@@ -345,6 +345,6 @@ mod tests {
         // .sh files are not in CODE_EXTENSIONS — env vars in scripts are fine
         let input = make_input("scripts/deploy.sh", "process.env.DEBUG");
         let result = EnvVarGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/cadence/src/validate_line_endings.rs
+++ b/crates/cadence/src/validate_line_endings.rs
@@ -3,7 +3,7 @@
 //! Windows-style `\r\n` endings cause `env: bash\r: No such file or directory`
 //! errors. This check blocks writing `.sh` and `.bash` files with `\r` bytes.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Blocks shell scripts that contain carriage return bytes.
 pub struct LineEndingsGuard;
@@ -46,7 +46,7 @@ mod tests {
     fn make_input(path: &str, content: &str) -> HookInput {
         HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -62,35 +62,35 @@ mod tests {
     fn lf_endings_pass() {
         let input = make_input("script.sh", "#!/bin/bash\necho hello\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn crlf_endings_blocked() {
         let input = make_input("script.sh", "#!/bin/bash\r\necho hello\r\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn non_shell_files_skipped() {
         let input = make_input("file.txt", "hello\r\nworld\r\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn bash_extension_checked() {
         let input = make_input("script.bash", "#!/bin/bash\r\necho hello\r\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn bash_extension_lf_passes() {
         let input = make_input("script.bash", "#!/bin/bash\necho hello\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -101,14 +101,14 @@ mod tests {
             cwd: None,
         };
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn no_content_allowed() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("script.sh".into()),
                 path: None,
                 command: None,
@@ -119,14 +119,14 @@ mod tests {
             cwd: None,
         };
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn mixed_endings_blocked() {
         let input = make_input("script.sh", "#!/bin/bash\necho hello\r\necho world\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     // --- Unhappy path: edge cases ---
@@ -136,7 +136,7 @@ mod tests {
         // Just \r without \n — still contains \r
         let input = make_input("script.sh", "#!/bin/bash\recho hello\r");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
@@ -144,35 +144,35 @@ mod tests {
         // Non-shell files are not checked
         let input = make_input("script.py", "#!/usr/bin/env python\r\nprint('hello')\r\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn makefile_crlf_not_checked() {
         let input = make_input("Makefile", "all:\r\n\techo hello\r\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn empty_shell_script_allowed() {
         let input = make_input("script.sh", "");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn shell_script_single_line_lf() {
         let input = make_input("script.sh", "#!/bin/bash\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn shell_script_no_newline() {
         let input = make_input("script.sh", "#!/bin/bash");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -180,6 +180,6 @@ mod tests {
         // Only .sh and .bash are checked — .zsh is not
         let input = make_input("script.zsh", "#!/bin/zsh\r\necho hello\r\n");
         let result = LineEndingsGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/cadence/src/warn_untracked.rs
+++ b/crates/cadence/src/warn_untracked.rs
@@ -3,7 +3,7 @@
 //! Shells out to `git ls-files --others --exclude-standard` to detect
 //! files that might have been forgotten. Filters out build artifacts.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use std::process::Command;
 
 /// Build artifact extensions to filter from untracked file warnings.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "claude-hooks-core"
+name = "cadence-hooks-core"
 version.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -151,7 +151,7 @@ pub fn run_check_from_stdin(check: &dyn Check) -> ! {
     match HookInput::from_stdin() {
         Ok(input) => run_check(check, &input),
         Err(e) => {
-            eprintln!("claude-hooks: {e}");
+            eprintln!("cadence-hooks: {e}");
             process::exit(0); // Fail open on parse errors
         }
     }

--- a/crates/guardrails/Cargo.toml
+++ b/crates/guardrails/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "claude-hooks-guardrails"
+name = "cadence-hooks-guardrails"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Git guardrails hooks: push protection, gh write guards, idle detection"
 
 [dependencies]
-claude-hooks-core.workspace = true
+cadence-hooks-core.workspace = true
 regex.workspace = true

--- a/crates/guardrails/src/check_idle_return.rs
+++ b/crates/guardrails/src/check_idle_return.rs
@@ -4,7 +4,7 @@
 //! returns after 5+ minutes of inactivity, warns them to review context.
 //! After 8+ hours, suggests starting a fresh session.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;

--- a/crates/guardrails/src/guard_gh_dangerous.rs
+++ b/crates/guardrails/src/guard_gh_dangerous.rs
@@ -3,7 +3,7 @@
 //! `gh repo delete` is permanently destructive with no undo. This guard
 //! blocks it in direct invocations and inside shell exec wrappers (`bash -c`).
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -87,7 +87,7 @@ mod tests {
     fn make_bash(cmd: &str) -> HookInput {
         HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some(cmd.into()),
@@ -102,25 +102,25 @@ mod tests {
     #[test]
     fn direct_repo_delete_blocked() {
         let result = GhDangerousGuard.run(&make_bash("gh repo delete my-repo --yes"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn repo_delete_in_exec_wrapper_blocked() {
         let result = GhDangerousGuard.run(&make_bash("bash -c \"gh repo delete my-repo --yes\""));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn repo_delete_in_quotes_not_blocked() {
         let result = GhDangerousGuard.run(&make_bash("echo \"don't gh repo delete anything\""));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn normal_gh_command_allowed() {
         let result = GhDangerousGuard.run(&make_bash("gh pr list"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -131,25 +131,25 @@ mod tests {
             cwd: None,
         };
         let result = GhDangerousGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn no_gh_in_command_allowed() {
         let result = GhDangerousGuard.run(&make_bash("ls -la"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn zsh_wrapper_blocked() {
         let result = GhDangerousGuard.run(&make_bash("zsh -c \"gh repo delete my-repo --yes\""));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn sh_wrapper_blocked() {
         let result = GhDangerousGuard.run(&make_bash("sh -c \"gh repo delete my-repo --yes\""));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     // strip_quotes tests
@@ -185,50 +185,50 @@ mod tests {
     #[test]
     fn repo_delete_in_single_quotes_not_blocked() {
         let result = GhDangerousGuard.run(&make_bash("echo 'gh repo delete is dangerous'"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn repo_delete_with_confirm_blocked() {
         let result = GhDangerousGuard.run(&make_bash("gh repo delete my-repo --confirm"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn repo_delete_full_path_blocked() {
         let result = GhDangerousGuard.run(&make_bash("gh repo delete owner/my-repo --yes"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn gh_repo_list_allowed() {
         let result = GhDangerousGuard.run(&make_bash("gh repo list"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn gh_repo_create_allowed() {
         let result = GhDangerousGuard.run(&make_bash("gh repo create my-new-repo"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn gh_repo_view_allowed() {
         let result = GhDangerousGuard.run(&make_bash("gh repo view owner/repo"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn repo_delete_in_chain_blocked() {
         let result = GhDangerousGuard.run(&make_bash("echo done && gh repo delete my-repo --yes"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn no_tool_name_allowed() {
         let input = HookInput {
             tool_name: None,
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some("gh repo delete".into()),
@@ -239,6 +239,6 @@ mod tests {
             cwd: None,
         };
         let result = GhDangerousGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 }

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -4,7 +4,7 @@
 //! comment, edit, delete, etc.) and verifies the target repository belongs to
 //! an allowed owner list. Also blocks looped writes and cross-repo mutations.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::process::Command;
 use std::sync::LazyLock;
@@ -596,14 +596,14 @@ mod tests {
             cwd: None,
         };
         let result = GhWriteGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn no_gh_in_command_allowed() {
         let input = HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some("ls -la".into()),
@@ -614,6 +614,6 @@ mod tests {
             cwd: None,
         };
         let result = GhWriteGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/guardrails/src/guard_git_init.rs
+++ b/crates/guardrails/src/guard_git_init.rs
@@ -3,7 +3,7 @@
 //! When a new repository is initialised, this check reminds the user to run
 //! `/a-star-is-born` so the repo starts with standard project files.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Warns when `git init` is detected so the user can scaffold project standards.
 pub struct GuardGitInit;
@@ -44,7 +44,7 @@ mod tests {
     fn make_bash(cmd: &str) -> HookInput {
         HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some(cmd.into()),
@@ -59,19 +59,19 @@ mod tests {
     #[test]
     fn git_init_detected() {
         let result = GuardGitInit.run(&make_bash("git init"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn git_init_with_path() {
         let result = GuardGitInit.run(&make_bash("git init my-project"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn normal_command_passes() {
         let result = GuardGitInit.run(&make_bash("git status"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -82,25 +82,25 @@ mod tests {
             cwd: None,
         };
         let result = GuardGitInit.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn init_without_git_allowed() {
         let result = GuardGitInit.run(&make_bash("npm init"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn git_without_init_allowed() {
         let result = GuardGitInit.run(&make_bash("git commit -m 'initial'"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn git_init_with_branch() {
         let result = GuardGitInit.run(&make_bash("git init -b main"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
@@ -108,7 +108,7 @@ mod tests {
         // "git" and "init" both present but not adjacent as "git init"
         // The command is "mkdir proj && git init" — "git init" IS adjacent here
         let result = GuardGitInit.run(&make_bash("mkdir proj && git init"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     // --- Unhappy path: edge cases ---
@@ -119,26 +119,26 @@ mod tests {
         let result = GuardGitInit.run(&make_bash("git submodule init"));
         // "git" and "submodule" are adjacent, then "submodule" and "init"
         // windows(2) checks: [git, submodule], [submodule, init] — neither is [git, init]
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn terraform_init_not_detected() {
         // "init" without "git" — should pass the !contains("git") check
         let result = GuardGitInit.run(&make_bash("terraform init"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn git_init_bare_warned() {
         let result = GuardGitInit.run(&make_bash("git init --bare"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 
     #[test]
     fn git_reinit_warned() {
         // Re-init existing repo
         let result = GuardGitInit.run(&make_bash("cd /project && git init"));
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Warn);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Warn);
     }
 }

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -4,7 +4,7 @@
 //! verifies the repository owner is in the configured allowlist. Also blocks
 //! looped pushes and force-push to `main`.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::process::Command;
 use std::sync::LazyLock;
@@ -498,14 +498,14 @@ mod tests {
             cwd: None,
         };
         let result = PushRemoteGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn non_push_command_allowed() {
         let input = HookInput {
             tool_name: Some("Bash".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: None,
                 path: None,
                 command: Some("git status".into()),
@@ -516,6 +516,6 @@ mod tests {
             cwd: None,
         };
         let result = PushRemoteGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -3,7 +3,7 @@
 //! Fires once per session (tracked via a temp-file marker) to nudge the
 //! user toward creating a feature branch before making changes.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;

--- a/crates/obsidian/Cargo.toml
+++ b/crates/obsidian/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "claude-hooks-obsidian"
+name = "cadence-hooks-obsidian"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Cadence Obsidian plugin hooks: vault trash guard"
 
 [dependencies]
-claude-hooks-core.workspace = true
+cadence-hooks-core.workspace = true
 serde_json.workspace = true

--- a/crates/obsidian/src/trash_guard.rs
+++ b/crates/obsidian/src/trash_guard.rs
@@ -4,7 +4,7 @@
 //! `rm` bypasses it and loses recoverability. This guard blocks `rm` inside
 //! the vault directory and suggests `mv` to `.trash/` instead.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Check if an rm command targets the Obsidian vault.
 fn check_rm_in_vault(command: &str, cwd: &str, vault: &str) -> CheckResult {
@@ -68,56 +68,56 @@ mod tests {
     #[test]
     fn non_rm_command_allowed() {
         let result = check_rm_in_vault("ls -la", "/vault", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn rm_outside_vault_allowed() {
         let result = check_rm_in_vault("rm temp.txt", "/home/user", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn rm_inside_vault_blocked() {
         let result = check_rm_in_vault("rm note.md", "/vault/notes", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rm_with_explicit_vault_path_blocked() {
         let result = check_rm_in_vault("rm /vault/notes/todo.md", "/home/user", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rm_rf_inside_vault_blocked() {
         let result = check_rm_in_vault("rm -rf old-notes/", "/vault", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rm_multiple_files_in_vault_blocked() {
         let result = check_rm_in_vault("rm a.md b.md c.md", "/vault/notes", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn vault_as_substring_not_matched() {
         // /vault2 should not match /vault
         let result = check_rm_in_vault("rm file.md", "/vault2/notes", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn non_rm_with_vault_path_allowed() {
         let result = check_rm_in_vault("cat /vault/notes/todo.md", "/home/user", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn block_message_contains_vault_path() {
         let result = check_rm_in_vault("rm note.md", "/vault", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         let msg = result.message.unwrap();
         assert!(msg.contains("/vault/.trash/"));
     }
@@ -131,7 +131,7 @@ mod tests {
             cwd: None,
         };
         let result = ObsidianTrashGuard.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     // --- Unhappy path: edge cases ---
@@ -139,64 +139,64 @@ mod tests {
     #[test]
     fn rm_at_vault_root_blocked() {
         let result = check_rm_in_vault("rm old-note.md", "/vault", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rm_deeply_nested_in_vault_blocked() {
         let result = check_rm_in_vault("rm file.md", "/vault/a/b/c/d", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rm_with_glob_in_vault_blocked() {
         let result = check_rm_in_vault("rm *.md", "/vault/notes", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn vault_with_trailing_slash() {
         let result = check_rm_in_vault("rm note.md", "/vault/notes", "/vault/");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn vault_trailing_slash_normalized() {
         // Trailing slash on vault is stripped before comparison
         let result = check_rm_in_vault("rm note.md", "/vault", "/vault/");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn mv_in_vault_allowed() {
         // mv is not rm — should be allowed
         let result = check_rm_in_vault("mv old.md new.md", "/vault", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn explicit_vault_path_deeply_nested() {
         let result = check_rm_in_vault("rm /vault/a/b/c.md", "/home/user", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn rm_with_vault_path_but_wrong_prefix() {
         // /vault-backup is not /vault
         let result = check_rm_in_vault("rm /vault-backup/note.md", "/home/user", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn relative_path_in_non_vault_cwd_allowed() {
         let result = check_rm_in_vault("rm note.md", "/home/user/notes", "/vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn block_message_suggests_trash() {
         let result = check_rm_in_vault("rm note.md", "/my-vault", "/my-vault");
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         let msg = result.message.unwrap();
         assert!(msg.contains(".trash"));
         assert!(msg.contains("/my-vault/.trash/"));

--- a/crates/rules/Cargo.toml
+++ b/crates/rules/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
-name = "claude-hooks-rules"
+name = "cadence-hooks-rules"
 version.workspace = true
 edition.workspace = true
 license.workspace = true
 description = "Rules plugin hooks: skill frontmatter validation, security pattern scanning"
 
 [dependencies]
-claude-hooks-core.workspace = true
+cadence-hooks-core.workspace = true
 regex.workspace = true

--- a/crates/rules/src/check_security_patterns.rs
+++ b/crates/rules/src/check_security_patterns.rs
@@ -3,7 +3,7 @@
 //! Maintains a table of language-specific anti-patterns (pickle, innerHTML,
 //! `shell=True`, unsafe Go imports, etc.) and warns when written code matches.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 
 /// A security pattern to check for in a specific file extension.

--- a/crates/rules/src/validate_skill_frontmatter.rs
+++ b/crates/rules/src/validate_skill_frontmatter.rs
@@ -3,7 +3,7 @@
 //! Checks that `SKILL.md` and command `.md` files have valid frontmatter
 //! with required fields, kebab-case names, and no unknown keys.
 
-use claude_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -240,7 +240,7 @@ mod tests {
     fn make_write_input(path: &str, content: &str) -> HookInput {
         HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some(path.into()),
                 path: None,
                 command: None,
@@ -256,14 +256,14 @@ mod tests {
     fn run_other_file_allowed() {
         let input = make_write_input("/project/src/main.rs", "fn main() {}");
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn run_skill_missing_frontmatter_blocks() {
         let input = make_write_input("/plugins/skills/my-skill/SKILL.md", "# No frontmatter");
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
@@ -273,7 +273,7 @@ mod tests {
             "---\ndescription: A test\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         assert!(result.message.unwrap().contains("Missing required 'name'"));
     }
 
@@ -284,7 +284,7 @@ mod tests {
             "---\nname: my-skill\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         assert!(
             result
                 .message
@@ -300,7 +300,7 @@ mod tests {
             "---\nname: My-Skill\ndescription: test\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         assert!(result.message.unwrap().contains("lowercase"));
     }
 
@@ -311,7 +311,7 @@ mod tests {
             "---\nname: other-name\ndescription: test\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         assert!(result.message.unwrap().contains("must match directory"));
     }
 
@@ -322,7 +322,7 @@ mod tests {
             "---\nname: my-skill\ndescription: A test skill\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -332,7 +332,7 @@ mod tests {
             "---\nname: my-cmd\ndescription: test\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         assert!(result.message.unwrap().contains("Remove 'name:'"));
     }
 
@@ -343,7 +343,7 @@ mod tests {
             "---\ndescription: A command\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -353,7 +353,7 @@ mod tests {
             "---\nname: my-skill\ndescription: test\nunknown-field: value\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         assert!(
             result
                 .message
@@ -370,14 +370,14 @@ mod tests {
             cwd: None,
         };
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn run_no_content_allowed() {
         let input = HookInput {
             tool_name: Some("Write".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("/plugins/skills/my-skill/SKILL.md".into()),
                 path: None,
                 command: None,
@@ -388,7 +388,7 @@ mod tests {
             cwd: None,
         };
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     // --- Unhappy path: edge cases ---
@@ -437,7 +437,7 @@ mod tests {
             "---\nunknown1: val\nunknown2: val\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
         let msg = result.message.unwrap();
         assert!(msg.contains("unknown1"));
         assert!(msg.contains("unknown2"));
@@ -451,7 +451,7 @@ mod tests {
         // regardless of tool_name
         let input = HookInput {
             tool_name: Some("Edit".into()),
-            tool_input: Some(claude_hooks_core::ToolInput {
+            tool_input: Some(cadence_hooks_core::ToolInput {
                 file_path: Some("/plugins/skills/my-skill/SKILL.md".into()),
                 path: None,
                 command: None,
@@ -462,7 +462,7 @@ mod tests {
             cwd: None,
         };
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
@@ -472,7 +472,7 @@ mod tests {
             "---\nname: my-skill\ndescription: A skill\nmodel: opus\nallowed-tools: Read,Grep\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
@@ -482,7 +482,7 @@ mod tests {
             "---\ndescription: Deploy the app\nallowed-tools: Bash\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
-        assert_eq!(result.outcome, claude_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,11 +4,11 @@
 //! Each subcommand reads JSON from stdin (the hook protocol) and exits with
 //! 0 (allow), 1 (warn), or 2 (block).
 
+use cadence_hooks_core::run_check_from_stdin;
 use clap::{Parser, Subcommand};
-use claude_hooks_core::run_check_from_stdin;
 
 #[derive(Parser)]
-#[command(name = "claude-hooks", version, about = "Compiled Claude Code hooks")]
+#[command(name = "cadence-hooks", version, about = "Compiled Claude Code hooks")]
 struct Cli {
     #[command(subcommand)]
     command: Commands,
@@ -93,67 +93,67 @@ fn main() {
     match cli.command {
         Commands::Cadence(cmd) => match cmd {
             CadenceCommands::Terminology => {
-                run_check_from_stdin(&claude_hooks_cadence::terminology::TerminologyGuard)
+                run_check_from_stdin(&cadence_hooks_cadence::terminology::TerminologyGuard)
             }
-            CadenceCommands::OrphanedTodos => {
-                run_check_from_stdin(&claude_hooks_cadence::block_orphaned_todos::OrphanedTodoGuard)
-            }
+            CadenceCommands::OrphanedTodos => run_check_from_stdin(
+                &cadence_hooks_cadence::block_orphaned_todos::OrphanedTodoGuard,
+            ),
             CadenceCommands::PreventSecretLeaks => {
-                run_check_from_stdin(&claude_hooks_cadence::prevent_secret_leaks::SecretLeaksGuard)
+                run_check_from_stdin(&cadence_hooks_cadence::prevent_secret_leaks::SecretLeaksGuard)
             }
             CadenceCommands::PreventSecretWrites => run_check_from_stdin(
-                &claude_hooks_cadence::prevent_secret_writes::SecretWritesGuard,
+                &cadence_hooks_cadence::prevent_secret_writes::SecretWritesGuard,
             ),
             CadenceCommands::MemoryGuard => {
-                run_check_from_stdin(&claude_hooks_cadence::memory_guard::MemoryGuard)
+                run_check_from_stdin(&cadence_hooks_cadence::memory_guard::MemoryGuard)
             }
             CadenceCommands::GitSafety => {
-                run_check_from_stdin(&claude_hooks_cadence::git_safety::GitSafetyGuard)
+                run_check_from_stdin(&cadence_hooks_cadence::git_safety::GitSafetyGuard)
             }
-            CadenceCommands::LineEndings => {
-                run_check_from_stdin(&claude_hooks_cadence::validate_line_endings::LineEndingsGuard)
-            }
+            CadenceCommands::LineEndings => run_check_from_stdin(
+                &cadence_hooks_cadence::validate_line_endings::LineEndingsGuard,
+            ),
             CadenceCommands::EnvVars => {
-                run_check_from_stdin(&claude_hooks_cadence::validate_env_vars::EnvVarGuard)
+                run_check_from_stdin(&cadence_hooks_cadence::validate_env_vars::EnvVarGuard)
             }
             CadenceCommands::WarnUntracked => {
-                run_check_from_stdin(&claude_hooks_cadence::warn_untracked::WarnUntrackedFiles)
+                run_check_from_stdin(&cadence_hooks_cadence::warn_untracked::WarnUntrackedFiles)
             }
             CadenceCommands::MarkdownLint => {
-                run_check_from_stdin(&claude_hooks_cadence::markdown_lint::MarkdownLint)
+                run_check_from_stdin(&cadence_hooks_cadence::markdown_lint::MarkdownLint)
             }
         },
         Commands::Guardrails(cmd) => match cmd {
             GuardrailsCommands::GuardPushRemote => {
-                run_check_from_stdin(&claude_hooks_guardrails::guard_push_remote::PushRemoteGuard)
+                run_check_from_stdin(&cadence_hooks_guardrails::guard_push_remote::PushRemoteGuard)
             }
-            GuardrailsCommands::GuardGhDangerous => {
-                run_check_from_stdin(&claude_hooks_guardrails::guard_gh_dangerous::GhDangerousGuard)
-            }
+            GuardrailsCommands::GuardGhDangerous => run_check_from_stdin(
+                &cadence_hooks_guardrails::guard_gh_dangerous::GhDangerousGuard,
+            ),
             GuardrailsCommands::GuardGhWrite => {
-                run_check_from_stdin(&claude_hooks_guardrails::guard_gh_write::GhWriteGuard)
+                run_check_from_stdin(&cadence_hooks_guardrails::guard_gh_write::GhWriteGuard)
             }
             GuardrailsCommands::GuardGitInit => {
-                run_check_from_stdin(&claude_hooks_guardrails::guard_git_init::GuardGitInit)
+                run_check_from_stdin(&cadence_hooks_guardrails::guard_git_init::GuardGitInit)
             }
             GuardrailsCommands::WarnMainBranch => {
-                run_check_from_stdin(&claude_hooks_guardrails::warn_main_branch::WarnMainBranch)
+                run_check_from_stdin(&cadence_hooks_guardrails::warn_main_branch::WarnMainBranch)
             }
             GuardrailsCommands::CheckIdleReturn => {
-                run_check_from_stdin(&claude_hooks_guardrails::check_idle_return::CheckIdleReturn)
+                run_check_from_stdin(&cadence_hooks_guardrails::check_idle_return::CheckIdleReturn)
             }
         },
         Commands::Rules(cmd) => match cmd {
             RulesCommands::ValidateFrontmatter => run_check_from_stdin(
-                &claude_hooks_rules::validate_skill_frontmatter::ValidateSkillFrontmatter,
+                &cadence_hooks_rules::validate_skill_frontmatter::ValidateSkillFrontmatter,
             ),
             RulesCommands::SecurityPatterns => run_check_from_stdin(
-                &claude_hooks_rules::check_security_patterns::SecurityPatternScanner,
+                &cadence_hooks_rules::check_security_patterns::SecurityPatternScanner,
             ),
         },
         Commands::Obsidian(cmd) => match cmd {
             ObsidianCommands::TrashGuard => {
-                run_check_from_stdin(&claude_hooks_obsidian::trash_guard::ObsidianTrashGuard)
+                run_check_from_stdin(&cadence_hooks_obsidian::trash_guard::ObsidianTrashGuard)
             }
         },
     }


### PR DESCRIPTION
## Summary

- Rename binary, all crate names, module paths, docs, CI, and LICENSE from `claude-hooks` to `cadence-hooks`
- Avoids naming collision with an existing `claude-hooks` package on Homebrew

All 486 tests pass. No functional changes.

## Test plan

- [x] `cargo test --workspace` — 486 passed
- [x] `cargo clippy -- -D warnings` — clean
- [ ] Tag v0.2.0 after merge, verify release builds `cadence-hooks` binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Rebranded project from `claude-hooks` to `cadence-hooks` across all components, configuration files, and documentation.
  * Updated binary name and all CLI references to reflect new project identity.
  * Updated repository URLs and installation instructions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->