### PR TITLE
feat(guardrails): support self-hosted forges via CADENCE_EXTRA_HOSTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,24 @@ All cadence-hooks config lives under the `CADENCE_*` prefix. `OBSIDIAN_VAULT` is
 | `CADENCE_BYPASS` | all hooks | Set to `1` to skip all enforcement (maintenance bypass) |
 | `CADENCE_ALLOWED_OWNERS` | `guard-push-remote`, `guard-gh-write` | Space or comma-separated usernames |
 | `CADENCE_ALLOWED_REPOS` | `guard-gh-write` | Space or comma-separated `owner/repo` pairs |
+| `CADENCE_EXTRA_HOSTS` | `guard-push-remote` | Self-hosted forge hosts that bare entries (`cameron`) should match in addition to the default host |
 | `OBSIDIAN_VAULT` | `trash-guard` | Absolute path to Obsidian vault |
+
+#### Allowlist host scoping
+
+Bare entries in `CADENCE_ALLOWED_OWNERS` and `CADENCE_ALLOWED_REPOS` match only the default host (`github.com`, or `GH_HOST` if set). For self-hosted forges (Gitea, Forgejo, GitLab CE, Bitbucket Server), use one of:
+
+- **Host-qualified entries** — `git.sjo.lol/cameron` matches only that host
+- **`CADENCE_EXTRA_HOSTS`** — opt additional hosts into the bare-entry flow when you reuse the same username across forges you control
+
+```bash
+# Match `cameron` on github.com AND git.sjo.lol
+export CADENCE_ALLOWED_OWNERS="cameron"
+export CADENCE_EXTRA_HOSTS="git.sjo.lol"
+
+# Or scope the entry explicitly without widening
+export CADENCE_ALLOWED_OWNERS="cameron git.sjo.lol/cameron"
+```
 
 Under Claude Code (detected via `CLAUDECODE=1`), the `configure` subcommand is hidden from `--help` and refuses to run interactively. `configure --list` remains available. Run `configure` from a real terminal to change hook state.
 

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -139,7 +139,8 @@ pub fn is_allowed(
 /// match any host in `extra_hosts` in addition to [`default_host`].
 ///
 /// Host-qualified entries (`gitea.internal/cameron`) are unaffected — they
-/// continue to match only their declared host.
+/// continue to match only their declared host. `extra_hosts` is normalized
+/// to lowercase internally, so callers may pass mixed-case values safely.
 pub fn is_allowed_with_extra_hosts(
     host: &str,
     owner: &str,
@@ -152,11 +153,12 @@ pub fn is_allowed_with_extra_hosts(
     let host_lower = host.to_lowercase();
     let owner_lower = owner.to_lowercase();
     let repo_lower = repo.to_lowercase();
+    let extra_hosts_lower: Vec<String> = extra_hosts.iter().map(|h| h.to_lowercase()).collect();
 
     let host_matches_bare_entry = |entry_host: Option<&str>| -> bool {
         match entry_host {
             Some(h) => h == host_lower,
-            None => host_lower == default || extra_hosts.iter().any(|h| h == &host_lower),
+            None => host_lower == default || extra_hosts_lower.iter().any(|h| h == &host_lower),
         }
     };
 
@@ -566,6 +568,22 @@ mod tests {
         let extras = vec!["git.sjo.lol".to_string()];
         assert!(!is_allowed_with_extra_hosts(
             "evil.example",
+            "cameron",
+            "repo",
+            &owners,
+            &[],
+            &extras,
+        ));
+    }
+
+    #[test]
+    fn extra_hosts_case_insensitive() {
+        // The function must tolerate mixed-case extra_hosts values from
+        // callers that don't go through env_extra_hosts() for normalization.
+        let owners = parse_allow_entries("cameron");
+        let extras = vec!["Git.SJO.Lol".to_string()];
+        assert!(is_allowed_with_extra_hosts(
+            "git.sjo.lol",
             "cameron",
             "repo",
             &owners,

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -55,6 +55,21 @@ pub fn default_host() -> String {
         .to_lowercase()
 }
 
+/// Read `CADENCE_EXTRA_HOSTS` env var as a list of additional hosts that bare
+/// allowlist entries (e.g., `cameron` rather than `git.sjo.lol/cameron`) should
+/// match in addition to [`default_host`].
+///
+/// Use this for self-hosted forges where you reuse the same username across
+/// hosts you control (Gitea, Forgejo, GitLab CE, Bitbucket Server). It does
+/// not widen host-qualified entries — `git.sjo.lol/cameron` still matches
+/// only that host.
+pub fn env_extra_hosts() -> Vec<String> {
+    env_list("CADENCE_EXTRA_HOSTS")
+        .into_iter()
+        .map(|h| h.to_lowercase())
+        .collect()
+}
+
 /// Parse a single allowlist entry string into an [`AllowEntry`].
 pub fn parse_allow_entry(entry: &str) -> AllowEntry {
     let parts: Vec<&str> = entry.splitn(3, '/').collect();
@@ -106,7 +121,10 @@ pub fn env_allow_entries(var: &str) -> Vec<AllowEntry> {
 }
 
 /// Check if a `(host, owner, repo)` triple is allowed by either the owner
-/// or repo allowlists. Bare entries (no host) match against `default_host`.
+/// or repo allowlists. Bare entries (no host) match against [`default_host`].
+///
+/// Use [`is_allowed_with_extra_hosts`] when you need bare entries to also
+/// match self-hosted forges (Gitea, Forgejo, GitLab CE, Bitbucket Server).
 pub fn is_allowed(
     host: &str,
     owner: &str,
@@ -114,15 +132,37 @@ pub fn is_allowed(
     owner_entries: &[AllowEntry],
     repo_entries: &[AllowEntry],
 ) -> bool {
+    is_allowed_with_extra_hosts(host, owner, repo, owner_entries, repo_entries, &[])
+}
+
+/// Like [`is_allowed`], but bare allowlist entries (e.g., `cameron`) also
+/// match any host in `extra_hosts` in addition to [`default_host`].
+///
+/// Host-qualified entries (`gitea.internal/cameron`) are unaffected — they
+/// continue to match only their declared host.
+pub fn is_allowed_with_extra_hosts(
+    host: &str,
+    owner: &str,
+    repo: &str,
+    owner_entries: &[AllowEntry],
+    repo_entries: &[AllowEntry],
+    extra_hosts: &[String],
+) -> bool {
     let default = default_host();
     let host_lower = host.to_lowercase();
     let owner_lower = owner.to_lowercase();
     let repo_lower = repo.to_lowercase();
 
+    let host_matches_bare_entry = |entry_host: Option<&str>| -> bool {
+        match entry_host {
+            Some(h) => h == host_lower,
+            None => host_lower == default || extra_hosts.iter().any(|h| h == &host_lower),
+        }
+    };
+
     // Check repo entries first (more specific)
     for entry in repo_entries {
-        let entry_host = entry.host.as_deref().unwrap_or(&default);
-        if entry_host == host_lower
+        if host_matches_bare_entry(entry.host.as_deref())
             && entry.owner == owner_lower
             && entry.repo.as_deref() == Some(repo_lower.as_str())
         {
@@ -132,8 +172,7 @@ pub fn is_allowed(
 
     // Check owner entries
     for entry in owner_entries {
-        let entry_host = entry.host.as_deref().unwrap_or(&default);
-        if entry_host == host_lower && entry.owner == owner_lower {
+        if host_matches_bare_entry(entry.host.as_deref()) && entry.owner == owner_lower {
             // If entry has a repo constraint, it must match
             if let Some(entry_repo) = &entry.repo
                 && *entry_repo != repo_lower
@@ -452,6 +491,101 @@ mod tests {
             "shared-repo",
             &[],
             &repos
+        ));
+    }
+
+    // --- is_allowed_with_extra_hosts ---
+
+    #[test]
+    fn extra_hosts_matches_bare_owner_on_self_hosted_forge() {
+        // Repro for cadence-hooks#15: bare `cameron` should match git.sjo.lol
+        // when that host is in CADENCE_EXTRA_HOSTS.
+        let owners = parse_allow_entries("cameron");
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(is_allowed_with_extra_hosts(
+            "git.sjo.lol",
+            "cameron",
+            "runelite-plugins",
+            &owners,
+            &[],
+            &extras,
+        ));
+    }
+
+    #[test]
+    fn extra_hosts_does_not_widen_qualified_entries() {
+        // Host-qualified entries stay scoped to their declared host even when
+        // extra_hosts is populated. Otherwise a `github.com/cameron` entry
+        // could leak into self-hosted matching, defeating the safety property.
+        let owners = parse_allow_entries("github.com/cameron");
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(!is_allowed_with_extra_hosts(
+            "git.sjo.lol",
+            "cameron",
+            "repo",
+            &owners,
+            &[],
+            &extras,
+        ));
+    }
+
+    #[test]
+    fn extra_hosts_preserves_default_host_match() {
+        // Bare entries continue to match default_host even with extras present.
+        let owners = parse_allow_entries("cameron");
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(is_allowed_with_extra_hosts(
+            "github.com",
+            "cameron",
+            "repo",
+            &owners,
+            &[],
+            &extras,
+        ));
+    }
+
+    #[test]
+    fn empty_extra_hosts_preserves_old_safety_property() {
+        // Regression guard for `owner_check_host_mismatch_blocked` semantics:
+        // with no extras, bare owner must NOT match a non-default host.
+        let owners = parse_allow_entries("cameron");
+        assert!(!is_allowed_with_extra_hosts(
+            "git.sjo.lol",
+            "cameron",
+            "repo",
+            &owners,
+            &[],
+            &[],
+        ));
+    }
+
+    #[test]
+    fn extra_hosts_does_not_match_unlisted_host() {
+        // Only hosts in extra_hosts unlock; others stay blocked.
+        let owners = parse_allow_entries("cameron");
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(!is_allowed_with_extra_hosts(
+            "evil.example",
+            "cameron",
+            "repo",
+            &owners,
+            &[],
+            &extras,
+        ));
+    }
+
+    #[test]
+    fn extra_hosts_with_bare_repo_entry() {
+        // Bare owner/repo entries (`external/shared-repo`) also widen to extras.
+        let repos = parse_allow_entries("cameron/runelite-plugins");
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(is_allowed_with_extra_hosts(
+            "git.sjo.lol",
+            "cameron",
+            "runelite-plugins",
+            &[],
+            &repos,
+            &extras,
         ));
     }
 

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -4,7 +4,7 @@
 //! verifies the repository owner is in the configured allowlist. Also blocks
 //! looped pushes and force-push to `main`.
 
-use cadence_hooks_core::config::{self, AllowEntry, env_allow_entries};
+use cadence_hooks_core::config::{self, AllowEntry, env_allow_entries, env_extra_hosts};
 use cadence_hooks_core::loop_analysis::{self, ChainAnalysis, LoopAnalysis};
 use cadence_hooks_core::shell::{
     LOOP_PATTERN, git_command, host_and_repo_from_url, parse_work_dir, strip_quotes,
@@ -12,14 +12,26 @@ use cadence_hooks_core::shell::{
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Check if a URL's owner is in the allowed list.
-fn check_owner(url: &str, allowed_owners: &[AllowEntry], allowed_repos: &[AllowEntry]) -> bool {
+fn check_owner(
+    url: &str,
+    allowed_owners: &[AllowEntry],
+    allowed_repos: &[AllowEntry],
+    extra_hosts: &[String],
+) -> bool {
     let Some((host, repo_path)) = host_and_repo_from_url(url) else {
         return false;
     };
     let mut parts = repo_path.splitn(2, '/');
     let owner = parts.next().unwrap_or("");
     let repo = parts.next().unwrap_or("");
-    config::is_allowed(&host, owner, repo, allowed_owners, allowed_repos)
+    config::is_allowed_with_extra_hosts(
+        &host,
+        owner,
+        repo,
+        allowed_owners,
+        allowed_repos,
+        extra_hosts,
+    )
 }
 
 /// Resolve the push URL for a git repo.
@@ -156,6 +168,7 @@ impl Check for PushRemoteGuard {
         // Owner-based checks require configuration
         let allowed_owners = env_allow_entries("CADENCE_ALLOWED_OWNERS");
         let allowed_repos = env_allow_entries("CADENCE_ALLOWED_REPOS");
+        let extra_hosts = env_extra_hosts();
 
         if allowed_owners.is_empty() {
             return CheckResult::block(
@@ -176,7 +189,7 @@ impl Check for PushRemoteGuard {
             for cmd in cmds {
                 if let Some(remote) = &cmd.explicit_repo
                     && let Some(url) = resolve_push_url(&work_dir_loop, Some(remote))
-                    && !check_owner(&url, &allowed_owners, &allowed_repos)
+                    && !check_owner(&url, &allowed_owners, &allowed_repos, &extra_hosts)
                 {
                     return CheckResult::block(format!(
                         "🚫 git-guardrails: Push loop targets remote you don't own\n   \
@@ -212,17 +225,33 @@ impl Check for PushRemoteGuard {
             ));
         };
 
-        if !check_owner(&url, &allowed_owners, &allowed_repos) {
+        if !check_owner(&url, &allowed_owners, &allowed_repos, &extra_hosts) {
             let all_entries: Vec<String> = allowed_owners
                 .iter()
                 .chain(allowed_repos.iter())
                 .map(|e| e.to_string())
                 .collect();
+
+            // If the URL host isn't the default and isn't in extra_hosts, the
+            // user likely tripped over host-scoping. Suggest the qualified
+            // forms before the generic "fix tracking" advice.
+            let url_host = host_and_repo_from_url(&url).map(|(h, _)| h);
+            let default = config::default_host();
+            let host_hint = url_host
+                .as_deref()
+                .filter(|h| *h != default && !extra_hosts.iter().any(|e| e == h))
+                .map(|h| {
+                    format!(
+                        "\n   Host scope:    bare entries match `{default}` only — for `{h}`, qualify them (`{h}/<owner>`) or set `CADENCE_EXTRA_HOSTS={h}`"
+                    )
+                })
+                .unwrap_or_default();
+
             return CheckResult::block(format!(
                 "🚫 git-guardrails: Push target is not yours\n   \
                  Would push to: {url}\n   \
                  Directory:     {work_dir}\n   \
-                 Allowed:       {}\n\n   \
+                 Allowed:       {}{host_hint}\n\n   \
                  Fix tracking:  git branch -u origin/main\n   \
                  Push explicit: git push origin main",
                 all_entries.join(" ")
@@ -249,6 +278,7 @@ mod tests {
             "https://github.com/cameronsjo/repo.git",
             &owners(&["cameronsjo"]),
             &[],
+            &[],
         ));
     }
 
@@ -257,6 +287,7 @@ mod tests {
         assert!(!check_owner(
             "https://github.com/other/repo.git",
             &owners(&["cameronsjo"]),
+            &[],
             &[],
         ));
     }
@@ -267,6 +298,7 @@ mod tests {
             "https://github.com/cameronsjo/repo.git",
             &owners(&["other", "cameronsjo"]),
             &[],
+            &[],
         ));
     }
 
@@ -274,6 +306,7 @@ mod tests {
     fn owner_check_empty_list() {
         assert!(!check_owner(
             "https://github.com/cameronsjo/repo.git",
+            &[],
             &[],
             &[],
         ));
@@ -284,6 +317,7 @@ mod tests {
         assert!(check_owner(
             "https://github.com/CameronSjo/repo.git",
             &owners(&["cameronsjo"]),
+            &[],
             &[],
         ));
     }
@@ -296,6 +330,7 @@ mod tests {
             "https://gitea.internal/cameron/cadence.git",
             &owners(&["gitea.internal/cameron"]),
             &[],
+            &[],
         ));
     }
 
@@ -305,6 +340,7 @@ mod tests {
         assert!(!check_owner(
             "https://gitea.internal/cameron/cadence.git",
             &owners(&["cameron"]),
+            &[],
             &[],
         ));
     }
@@ -317,17 +353,29 @@ mod tests {
             "https://github.com/cameronsjo/repo.git",
             &o,
             &[],
+            &[],
         ));
         // gitea.internal/cameron → allowed
-        assert!(check_owner("git@gitea.internal:cameron/repo.git", &o, &[],));
+        assert!(check_owner(
+            "git@gitea.internal:cameron/repo.git",
+            &o,
+            &[],
+            &[]
+        ));
         // gitea.internal/cameronsjo → blocked
         assert!(!check_owner(
             "https://gitea.internal/cameronsjo/repo.git",
             &o,
             &[],
+            &[],
         ));
         // github.com/cameron → blocked
-        assert!(!check_owner("https://github.com/cameron/repo.git", &o, &[],));
+        assert!(!check_owner(
+            "https://github.com/cameron/repo.git",
+            &o,
+            &[],
+            &[]
+        ));
     }
 
     #[test]
@@ -337,6 +385,7 @@ mod tests {
             "https://github.com/external/shared-repo.git",
             &[],
             &repos,
+            &[],
         ));
     }
 
@@ -377,6 +426,7 @@ mod tests {
             "git@github.com:cameronsjo/repo.git",
             &owners(&["cameronsjo"]),
             &[],
+            &[],
         ));
     }
 
@@ -386,12 +436,55 @@ mod tests {
             "https://github.com/cameronsjo/repo",
             &owners(&["cameronsjo"]),
             &[],
+            &[],
         ));
     }
 
     #[test]
     fn owner_check_malformed_returns_false() {
-        assert!(!check_owner("not-a-url", &owners(&["cameronsjo"]), &[]));
+        assert!(!check_owner(
+            "not-a-url",
+            &owners(&["cameronsjo"]),
+            &[],
+            &[]
+        ));
+    }
+
+    // --- check_owner: extra_hosts (issue #15) ---
+
+    #[test]
+    fn owner_check_extra_hosts_unlocks_self_hosted_forge() {
+        // Repro for cadence-hooks#15: bare `cameron` matches a self-hosted
+        // Gitea host once it's listed in extra_hosts.
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(check_owner(
+            "https://git.sjo.lol/cameron/runelite-plugins.git",
+            &owners(&["cameron"]),
+            &[],
+            &extras,
+        ));
+    }
+
+    #[test]
+    fn owner_check_extra_hosts_does_not_unlock_unlisted_host() {
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(!check_owner(
+            "https://evil.example/cameron/repo.git",
+            &owners(&["cameron"]),
+            &[],
+            &extras,
+        ));
+    }
+
+    #[test]
+    fn owner_check_extra_hosts_preserves_default_host_match() {
+        let extras = vec!["git.sjo.lol".to_string()];
+        assert!(check_owner(
+            "https://github.com/cameron/repo.git",
+            &owners(&["cameron"]),
+            &[],
+            &extras,
+        ));
     }
 
     // --- PushRemoteGuard::run(): loop and multi-push scenarios ---


### PR DESCRIPTION
## Summary

Closes #15. Adds opt-in support for self-hosted forges (Gitea, Forgejo, GitLab CE, Bitbucket Server) without weakening the existing host-scoping safety property.

- New env var `CADENCE_EXTRA_HOSTS` extends bare allowlist entries (`cameron`) to additional hosts beyond the default
- Host-qualified entries (`git.sjo.lol/cameron`) are unaffected — they still match only their declared host
- New API: `is_allowed_with_extra_hosts` in `cadence-hooks-core`. Existing `is_allowed` keeps its 5-arg signature and delegates with empty extras (no caller churn)
- `guard-push-remote` reads `env_extra_hosts()` and threads it through `check_owner`
- `guard-gh-write` is unchanged — `gh` CLI is GitHub-only by definition
- Block message gains a host-scope hint when the URL host is unknown to both default and extras, surfacing the qualified-entry fix and the env-var fix inline

## Why this design

The original report (#15) suggested making owner-match host-agnostic. That would break `owner_check_host_mismatch_blocked` by design — bare `cameron` would auto-allow on any forge, including ones a user doesn't control. The opt-in env-var keeps the safe default while solving the actual UX gap: the user knows their gitea host, just had no way to tell the binary about it without fully qualifying every entry.

## Test coverage

- `extra_hosts_matches_bare_owner_on_self_hosted_forge` — direct repro of #15
- `extra_hosts_does_not_widen_qualified_entries` — ensures `github.com/cameron` doesn't leak into self-hosted matching
- `extra_hosts_preserves_default_host_match` — bare entries still match the default host when extras are populated
- `empty_extra_hosts_preserves_old_safety_property` — regression guard for `owner_check_host_mismatch_blocked` semantics
- `extra_hosts_does_not_match_unlisted_host` — extras are an allowlist, not a wildcard
- `extra_hosts_with_bare_repo_entry` — same widening applies to bare `owner/repo` entries
- Three parallel `owner_check_extra_hosts_*` tests at the `check_owner` layer
- All 945 workspace tests pass; `make ci` clean (fmt, clippy, test)

## Test plan

- [ ] `CADENCE_ALLOWED_OWNERS=cameron CADENCE_EXTRA_HOSTS=git.sjo.lol git push origin main` from a git.sjo.lol clone — push proceeds
- [ ] Same setup without `CADENCE_EXTRA_HOSTS` — push blocks, message includes the host-scope hint
- [ ] Existing github.com workflow with bare `cameronsjo` — unchanged
- [ ] `CADENCE_ALLOWED_OWNERS=github.com/cameron CADENCE_EXTRA_HOSTS=git.sjo.lol` — push to git.sjo.lol/cameron blocks (qualified entries don't widen)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * New environment option to scope allowlist entries to additional hosts, enabling allowlist matching across extra self-hosted forge hosts.
  * Push validation now provides contextual guidance when a push target is blocked, including host-scoping suggestions.

* **Documentation**
  * Added "Allowlist host scoping" section with examples clarifying bare vs host-qualified allowlist behavior and configuration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->