### PR TITLE
feat: add configure interactive wizard

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -65,7 +65,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -76,7 +76,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -132,7 +132,7 @@ dependencies = [
  "cached",
  "indenter",
  "peg",
- "thiserror",
+ "thiserror 2.0.18",
  "tracing",
  "utf8-chars",
 ]
@@ -154,7 +154,7 @@ dependencies = [
  "cached_proc_macro_types",
  "hashbrown 0.15.5",
  "once_cell",
- "thiserror",
+ "thiserror 2.0.18",
  "web-time",
 ]
 
@@ -186,7 +186,9 @@ dependencies = [
  "cadence-hooks-obsidian",
  "cadence-hooks-rules",
  "clap",
+ "dialoguer",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -285,6 +287,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
+name = "console"
+version = "0.15.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "054ccb5b10f9f2cbf51eb355ca1d05c2d279ce1804688d0db74b4733a5aeafd8"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "unicode-width",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "darling"
 version = "0.20.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -354,6 +369,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "dialoguer"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "658bce805d770f407bc62102fca7c2c64ceef2fbcb2b8bd19d2765ce093980de"
+dependencies = [
+ "console",
+ "shell-words",
+ "tempfile",
+ "thiserror 1.0.69",
+ "zeroize",
+]
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -366,7 +400,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -623,7 +657,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -682,6 +716,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,7 +748,16 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
 ]
 
 [[package]]
@@ -717,7 +766,18 @@ version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -767,6 +827,12 @@ name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-width"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
 
 [[package]]
 name = "unicode-xid"
@@ -910,12 +976,85 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
 ]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -1024,6 +1163,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,7 @@ serde_json = "1"
 regex = "1"
 clap = { version = "4", features = ["derive"] }
 brush-parser = "0.3"
+dialoguer = "0.11"
 
 cadence-hooks-core = { path = "crates/core" }
 cadence-hooks-cadence = { path = "crates/cadence" }
@@ -37,9 +38,12 @@ path = "src/main.rs"
 
 [dev-dependencies]
 serde_json.workspace = true
+tempfile = "3"
 
 [dependencies]
 clap.workspace = true
+dialoguer.workspace = true
+serde_json.workspace = true
 cadence-hooks-core.workspace = true
 cadence-hooks-cadence.workspace = true
 cadence-hooks-guardrails.workspace = true

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -148,28 +148,17 @@ pub fn run(list_only: bool, hooks: &[HookEntry]) -> ! {
 
     let currently_disabled = read_disabled_hooks(&settings_path);
 
-    // Build grouped items for the multi-select.
-    // Each item is a formatted string; we track which are pre-selected.
+    // Build items for the multi-select — only real hooks, no separators.
+    // Plugin name is prefixed to each item for visual grouping.
     let mut items: Vec<String> = Vec::new();
     let mut defaults: Vec<bool> = Vec::new();
     let mut hook_names: Vec<&str> = Vec::new();
-    let mut current_plugin = "";
 
     for hook in hooks {
-        if hook.plugin != current_plugin {
-            if !current_plugin.is_empty() {
-                // Separator between groups
-                items.push(String::new());
-                defaults.push(false);
-                hook_names.push("");
-            }
-            items.push(format!("── {} ──", hook.plugin));
-            defaults.push(false);
-            hook_names.push("");
-            current_plugin = hook.plugin;
-        }
-
-        items.push(format!("{:<28} {}", hook.name, hook.description));
+        items.push(format!(
+            "[{:<10}] {:<28} {}",
+            hook.plugin, hook.name, hook.description
+        ));
         // Pre-select hooks that are currently DISABLED (user is selecting what to disable)
         defaults.push(currently_disabled.iter().any(|d| d == hook.name));
         hook_names.push(hook.name);
@@ -190,17 +179,9 @@ pub fn run(list_only: bool, hooks: &[HookEntry]) -> ! {
         }
     };
 
-    // Map selections back to hook names (skip separator/header entries)
     let new_disabled: Vec<String> = selections
         .into_iter()
-        .filter_map(|i| {
-            let name = hook_names[i];
-            if name.is_empty() {
-                None
-            } else {
-                Some(name.to_string())
-            }
-        })
+        .map(|i| hook_names[i].to_string())
         .collect();
 
     // Write result

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -1,0 +1,226 @@
+//! Interactive configuration wizard for per-project hook disabling.
+//!
+//! Reads/writes `.claude/settings.json` in the project root, merging the
+//! `CADENCE_HOOKS_DISABLE` env var into the existing `env` block without
+//! clobbering other settings.
+
+use crate::HookEntry;
+use dialoguer::MultiSelect;
+use serde_json::{Map, Value};
+use std::path::{Path, PathBuf};
+use std::{fs, process};
+
+/// Locate `.claude/settings.json` — walk up from CWD to find a git root,
+/// then use `<root>/.claude/settings.json`. Falls back to CWD if no git root.
+fn find_settings_path() -> PathBuf {
+    let start = std::env::current_dir().unwrap_or_else(|_| PathBuf::from("."));
+
+    // Walk up looking for .git directory (project root)
+    let mut dir = start.as_path();
+    loop {
+        if dir.join(".git").exists() {
+            return dir.join(".claude/settings.json");
+        }
+        match dir.parent() {
+            Some(parent) => dir = parent,
+            None => break,
+        }
+    }
+
+    // No git root found — use CWD
+    start.join(".claude/settings.json")
+}
+
+/// Read the current `CADENCE_HOOKS_DISABLE` value from settings.json.
+fn read_disabled_hooks(settings_path: &Path) -> Vec<String> {
+    let content = match fs::read_to_string(settings_path) {
+        Ok(c) => c,
+        Err(_) => return Vec::new(),
+    };
+
+    let json: Value = match serde_json::from_str(&content) {
+        Ok(v) => v,
+        Err(_) => return Vec::new(),
+    };
+
+    json.get("env")
+        .and_then(|env| env.get("CADENCE_HOOKS_DISABLE"))
+        .and_then(|v| v.as_str())
+        .map(|s| {
+            s.split(',')
+                .map(|h| h.trim().to_string())
+                .filter(|h| !h.is_empty())
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// Write the disabled hooks list back to settings.json, merging into existing content.
+fn write_disabled_hooks(settings_path: &Path, disabled: &[String]) -> Result<(), String> {
+    // Read existing settings or start fresh
+    let mut root: Map<String, Value> = if settings_path.exists() {
+        let content = fs::read_to_string(settings_path)
+            .map_err(|e| format!("Failed to read {}: {e}", settings_path.display()))?;
+        match serde_json::from_str(&content) {
+            Ok(Value::Object(map)) => map,
+            Ok(_) => return Err(format!("{} is not a JSON object", settings_path.display())),
+            // Empty or invalid — start fresh
+            Err(_) => Map::new(),
+        }
+    } else {
+        Map::new()
+    };
+
+    // Get or create the `env` block
+    let env = root
+        .entry("env")
+        .or_insert_with(|| Value::Object(Map::new()));
+    let env_map = env
+        .as_object_mut()
+        .ok_or_else(|| format!("`env` in {} is not an object", settings_path.display()))?;
+
+    if disabled.is_empty() {
+        env_map.remove("CADENCE_HOOKS_DISABLE");
+        // Clean up empty env block
+        if env_map.is_empty() {
+            root.remove("env");
+        }
+    } else {
+        env_map.insert(
+            "CADENCE_HOOKS_DISABLE".to_string(),
+            Value::String(disabled.join(",")),
+        );
+    }
+
+    // Ensure parent directory exists
+    if let Some(parent) = settings_path.parent() {
+        fs::create_dir_all(parent)
+            .map_err(|e| format!("Failed to create {}: {e}", parent.display()))?;
+    }
+
+    let output = serde_json::to_string_pretty(&Value::Object(root))
+        .map_err(|e| format!("Failed to serialize settings: {e}"))?;
+
+    fs::write(settings_path, output + "\n")
+        .map_err(|e| format!("Failed to write {}: {e}", settings_path.display()))?;
+
+    Ok(())
+}
+
+/// Print current configuration without interactive mode.
+fn print_config(settings_path: &Path, hooks: &[HookEntry]) {
+    let disabled = read_disabled_hooks(settings_path);
+
+    println!("Settings: {}", settings_path.display());
+
+    if disabled.is_empty() {
+        println!("\nAll hooks enabled (no overrides).");
+        return;
+    }
+
+    println!("\nDisabled hooks:");
+    for name in &disabled {
+        // Find description from catalog
+        let desc = hooks
+            .iter()
+            .find(|h| h.name == name)
+            .map(|h| h.description)
+            .unwrap_or("(unknown hook)");
+        println!("  {name:<28} {desc}");
+    }
+
+    let enabled_count = hooks.len()
+        - disabled
+            .iter()
+            .filter(|d| hooks.iter().any(|h| h.name == d.as_str()))
+            .count();
+    println!("\n{} of {} hooks active.", enabled_count, hooks.len());
+}
+
+/// Run the configure wizard (or --list mode).
+pub fn run(list_only: bool, hooks: &[HookEntry]) -> ! {
+    let settings_path = find_settings_path();
+
+    if list_only {
+        print_config(&settings_path, hooks);
+        process::exit(0);
+    }
+
+    let currently_disabled = read_disabled_hooks(&settings_path);
+
+    // Build grouped items for the multi-select.
+    // Each item is a formatted string; we track which are pre-selected.
+    let mut items: Vec<String> = Vec::new();
+    let mut defaults: Vec<bool> = Vec::new();
+    let mut hook_names: Vec<&str> = Vec::new();
+    let mut current_plugin = "";
+
+    for hook in hooks {
+        if hook.plugin != current_plugin {
+            if !current_plugin.is_empty() {
+                // Separator between groups
+                items.push(String::new());
+                defaults.push(false);
+                hook_names.push("");
+            }
+            items.push(format!("── {} ──", hook.plugin));
+            defaults.push(false);
+            hook_names.push("");
+            current_plugin = hook.plugin;
+        }
+
+        items.push(format!("{:<28} {}", hook.name, hook.description));
+        // Pre-select hooks that are currently DISABLED (user is selecting what to disable)
+        defaults.push(currently_disabled.iter().any(|d| d == hook.name));
+        hook_names.push(hook.name);
+    }
+
+    println!("Configure cadence-hooks for: {}", settings_path.display());
+    println!("Select hooks to DISABLE (space to toggle, enter to confirm):\n");
+
+    let selections = match MultiSelect::new()
+        .items(&items)
+        .defaults(&defaults)
+        .interact_opt()
+    {
+        Ok(Some(sel)) => sel,
+        Ok(None) | Err(_) => {
+            println!("Cancelled.");
+            process::exit(0);
+        }
+    };
+
+    // Map selections back to hook names (skip separator/header entries)
+    let new_disabled: Vec<String> = selections
+        .into_iter()
+        .filter_map(|i| {
+            let name = hook_names[i];
+            if name.is_empty() {
+                None
+            } else {
+                Some(name.to_string())
+            }
+        })
+        .collect();
+
+    // Write result
+    match write_disabled_hooks(&settings_path, &new_disabled) {
+        Ok(()) => {
+            if new_disabled.is_empty() {
+                println!("\nAll hooks enabled. Removed CADENCE_HOOKS_DISABLE from settings.");
+            } else {
+                println!(
+                    "\nDisabled {} hook(s): {}",
+                    new_disabled.len(),
+                    new_disabled.join(", ")
+                );
+                println!("Written to: {}", settings_path.display());
+            }
+            process::exit(0);
+        }
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    }
+}

--- a/src/configure.rs
+++ b/src/configure.rs
@@ -64,8 +64,7 @@ fn write_disabled_hooks(settings_path: &Path, disabled: &[String]) -> Result<(),
         match serde_json::from_str(&content) {
             Ok(Value::Object(map)) => map,
             Ok(_) => return Err(format!("{} is not a JSON object", settings_path.display())),
-            // Empty or invalid — start fresh
-            Err(_) => Map::new(),
+            Err(e) => return Err(format!("Failed to parse {}: {e}", settings_path.display())),
         }
     } else {
         Map::new()

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,8 @@ use cadence_hooks_core::{HookEvent, run_check_from_stdin};
 use clap::{Parser, Subcommand};
 use std::process;
 
+mod configure;
+
 #[derive(Parser)]
 #[command(name = "cadence-hooks", version, about = "Compiled Claude Code hooks")]
 struct Cli {
@@ -35,6 +37,13 @@ enum Commands {
 
     /// List all hooks with descriptions and disable status
     List,
+
+    /// Interactively configure which hooks to disable for this project
+    Configure {
+        /// Print current configuration without interactive mode
+        #[arg(long)]
+        list: bool,
+    },
 }
 
 #[derive(Subcommand)]
@@ -265,7 +274,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
         Commands::Obsidian(o) => Some(match o {
             ObsidianCommands::TrashGuard => "trash-guard",
         }),
-        Commands::List => None,
+        Commands::List | Commands::Configure { .. } => None,
     }
 }
 
@@ -314,9 +323,9 @@ fn print_hook_list() {
 fn main() {
     // Maintenance bypass — set CADENCE_HOOKS_BYPASS=1 to skip all enforcement.
     // Useful when editing hook source or testing. Per-session, can't be left on accidentally.
-    // Note: `list` subcommand is exempt — it needs to show bypass status.
+    // Note: `list` and `configure` subcommands are exempt — they need to work always.
     let bypassed = std::env::var("CADENCE_HOOKS_BYPASS").as_deref() == Ok("1");
-    if bypassed && !std::env::args().any(|a| a == "list") {
+    if bypassed && !std::env::args().any(|a| a == "list" || a == "configure") {
         eprintln!("⚠️  cadence-hooks: all enforcement bypassed (CADENCE_HOOKS_BYPASS=1)");
         process::exit(0);
     }
@@ -398,6 +407,9 @@ fn main() {
         Commands::List => {
             print_hook_list();
             process::exit(0);
+        }
+        Commands::Configure { list } => {
+            configure::run(list, HOOKS);
         }
         Commands::Cadence(cmd) => match cmd {
             CadenceCommands::Terminology => {

--- a/tests/configure.rs
+++ b/tests/configure.rs
@@ -1,0 +1,243 @@
+//! Integration tests for the `configure` subcommand.
+//!
+//! Tests the `--list` flag and settings.json read/write behavior.
+//! The interactive multi-select cannot be tested without a TTY,
+//! so we focus on the non-interactive paths.
+
+use std::fs;
+use std::process::Command;
+
+fn cadence_hooks() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cadence-hooks"));
+    cmd.env_remove("CADENCE_HOOKS_BYPASS");
+    cmd.env_remove("CADENCE_HOOKS_DISABLE");
+    cmd
+}
+
+// ── configure --list ─────────────────────────────────────────────────
+
+#[test]
+fn configure_list_shows_all_enabled_when_no_settings() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        stdout.contains("All hooks enabled"),
+        "should report all enabled when no settings exist: {stdout}"
+    );
+}
+
+#[test]
+fn configure_list_shows_disabled_hooks() {
+    let tmp = tempfile::tempdir().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"env":{"CADENCE_HOOKS_DISABLE":"git-safety,warn-main-branch"}}"#,
+    )
+    .unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        stdout.contains("git-safety"),
+        "should list disabled hook: {stdout}"
+    );
+    assert!(
+        stdout.contains("warn-main-branch"),
+        "should list disabled hook: {stdout}"
+    );
+    assert!(
+        stdout.contains("Disabled hooks:"),
+        "should show disabled section: {stdout}"
+    );
+}
+
+#[test]
+fn configure_list_shows_settings_path() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("settings.json"),
+        "should show settings path: {stdout}"
+    );
+}
+
+#[test]
+fn configure_list_shows_hook_count() {
+    let tmp = tempfile::tempdir().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"env":{"CADENCE_HOOKS_DISABLE":"git-safety"}}"#,
+    )
+    .unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    // Should show "N of M hooks active"
+    assert!(
+        stdout.contains("hooks active"),
+        "should show active hook count: {stdout}"
+    );
+}
+
+#[test]
+fn configure_list_handles_malformed_settings() {
+    let tmp = tempfile::tempdir().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(claude_dir.join("settings.json"), "not valid json {{{").unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "should gracefully handle malformed settings"
+    );
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("All hooks enabled"),
+        "malformed settings should show all enabled: {stdout}"
+    );
+}
+
+#[test]
+fn configure_list_handles_empty_disable_value() {
+    let tmp = tempfile::tempdir().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"env":{"CADENCE_HOOKS_DISABLE":""}}"#,
+    )
+    .unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        stdout.contains("All hooks enabled"),
+        "empty disable value should show all enabled: {stdout}"
+    );
+}
+
+#[test]
+fn configure_list_preserves_unknown_hooks() {
+    let tmp = tempfile::tempdir().unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"env":{"CADENCE_HOOKS_DISABLE":"future-hook,git-safety"}}"#,
+    )
+    .unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        stdout.contains("future-hook"),
+        "should show unknown hooks too: {stdout}"
+    );
+    assert!(
+        stdout.contains("(unknown hook)"),
+        "should mark unknown hooks: {stdout}"
+    );
+}
+
+// ── configure works during bypass ────────────────────────────────────
+
+#[test]
+fn configure_works_during_bypass() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.env("CADENCE_HOOKS_BYPASS", "1");
+    cmd.current_dir(tmp.path());
+
+    let output = cmd.output().expect("failed to execute binary");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "configure should work even when bypass is active"
+    );
+}
+
+// ── configure finds git root ─────────────────────────────────────────
+
+#[test]
+fn configure_finds_git_root_settings() {
+    let tmp = tempfile::tempdir().unwrap();
+
+    // Create a fake git root with settings
+    fs::create_dir_all(tmp.path().join(".git")).unwrap();
+    let claude_dir = tmp.path().join(".claude");
+    fs::create_dir_all(&claude_dir).unwrap();
+    fs::write(
+        claude_dir.join("settings.json"),
+        r#"{"env":{"CADENCE_HOOKS_DISABLE":"terminology"}}"#,
+    )
+    .unwrap();
+
+    // Run from a subdirectory
+    let subdir = tmp.path().join("src").join("deep");
+    fs::create_dir_all(&subdir).unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["configure", "--list"]);
+    cmd.current_dir(&subdir);
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert_eq!(output.status.code(), Some(0));
+    assert!(
+        stdout.contains("terminology"),
+        "should find settings from git root when run from subdir: {stdout}"
+    );
+}


### PR DESCRIPTION
## Summary

- Adds `cadence-hooks configure` — an interactive TUI wizard (via `dialoguer`) for selecting which hooks to disable per-project
- Writes `CADENCE_HOOKS_DISABLE` into `.claude/settings.json` env block, merging without clobbering existing settings
- `configure --list` prints current config non-interactively (for scripts/CI)
- Finds settings by walking up to git root, gracefully handles missing/malformed files

## Test plan

- [x] 9 new integration tests pass (`cargo test --test configure`)
- [x] Full suite green (`cargo test` — 33 tests)
- [x] `cargo clippy --all-targets` clean
- [x] `cargo fmt` clean
- [ ] CI green on push
- [ ] Manual smoke test: run `cadence-hooks configure` in a project

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a configure subcommand to interactively manage which cadence hooks are active per project, plus a --list mode to view current configuration and counts; discovers project settings from repository root when available.

* **Tests**
  * Added integration tests for list behavior, malformed/empty settings, unknown entries, git-root discovery, and bypass behavior.

* **Chores**
  * Updated dependencies and dev-dependencies (including interactive prompt and tempfile utilities).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->