### PR TITLE
feat(guardrails): AST-based chain analysis for multi-push commands

### DIFF
--- a/crates/core/src/loop_analysis.rs
+++ b/crates/core/src/loop_analysis.rs
@@ -808,8 +808,7 @@ mod tests {
     #[test]
     fn chain_does_not_count_pushes_inside_loops() {
         // The loop push should be handled by analyze_push_loops, not chain analysis
-        let result =
-            analyze_push_chain("git push origin main && for b in a b; do git push; done");
+        let result = analyze_push_chain("git push origin main && for b in a b; do git push; done");
         // Only the top-level push is counted — loop body is excluded
         assert!(matches!(result, ChainAnalysis::SingleOrNone));
     }
@@ -829,32 +828,28 @@ mod tests {
     #[test]
     fn chain_push_hidden_in_subshell() {
         // Push to different remote inside ( ) should be caught
-        let result =
-            analyze_push_chain("git push origin main && (git push upstream main)");
+        let result = analyze_push_chain("git push origin main && (git push upstream main)");
         assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
     }
 
     #[test]
     fn chain_push_hidden_in_brace_group() {
         // Push to different remote inside { } should be caught
-        let result =
-            analyze_push_chain("git push origin main && { git push upstream main; }");
+        let result = analyze_push_chain("git push origin main && { git push upstream main; }");
         assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
     }
 
     #[test]
     fn chain_or_operator_different_remotes() {
         // || chain — fallback push to different remote should block
-        let result =
-            analyze_push_chain("git push origin main || git push upstream main");
+        let result = analyze_push_chain("git push origin main || git push upstream main");
         assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
     }
 
     #[test]
     fn chain_or_operator_same_remote() {
         // || chain — retry to same remote should be allowed
-        let result =
-            analyze_push_chain("git push origin main || git push origin main");
+        let result = analyze_push_chain("git push origin main || git push origin main");
         match result {
             ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
             other => panic!("expected SameRemote, got {other:?}"),
@@ -864,8 +859,7 @@ mod tests {
     #[test]
     fn chain_variable_as_remote_treated_as_missing() {
         // $REMOTE is not a literal remote name — should be caught as missing
-        let result =
-            analyze_push_chain("git push $REMOTE main && git push origin main");
+        let result = analyze_push_chain("git push $REMOTE main && git push origin main");
         // $REMOTE won't match any known remote in extract_push_remote,
         // but at the chain level it's a non-flag positional arg
         // The key question: does brush-parser preserve $REMOTE as a word?
@@ -883,16 +877,15 @@ mod tests {
     fn chain_push_in_if_then_else() {
         // Pushes in different branches of an if statement to different remotes
         let result = analyze_push_chain(
-            "if true; then git push origin main; else git push upstream main; fi"
+            "if true; then git push origin main; else git push upstream main; fi",
         );
         assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
     }
 
     #[test]
     fn chain_push_in_if_same_remote() {
-        let result = analyze_push_chain(
-            "if true; then git push origin main; else git push origin feat; fi"
-        );
+        let result =
+            analyze_push_chain("if true; then git push origin main; else git push origin feat; fi");
         match result {
             ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
             other => panic!("expected SameRemote, got {other:?}"),
@@ -904,7 +897,7 @@ mod tests {
         // The loop push should be ignored by chain analysis (handled by loop analysis)
         // Only the top-level push counts
         let result = analyze_push_chain(
-            "git push origin main && for b in a b; do git push upstream $b; done"
+            "git push origin main && for b in a b; do git push upstream $b; done",
         );
         // Only one top-level push — loop body excluded
         assert!(matches!(result, ChainAnalysis::SingleOrNone));
@@ -914,9 +907,7 @@ mod tests {
     fn chain_command_substitution_in_remote() {
         // $(echo upstream) — parser should still produce a word node
         // but it won't be a simple literal remote name
-        let result = analyze_push_chain(
-            "git push origin main && git push $(echo upstream) main"
-        );
+        let result = analyze_push_chain("git push origin main && git push $(echo upstream) main");
         // Command substitution as remote — should not match "origin"
         assert!(!matches!(result, ChainAnalysis::SameRemote(ref r) if r == "origin"));
     }
@@ -924,18 +915,14 @@ mod tests {
     #[test]
     fn chain_quoted_git_push_not_counted() {
         // "git push" inside echo string should not be treated as a push command
-        let result = analyze_push_chain(
-            r#"echo "running git push" && git push origin main"#
-        );
+        let result = analyze_push_chain(r#"echo "running git push" && git push origin main"#);
         assert!(matches!(result, ChainAnalysis::SingleOrNone));
     }
 
     #[test]
     fn chain_force_push_same_remote_still_same() {
         // Force push is a separate concern (not chain analysis's job) — same remote is same remote
-        let result = analyze_push_chain(
-            "git push origin main && git push --force origin feat"
-        );
+        let result = analyze_push_chain("git push origin main && git push --force origin feat");
         match result {
             ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
             other => panic!("expected SameRemote, got {other:?}"),
@@ -945,9 +932,7 @@ mod tests {
     #[test]
     fn chain_push_tags_same_remote() {
         // Common pattern: push branch then push tags
-        let result = analyze_push_chain(
-            "git push origin main && git push origin --tags"
-        );
+        let result = analyze_push_chain("git push origin main && git push origin --tags");
         match result {
             ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
             other => panic!("expected SameRemote, got {other:?}"),
@@ -957,7 +942,7 @@ mod tests {
     #[test]
     fn chain_three_different_remotes() {
         let result = analyze_push_chain(
-            "git push origin main && git push upstream main && git push backup main"
+            "git push origin main && git push upstream main && git push backup main",
         );
         assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
     }
@@ -965,7 +950,7 @@ mod tests {
     #[test]
     fn chain_two_same_one_different() {
         let result = analyze_push_chain(
-            "git push origin main && git push origin v1.0 && git push upstream main"
+            "git push origin main && git push origin v1.0 && git push upstream main",
         );
         assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
     }

--- a/crates/core/src/loop_analysis.rs
+++ b/crates/core/src/loop_analysis.rs
@@ -823,4 +823,150 @@ mod tests {
             other => panic!("expected SameRemote, got {other:?}"),
         }
     }
+
+    // --- adversarial: chain analysis bypass attempts ---
+
+    #[test]
+    fn chain_push_hidden_in_subshell() {
+        // Push to different remote inside ( ) should be caught
+        let result =
+            analyze_push_chain("git push origin main && (git push upstream main)");
+        assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
+    }
+
+    #[test]
+    fn chain_push_hidden_in_brace_group() {
+        // Push to different remote inside { } should be caught
+        let result =
+            analyze_push_chain("git push origin main && { git push upstream main; }");
+        assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
+    }
+
+    #[test]
+    fn chain_or_operator_different_remotes() {
+        // || chain — fallback push to different remote should block
+        let result =
+            analyze_push_chain("git push origin main || git push upstream main");
+        assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
+    }
+
+    #[test]
+    fn chain_or_operator_same_remote() {
+        // || chain — retry to same remote should be allowed
+        let result =
+            analyze_push_chain("git push origin main || git push origin main");
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_variable_as_remote_treated_as_missing() {
+        // $REMOTE is not a literal remote name — should be caught as missing
+        let result =
+            analyze_push_chain("git push $REMOTE main && git push origin main");
+        // $REMOTE won't match any known remote in extract_push_remote,
+        // but at the chain level it's a non-flag positional arg
+        // The key question: does brush-parser preserve $REMOTE as a word?
+        // If so, it becomes explicit_repo = Some("$REMOTE") which differs from "origin"
+        assert!(!matches!(result, ChainAnalysis::SameRemote(_)));
+    }
+
+    #[test]
+    fn chain_empty_string() {
+        let result = analyze_push_chain("");
+        assert!(matches!(result, ChainAnalysis::SingleOrNone));
+    }
+
+    #[test]
+    fn chain_push_in_if_then_else() {
+        // Pushes in different branches of an if statement to different remotes
+        let result = analyze_push_chain(
+            "if true; then git push origin main; else git push upstream main; fi"
+        );
+        assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
+    }
+
+    #[test]
+    fn chain_push_in_if_same_remote() {
+        let result = analyze_push_chain(
+            "if true; then git push origin main; else git push origin feat; fi"
+        );
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_mixed_with_loop_only_counts_top_level() {
+        // The loop push should be ignored by chain analysis (handled by loop analysis)
+        // Only the top-level push counts
+        let result = analyze_push_chain(
+            "git push origin main && for b in a b; do git push upstream $b; done"
+        );
+        // Only one top-level push — loop body excluded
+        assert!(matches!(result, ChainAnalysis::SingleOrNone));
+    }
+
+    #[test]
+    fn chain_command_substitution_in_remote() {
+        // $(echo upstream) — parser should still produce a word node
+        // but it won't be a simple literal remote name
+        let result = analyze_push_chain(
+            "git push origin main && git push $(echo upstream) main"
+        );
+        // Command substitution as remote — should not match "origin"
+        assert!(!matches!(result, ChainAnalysis::SameRemote(ref r) if r == "origin"));
+    }
+
+    #[test]
+    fn chain_quoted_git_push_not_counted() {
+        // "git push" inside echo string should not be treated as a push command
+        let result = analyze_push_chain(
+            r#"echo "running git push" && git push origin main"#
+        );
+        assert!(matches!(result, ChainAnalysis::SingleOrNone));
+    }
+
+    #[test]
+    fn chain_force_push_same_remote_still_same() {
+        // Force push is a separate concern (not chain analysis's job) — same remote is same remote
+        let result = analyze_push_chain(
+            "git push origin main && git push --force origin feat"
+        );
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_push_tags_same_remote() {
+        // Common pattern: push branch then push tags
+        let result = analyze_push_chain(
+            "git push origin main && git push origin --tags"
+        );
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_three_different_remotes() {
+        let result = analyze_push_chain(
+            "git push origin main && git push upstream main && git push backup main"
+        );
+        assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
+    }
+
+    #[test]
+    fn chain_two_same_one_different() {
+        let result = analyze_push_chain(
+            "git push origin main && git push origin v1.0 && git push upstream main"
+        );
+        assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
+    }
 }

--- a/crates/core/src/loop_analysis.rs
+++ b/crates/core/src/loop_analysis.rs
@@ -61,6 +61,113 @@ pub fn analyze_gh_loops(command: &str) -> LoopAnalysis {
     }
 }
 
+/// Result of analyzing chained (non-loop) push commands.
+#[derive(Debug)]
+pub enum ChainAnalysis {
+    /// Zero or one push command — no chain to analyze.
+    SingleOrNone,
+    /// Multiple pushes, all with the same explicit remote.
+    SameRemote(String),
+    /// Multiple pushes targeting different remotes.
+    DifferentRemotes(Vec<LoopedCommand>),
+    /// Multiple pushes but some lack explicit remotes.
+    MissingRemotes(Vec<LoopedCommand>),
+    /// Parser failed — caller should fall back to counting.
+    ParseFailed,
+}
+
+/// Parse a shell command and analyze chained `git push` commands outside loops.
+///
+/// Extracts all top-level (non-looped) `git push` commands from `&&`/`;` chains
+/// and determines if they all target the same remote.
+pub fn analyze_push_chain(command: &str) -> ChainAnalysis {
+    let program = match parse_command(command) {
+        Some(p) => p,
+        None => return ChainAnalysis::ParseFailed,
+    };
+
+    let mut push_commands = Vec::new();
+    for complete_cmd in &program.complete_commands {
+        collect_top_level_pushes(complete_cmd, &mut push_commands);
+    }
+
+    if push_commands.len() <= 1 {
+        return ChainAnalysis::SingleOrNone;
+    }
+
+    if push_commands.iter().any(|c| c.explicit_repo.is_none()) {
+        return ChainAnalysis::MissingRemotes(push_commands);
+    }
+
+    let remotes: Vec<&str> = push_commands
+        .iter()
+        .filter_map(|c| c.explicit_repo.as_deref())
+        .collect();
+
+    if remotes.windows(2).all(|w| w[0] == w[1]) {
+        ChainAnalysis::SameRemote(remotes[0].to_string())
+    } else {
+        ChainAnalysis::DifferentRemotes(push_commands)
+    }
+}
+
+/// Collect `git push` commands from top-level (non-loop) positions in a compound list.
+fn collect_top_level_pushes(list: &CompoundList, out: &mut Vec<LoopedCommand>) {
+    for item in &list.0 {
+        let and_or = &item.0;
+        collect_top_level_pushes_from_pipeline(&and_or.first, out);
+        for additional in &and_or.additional {
+            let pipeline = match additional {
+                brush_parser::ast::AndOr::And(p) | brush_parser::ast::AndOr::Or(p) => p,
+            };
+            collect_top_level_pushes_from_pipeline(pipeline, out);
+        }
+    }
+}
+
+/// Collect `git push` from pipelines, but do NOT recurse into loop bodies.
+fn collect_top_level_pushes_from_pipeline(pipeline: &Pipeline, out: &mut Vec<LoopedCommand>) {
+    for cmd in &pipeline.seq {
+        match cmd {
+            Command::Simple(simple) => {
+                if is_git_push_command(simple) {
+                    out.push(LoopedCommand {
+                        name: "git push".to_string(),
+                        explicit_repo: extract_push_remote(simple),
+                        args: suffix_words(simple),
+                    });
+                }
+            }
+            Command::Compound(compound, _) => {
+                // Recurse into brace groups and subshells but NOT loops
+                match compound {
+                    CompoundCommand::BraceGroup(bg) => {
+                        collect_top_level_pushes(&bg.list, out);
+                    }
+                    CompoundCommand::Subshell(sub) => {
+                        collect_top_level_pushes(&sub.list, out);
+                    }
+                    CompoundCommand::IfClause(if_cmd) => {
+                        collect_top_level_pushes(&if_cmd.condition, out);
+                        collect_top_level_pushes(&if_cmd.then, out);
+                        if let Some(elses) = &if_cmd.elses {
+                            for else_clause in elses {
+                                if let Some(cond) = &else_clause.condition {
+                                    collect_top_level_pushes(cond, out);
+                                }
+                                collect_top_level_pushes(&else_clause.body, out);
+                            }
+                        }
+                    }
+                    // Skip loops — those are handled by analyze_push_loops
+                    _ => {}
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
 /// Parse a shell command and analyze any loops for `git push` commands.
 pub fn analyze_push_loops(command: &str) -> LoopAnalysis {
     let program = match parse_command(command) {
@@ -641,5 +748,79 @@ mod tests {
             "for a in 1; do for b in 2; do for c in 3; do git push; done; done; done",
         );
         assert!(matches!(result, LoopAnalysis::MissingTargets(_)));
+    }
+
+    // --- analyze_push_chain ---
+
+    #[test]
+    fn chain_single_push_returns_single() {
+        let result = analyze_push_chain("git push origin main");
+        assert!(matches!(result, ChainAnalysis::SingleOrNone));
+    }
+
+    #[test]
+    fn chain_no_push_returns_single() {
+        let result = analyze_push_chain("git status && git log");
+        assert!(matches!(result, ChainAnalysis::SingleOrNone));
+    }
+
+    #[test]
+    fn chain_same_remote_detected() {
+        let result = analyze_push_chain("git push origin main && git push origin v1.0.0");
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_different_remotes_detected() {
+        let result = analyze_push_chain("git push origin main && git push upstream main");
+        assert!(matches!(result, ChainAnalysis::DifferentRemotes(_)));
+    }
+
+    #[test]
+    fn chain_missing_remote_detected() {
+        let result = analyze_push_chain("git push && git push origin main");
+        assert!(matches!(result, ChainAnalysis::MissingRemotes(_)));
+    }
+
+    #[test]
+    fn chain_semicolon_same_remote() {
+        let result = analyze_push_chain("git push origin main; git push origin v2.0.0");
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_three_pushes_same_remote() {
+        let result = analyze_push_chain(
+            "git push origin main && git push origin v1.0.0 && git push origin --tags",
+        );
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn chain_does_not_count_pushes_inside_loops() {
+        // The loop push should be handled by analyze_push_loops, not chain analysis
+        let result =
+            analyze_push_chain("git push origin main && for b in a b; do git push; done");
+        // Only the top-level push is counted — loop body is excluded
+        assert!(matches!(result, ChainAnalysis::SingleOrNone));
+    }
+
+    #[test]
+    fn chain_with_non_push_commands_interleaved() {
+        let result =
+            analyze_push_chain("git tag v1.0.0 && git push origin main && git push origin v1.0.0");
+        match result {
+            ChainAnalysis::SameRemote(remote) => assert_eq!(remote, "origin"),
+            other => panic!("expected SameRemote, got {other:?}"),
+        }
     }
 }

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -4,7 +4,7 @@
 //! verifies the repository owner is in the configured allowlist. Also blocks
 //! looped pushes and force-push to `main`.
 
-use cadence_hooks_core::loop_analysis::{self, LoopAnalysis};
+use cadence_hooks_core::loop_analysis::{self, ChainAnalysis, LoopAnalysis};
 use cadence_hooks_core::shell::{
     LOOP_PATTERN, git_command, parse_work_dir, repo_from_url, strip_quotes,
 };
@@ -78,13 +78,34 @@ impl Check for PushRemoteGuard {
         // Structural safety checks first — these don't need the owner list
         // and must block even when unconfigured.
 
-        // Complexity gate: block batch pushes (strip quotes to avoid false positives)
-        let push_count = strip_quotes(command).matches("git push").count();
-        if push_count > 1 {
-            return CheckResult::block(
-                "🚫 git-guardrails: multiple git push commands — cannot verify targets\n   \
-                 Run each push individually so remotes can be validated.",
-            );
+        // Chain analysis: multiple pushes in && / ; chains
+        match loop_analysis::analyze_push_chain(command) {
+            ChainAnalysis::SameRemote(_) => {
+                // All chained pushes target the same remote — safe to proceed
+            }
+            ChainAnalysis::DifferentRemotes(_) => {
+                return CheckResult::block(
+                    "🚫 git-guardrails: chained git push to different remotes\n   \
+                     Run each push individually so remotes can be validated.",
+                );
+            }
+            ChainAnalysis::MissingRemotes(_) => {
+                return CheckResult::block(
+                    "🚫 git-guardrails: chained git push without explicit remotes\n   \
+                     Specify the remote explicitly on each push, or run them individually.",
+                );
+            }
+            ChainAnalysis::ParseFailed => {
+                // Fall back to substring count
+                let push_count = strip_quotes(command).matches("git push").count();
+                if push_count > 1 {
+                    return CheckResult::block(
+                        "🚫 git-guardrails: multiple git push commands — cannot verify targets\n   \
+                         Run each push individually so remotes can be validated.",
+                    );
+                }
+            }
+            ChainAnalysis::SingleOrNone => {}
         }
 
         // AST-based loop detection (MissingTargets and ParseFailed don't need owners)
@@ -298,12 +319,31 @@ mod tests {
     }
 
     #[test]
-    fn multiple_pushes_blocked() {
-        // Multiple pushes are checked before env vars
+    fn chained_pushes_different_remotes_blocked() {
         let result =
             PushRemoteGuard.run(&make_bash("git push origin main && git push upstream main"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
-        assert!(result.message.unwrap().contains("multiple"));
+        assert!(result.message.unwrap().contains("different remotes"));
+    }
+
+    #[test]
+    fn chained_pushes_same_remote_allowed() {
+        // git push origin main && git push origin v1.0.0 — same remote, safe
+        let result =
+            PushRemoteGuard.run(&make_bash("git push origin main && git push origin v1.0.0"));
+        // Should NOT block at the chain stage — continues to owner validation
+        let msg = result.message.as_deref().unwrap_or("");
+        assert!(
+            !msg.contains("different remotes") && !msg.contains("multiple"),
+            "same-remote chain should not be blocked as batch: {msg}"
+        );
+    }
+
+    #[test]
+    fn chained_pushes_missing_remote_blocked() {
+        let result = PushRemoteGuard.run(&make_bash("git push && git push origin main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert!(result.message.unwrap().contains("without explicit remotes"));
     }
 
     #[test]
@@ -314,11 +354,11 @@ mod tests {
     }
 
     #[test]
-    fn push_chain_with_semicolon_counted() {
+    fn push_chain_with_semicolon_different_remotes_blocked() {
         let result =
             PushRemoteGuard.run(&make_bash("git push origin main; git push upstream feat"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
-        assert!(result.message.unwrap().contains("multiple"));
+        assert!(result.message.unwrap().contains("different remotes"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Replace blunt `push_count > 1` substring check with AST-based chain analysis using `brush-parser`
- Chained pushes to the **same remote** are now **allowed**
- Chained pushes to **different remotes** or with **missing remotes** still block
- Falls back to substring count when the AST parser fails

Adds `ChainAnalysis` enum and `analyze_push_chain()` to `loop_analysis` module.

## Test plan

- [x] `cargo test --workspace` — all 808 tests pass
- [x] `cargo clippy --workspace -- -D warnings` — clean
- [ ] Manual: same-remote chain should be allowed
- [ ] Manual: different-remote chain should block

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust push-chain analysis: detects chained git push patterns across &&, ; and pipeline forms, and distinguishes same-remote chains from mixed or unspecified-remote chains.

* **Bug Fixes**
  * Blocks chained pushes to different remotes and pushes missing explicit remotes more accurately.
  * Ignores pushes that occur inside loop constructs.
  * Falls back gracefully when command parsing fails to avoid false negatives.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->