### PR TITLE
chore: add issue templates and reporting docs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,103 @@
+name: Bug report
+description: Something the binary does wrong — a hook that misfires, blocks the wrong action, or returns the wrong exit code.
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to file a bug. The more reproducible the report, the faster the fix.
+
+        Sensitive paths, hostnames, and emails should be redacted before posting.
+
+  - type: input
+    id: version
+    attributes:
+      label: cadence-hooks version
+      description: Output of `cadence-hooks --version`. If installed via Homebrew, also note the formula tap (e.g., `cadence-hooks-beta`).
+      placeholder: "cadence-hooks 0.5.0 (homebrew: cadence-hooks-beta)"
+    validations:
+      required: true
+
+  - type: input
+    id: os
+    attributes:
+      label: OS / platform
+      description: macOS / Linux / WSL plus version (e.g., `macOS 15.2 (Darwin 25.2.0)`).
+      placeholder: "macOS 15.2 (Darwin 25.2.0)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: subcommand
+    attributes:
+      label: Subcommand / hook
+      description: Which hook is misbehaving? Pick the closest plugin namespace.
+      options:
+        - cadence (terminology, orphaned-todos, prevent-secret-leaks, prevent-secret-writes, memory-guard, git-safety, line-endings, env-vars, warn-untracked, markdown-lint)
+        - guardrails (guard-push-remote, guard-gh-write, guard-gh-dangerous, guard-git-init, warn-main-branch, check-idle-return)
+        - rules (validate-frontmatter, security-patterns)
+        - obsidian (trash-guard)
+        - configure / version / other
+    validations:
+      required: true
+
+  - type: input
+    id: hook
+    attributes:
+      label: Specific hook name
+      description: The exact subcommand name (e.g., `guard-push-remote`).
+      placeholder: "guard-push-remote"
+    validations:
+      required: true
+
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment snapshot
+      description: Relevant `CADENCE_*` env vars and any plugin-specific config from `~/.claude/settings.json`. Redact tokens, paths, and personal info.
+      render: shell
+      placeholder: |
+        CADENCE_ALLOWED_OWNERS="cameronsjo cameron"
+        CADENCE_DISABLE=""
+        CADENCE_BYPASS=""
+    validations:
+      required: false
+
+  - type: textarea
+    id: repro
+    attributes:
+      label: Reproduction
+      description: Minimal steps to reproduce. A console transcript is ideal — include the command and the full hook output.
+      render: shell
+      placeholder: |
+        $ git push origin main
+        🚫 git-guardrails: Push target is not yours
+           Would push to: ...
+           Allowed:       ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: Push proceeds because the path owner matches the allow-list.
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: Push is blocked even though the URL path owner is in the allow-list.
+    validations:
+      required: true
+
+  - type: textarea
+    id: hypothesis
+    attributes:
+      label: Hypothesis or notes
+      description: Any guesses about root cause, related code paths, or workarounds you found. Optional.
+      placeholder: Owner-match logic seems to special-case `github.com`...
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -28,15 +28,15 @@ body:
       required: true
 
   - type: dropdown
-    id: subcommand
+    id: namespace
     attributes:
-      label: Subcommand / hook
-      description: Which hook is misbehaving? Pick the closest plugin namespace.
+      label: Plugin namespace
+      description: Which plugin family does the misbehaving hook belong to?
       options:
-        - cadence (terminology, orphaned-todos, prevent-secret-leaks, prevent-secret-writes, memory-guard, git-safety, line-endings, env-vars, warn-untracked, markdown-lint)
-        - guardrails (guard-push-remote, guard-gh-write, guard-gh-dangerous, guard-git-init, warn-main-branch, check-idle-return)
-        - rules (validate-frontmatter, security-patterns)
-        - obsidian (trash-guard)
+        - cadence
+        - guardrails
+        - rules
+        - obsidian
         - configure / version / other
     validations:
       required: true
@@ -45,7 +45,7 @@ body:
     id: hook
     attributes:
       label: Specific hook name
-      description: The exact subcommand name (e.g., `guard-push-remote`).
+      description: The exact subcommand name. Run `cadence-hooks <namespace> --help` to list available hooks.
       placeholder: "guard-push-remote"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -45,7 +45,7 @@ body:
     id: hook
     attributes:
       label: Specific hook name
-      description: The exact subcommand name. Run `cadence-hooks <namespace> --help` to list available hooks.
+      description: The exact subcommand name. For a namespace, run `cadence-hooks <namespace> --help` to list its hooks. For top-level options, see `cadence-hooks --help`.
       placeholder: "guard-push-remote"
     validations:
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Documentation
+    url: https://github.com/cameronsjo/cadence-hooks#readme
+    about: Hook reference, environment variables, and architecture overview.
+  - name: Plugin distribution issues
+    url: https://github.com/cameronsjo/claude-configurations/issues
+    about: Marketplace, plugin metadata, or hooks.json wiring (not binary behavior).

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,71 @@
+name: Feature request
+description: Suggest a new hook, a new flag on an existing hook, or a behavior change.
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the suggestion. Please describe the use case before the implementation — it makes the trade-offs easier to discuss.
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Scope
+      description: Which surface does this touch?
+      options:
+        - New hook (cadence)
+        - New hook (guardrails)
+        - New hook (rules)
+        - New hook (obsidian)
+        - Change to existing hook
+        - CLI / configure / packaging
+        - Other
+    validations:
+      required: true
+
+  - type: input
+    id: hook
+    attributes:
+      label: Affected hook(s)
+      description: If this changes existing behavior, which subcommand?
+      placeholder: "guardrails warn-main-branch"
+    validations:
+      required: false
+
+  - type: textarea
+    id: use-case
+    attributes:
+      label: Use case
+      description: What are you trying to do, and what currently gets in the way?
+      placeholder: |
+        During session wrap-up I often work directly on main for small config edits...
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposal
+      description: How should it work? Be concrete about the user-facing behavior — flags, env vars, exit codes, hook output.
+      placeholder: |
+        Add `dismiss-main-branch-warn --for 30m` that writes a marker file...
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you weighed. Helps narrow the design space.
+      placeholder: |
+        Option A — env var timeout: simpler but no per-repo scope...
+    validations:
+      required: false
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: Related issues, prior art in other tools, links to discussion. Optional.
+    validations:
+      required: false

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Hooks are organized by the plugin they serve:
 | `git-safety` | PreToolUse (Bash) | Block force-push to main, reset --hard, etc. |
 | `line-endings` | PreToolUse (Write) | Validate shell script line endings (LF, not CRLF) |
 | `env-vars` | PreToolUse (Write, Edit) | Warn on generic env var names (DEBUG, PORT) |
-| `warn-untracked` | PreToolUse (Bash) | Warn about untracked files during git commit |
+| `warn-docs-update` | PreToolUse (Bash) | Nudge to review docs when creating a PR (`gh pr create`) |
 | `markdown-lint` | PreToolUse (Write) | Run markdownlint on markdown files |
 
 ### guardrails (git-guardrails)
@@ -34,7 +34,11 @@ Hooks are organized by the plugin they serve:
 | `guard-gh-dangerous` | PreToolUse (Bash) | Block irreversible gh operations (repo delete) |
 | `guard-git-init` | PreToolUse (Bash) | Nudge to scaffold after git init |
 | `warn-main-branch` | PreToolUse (Write, Edit) | Warn when editing on main/master branch |
+| `warn-branch-base` | PreToolUse (Bash) | Warn when creating a branch from a non-main base |
+| `warn-cron-datetime` | PreToolUse (CronCreate) | Inject current datetime before scheduling cron jobs |
+| `warn-untracked` | PreToolUse (Bash) | Warn about untracked files during git commit |
 | `check-idle-return` | PreToolUse | Nudge after idle periods between edits |
+| `nudge-upgrade-after-push` | PostToolUse (Bash) | Nudge to schedule a brew upgrade after pushing cadence-hooks to main |
 
 ### rules
 
@@ -145,7 +149,7 @@ Under Claude Code (detected via `CLAUDECODE=1`), the `configure` subcommand is h
 cadence-hooks (binary)
 ├── crates/core        — Hook protocol: JSON parsing, Check trait, exit codes
 ├── crates/cadence     — Cadence plugin hooks (10 checks)
-├── crates/guardrails  — Git guardrails hooks (6 checks)
+├── crates/guardrails  — Git guardrails hooks (10 checks)
 ├── crates/rules       — Rules plugin hooks (2 checks)
 ├── crates/obsidian    — Obsidian plugin hooks (1 check)
 └── src/main.rs        — CLI: routes subcommands to checks

--- a/README.md
+++ b/README.md
@@ -175,6 +175,12 @@ make install       # Install to ~/.cargo/bin
 
 Requires Rust 2024 edition (1.85+).
 
+## Reporting issues
+
+Bug reports and feature requests for the binary belong here: [Issues](https://github.com/cameronsjo/cadence-hooks/issues/new/choose).
+
+Two templates are available — Bug report (capture version, OS, subcommand, env, and repro) and Feature request. Issues about plugin distribution, marketplace metadata, or `hooks.json` wiring belong in [claude-configurations](https://github.com/cameronsjo/claude-configurations/issues) instead.
+
 ## License
 
 [BSL-1.1](LICENSE) — free for personal, non-commercial use. Converts to MIT after four years.

--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ Requires Rust 2024 edition (1.85+).
 
 Bug reports and feature requests for the binary belong here: [Issues](https://github.com/cameronsjo/cadence-hooks/issues/new/choose).
 
-Two templates are available — Bug report (capture version, OS, subcommand, env, and repro) and Feature request. Issues about plugin distribution, marketplace metadata, or `hooks.json` wiring belong in [claude-configurations](https://github.com/cameronsjo/claude-configurations/issues) instead.
+Two templates are available — Bug report (capture version, OS, plugin namespace, hook name, env, and repro) and Feature request. Issues about plugin distribution, marketplace metadata, or `hooks.json` wiring belong in [claude-configurations](https://github.com/cameronsjo/claude-configurations/issues) instead.
 
 ## License
 


### PR DESCRIPTION
## Summary

- Issues was just enabled on this repo (refs cameronsjo/claude-configurations#10) — this PR seeds it with structured templates so bug reports arrive with the context needed for triage
- Bug report and feature request as YAML issue forms (required version/OS/subcommand/env/repro fields)
- `config.yml` disables blank issues and routes plugin-distribution bugs to `claude-configurations`
- README gains a Reporting issues section pointing at `/issues/new/choose`

## Why issue forms over Markdown templates

Forms enforce required fields and render fenced code blocks correctly via `render: shell`. The subcommand dropdown also doubles as a discoverability cheatsheet — it enumerates every hook by namespace, so users who think `warn-main-branch` lives under `cadence` (it's `guardrails`) get corrected at the form layer.

## Follow-up

Once this lands, claude-configurations#9 (guardrails Gitea bug) and claude-configurations#11 (warn-main-branch snooze) get transferred over here.

## Test plan

- [ ] Issues tab visible on the repo
- [ ] `Issues → New issue` shows Bug report + Feature request, no blank option
- [ ] Bug report form submits with required fields enforced
- [ ] Contact link to claude-configurations issues works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added structured bug report and feature request issue forms that collect required context and apply default labels.
  * Disabled creation of blank issues and added contact links to direct users to relevant resources.
  * Updated README: refreshed hook inventory and guardrails list, adjusted architecture overview to reflect additional checks, and added a “Reporting issues” section.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->