### PR TITLE
feat(guardrails): add dismiss-main-branch-warn snooze command

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,20 @@ All cadence-hooks config lives under the `CADENCE_*` prefix. `OBSIDIAN_VAULT` is
 
 Under Claude Code (detected via `CLAUDECODE=1`), the `configure` subcommand is hidden from `--help` and refuses to run interactively. `configure --list` remains available. Run `configure` from a real terminal to change hook state.
 
+### Snoozing warn-main-branch
+
+`warn-main-branch` fires once per session — but during quick wrap-up edits on a repo that's intentionally on `main`, even one nudge per session is noise. Silence it for a time-bound window per-repo:
+
+```bash
+# Default: 30 minutes
+cadence-hooks guardrails dismiss-main-branch-warn
+
+# Explicit duration: 2h, 1d, 45s, etc. Capped at 24h.
+cadence-hooks guardrails dismiss-main-branch-warn --for 2h
+```
+
+The snooze marker lives at `<repo>/.git/cadence-hooks/main-branch-snoozed-until`, so it's per-repo and ignored by default (`.git/` is never committed). The hook's own warn output also points at the command, so it's discoverable when the warning fires.
+
 ## Architecture
 
 ```

--- a/crates/guardrails/src/dismiss_main_branch_warn.rs
+++ b/crates/guardrails/src/dismiss_main_branch_warn.rs
@@ -1,0 +1,252 @@
+//! Per-repo snooze for the `warn-main-branch` hook.
+//!
+//! Exposes:
+//! - `is_snoozed_now(repo_root)` — used by `warn-main-branch` to skip its nudge
+//! - `run_dismiss(duration_str)` — the `dismiss-main-branch-warn` subcommand entry point
+//!
+//! The marker file lives at `<repo_root>/.git/cadence-hooks/main-branch-snoozed-until`
+//! and contains a single Unix epoch-seconds line. `.git/` is gitignored by
+//! default, so the marker never accidentally gets committed.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+const SNOOZE_DIR: &str = ".git/cadence-hooks";
+const SNOOZE_FILE: &str = "main-branch-snoozed-until";
+/// Cap to keep the safety guarantee meaningful — a stale snooze lingering for
+/// weeks would silently disable the warning long after the user forgot it
+/// existed. 24h forces the user to renew if they really want it.
+const MAX_SNOOZE_SECONDS: u64 = 24 * 60 * 60;
+
+/// Parse a duration string like `30m`, `2h`, `1d`, or `45s`.
+///
+/// Returns `None` for malformed input or non-positive values. Bare numbers
+/// (no unit) are rejected — the unit is required so users don't get bitten
+/// by ambiguity (`30` could plausibly be seconds or minutes).
+pub fn parse_duration(s: &str) -> Option<Duration> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    let (num_part, unit) = s.split_at(s.len() - 1);
+    let n: u64 = num_part.parse().ok()?;
+    if n == 0 {
+        return None;
+    }
+    let secs_per_unit: u64 = match unit {
+        "s" => 1,
+        "m" => 60,
+        "h" => 60 * 60,
+        "d" => 24 * 60 * 60,
+        _ => return None,
+    };
+    n.checked_mul(secs_per_unit).map(Duration::from_secs)
+}
+
+/// Marker file path for a given repo root.
+pub fn marker_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(SNOOZE_DIR).join(SNOOZE_FILE)
+}
+
+/// Pure: given the marker contents and current epoch, is the snooze active?
+fn is_snoozed_at(marker_contents: &str, now_epoch: u64) -> bool {
+    let parsed: Option<u64> = marker_contents.trim().parse().ok();
+    matches!(parsed, Some(until) if until > now_epoch)
+}
+
+/// Locate the current repo root via `git rev-parse --show-toplevel`.
+/// Returns None if not in a git repo or git is unavailable.
+fn repo_root() -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
+}
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Convenience: read the marker for the current repo and decide if it's still
+/// active. Used by `warn-main-branch` before evaluating its own logic.
+pub fn is_snoozed_now() -> bool {
+    let Some(root) = repo_root() else {
+        return false;
+    };
+    let path = marker_path(&root);
+    let Ok(contents) = fs::read_to_string(&path) else {
+        return false;
+    };
+    is_snoozed_at(&contents, now_epoch())
+}
+
+/// Entry point for the `dismiss-main-branch-warn` subcommand.
+///
+/// Writes `<repo_root>/.git/cadence-hooks/main-branch-snoozed-until` with the
+/// epoch seconds when the snooze expires, then prints a confirmation. Exits 1
+/// on failure (missing repo, invalid duration, write error). Stays at exit 0
+/// on success — this is a user-facing CLI, not a hook.
+pub fn run_dismiss(duration_str: &str) -> ! {
+    let duration = match parse_duration(duration_str) {
+        Some(d) => d,
+        None => {
+            eprintln!(
+                "cadence-hooks: invalid duration '{duration_str}'\n   \
+                 Expected: <number><s|m|h|d>, e.g. `30m`, `2h`, `1d`"
+            );
+            process::exit(1);
+        }
+    };
+
+    let secs = duration.as_secs();
+    if secs > MAX_SNOOZE_SECONDS {
+        eprintln!(
+            "cadence-hooks: snooze duration capped at 24h (got {duration_str})\n   \
+             Re-run with a smaller window, or run again later to renew."
+        );
+        process::exit(1);
+    }
+
+    let Some(root) = repo_root() else {
+        eprintln!(
+            "cadence-hooks: not inside a git repository\n   \
+             dismiss-main-branch-warn must be run from within the repo you want to silence."
+        );
+        process::exit(1);
+    };
+
+    let path = marker_path(&root);
+    if let Some(parent) = path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        eprintln!("cadence-hooks: could not create {}: {e}", parent.display());
+        process::exit(1);
+    }
+
+    let until = now_epoch().saturating_add(secs);
+    if let Err(e) = fs::write(&path, format!("{until}\n")) {
+        eprintln!("cadence-hooks: could not write {}: {e}", path.display());
+        process::exit(1);
+    }
+
+    println!(
+        "warn-main-branch silenced for {duration_str} in {} (until epoch {until})",
+        root.display()
+    );
+    process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- parse_duration ---
+
+    #[test]
+    fn parse_duration_minutes() {
+        assert_eq!(parse_duration("30m"), Some(Duration::from_secs(1800)));
+    }
+
+    #[test]
+    fn parse_duration_hours() {
+        assert_eq!(parse_duration("2h"), Some(Duration::from_secs(7200)));
+    }
+
+    #[test]
+    fn parse_duration_days() {
+        assert_eq!(parse_duration("1d"), Some(Duration::from_secs(86400)));
+    }
+
+    #[test]
+    fn parse_duration_seconds() {
+        assert_eq!(parse_duration("45s"), Some(Duration::from_secs(45)));
+    }
+
+    #[test]
+    fn parse_duration_rejects_bare_number() {
+        assert_eq!(parse_duration("30"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_unknown_unit() {
+        assert_eq!(parse_duration("30y"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_zero() {
+        // Zero would write a marker that's instantly expired — useless and
+        // confusing. Reject it so users get an error instead of silence.
+        assert_eq!(parse_duration("0m"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_empty() {
+        assert_eq!(parse_duration(""), None);
+        assert_eq!(parse_duration("   "), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_negative() {
+        // u64 parse rejects the leading `-`, so this is a no-op assertion that
+        // documents the contract: only positive values are accepted.
+        assert_eq!(parse_duration("-30m"), None);
+    }
+
+    #[test]
+    fn parse_duration_trims_whitespace() {
+        assert_eq!(parse_duration("  30m  "), Some(Duration::from_secs(1800)));
+    }
+
+    // --- is_snoozed_at (pure decision) ---
+
+    #[test]
+    fn snoozed_when_marker_in_future() {
+        assert!(is_snoozed_at("2000000000", 1_000_000_000));
+    }
+
+    #[test]
+    fn not_snoozed_when_marker_in_past() {
+        assert!(!is_snoozed_at("100", 1_000_000_000));
+    }
+
+    #[test]
+    fn not_snoozed_when_marker_equal_to_now() {
+        // Exactly-equal counts as expired — the snooze window is exclusive at
+        // its upper bound, otherwise a zero-duration snooze would briefly fire.
+        assert!(!is_snoozed_at("1000", 1000));
+    }
+
+    #[test]
+    fn not_snoozed_when_marker_unparseable() {
+        assert!(!is_snoozed_at("not-a-number", 1_000_000_000));
+        assert!(!is_snoozed_at("", 1_000_000_000));
+    }
+
+    #[test]
+    fn snoozed_tolerates_trailing_newline() {
+        assert!(is_snoozed_at("2000000000\n", 1_000_000_000));
+    }
+
+    // --- marker_path ---
+
+    #[test]
+    fn marker_path_is_under_dot_git() {
+        let p = marker_path(Path::new("/tmp/repo"));
+        assert_eq!(
+            p,
+            Path::new("/tmp/repo/.git/cadence-hooks/main-branch-snoozed-until")
+        );
+    }
+}

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -5,6 +5,8 @@
 
 /// Nudge after idle periods between edits to re-check context.
 pub mod check_idle_return;
+/// Per-repo snooze command + helper consumed by `warn_main_branch`.
+pub mod dismiss_main_branch_warn;
 /// Block irreversible `gh` operations (repo delete).
 pub mod guard_gh_dangerous;
 /// Block `gh` write operations targeting repos you don't own.

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -1,8 +1,12 @@
 //! Warn when editing on the main branch without a feature branch.
 //!
 //! Fires once per session (tracked via a temp-file marker) to nudge the
-//! user toward creating a feature branch before making changes.
+//! user toward creating a feature branch before making changes. Users who
+//! intentionally work on main can silence the warning per-repo with
+//! `cadence-hooks guardrails dismiss-main-branch-warn --for <duration>` —
+//! see [`crate::dismiss_main_branch_warn`].
 
+use crate::dismiss_main_branch_warn;
 use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
@@ -16,19 +20,21 @@ fn is_default_branch(branch: &str) -> bool {
 
 /// Pure decision: should we warn about editing on this branch?
 ///
-/// Returns `Warn` if on a default branch and not already warned this session.
-fn should_warn(branch: &str, already_warned: bool) -> CheckResult {
+/// Returns `Nudge` if on a default branch, not already warned this session,
+/// and not currently snoozed via `dismiss-main-branch-warn`.
+fn should_warn(branch: &str, already_warned: bool, snoozed: bool) -> CheckResult {
     if !is_default_branch(branch) {
         return CheckResult::allow();
     }
 
-    if already_warned {
+    if snoozed || already_warned {
         return CheckResult::allow();
     }
 
     CheckResult::nudge(format!(
         "You're editing files directly on '{branch}'. \
-         Ask the user: should this work be on a feature branch instead?"
+         Ask the user: should this work be on a feature branch instead?\n\
+         To silence for this repo: cadence-hooks guardrails dismiss-main-branch-warn --for 30m"
     ))
 }
 
@@ -79,8 +85,9 @@ impl Check for WarnMainBranch {
         };
 
         let already_warned = Self::marker_path().as_ref().is_some_and(|p| p.exists());
+        let snoozed = dismiss_main_branch_warn::is_snoozed_now();
 
-        let result = should_warn(&branch, already_warned);
+        let result = should_warn(&branch, already_warned, snoozed);
 
         // Create marker on warn to suppress future warnings this session
         if result.outcome == Outcome::Nudge
@@ -99,7 +106,7 @@ mod tests {
 
     #[test]
     fn main_branch_warns() {
-        let result = should_warn("main", false);
+        let result = should_warn("main", false, false);
         assert_eq!(result.outcome, Outcome::Nudge);
         assert!(
             result
@@ -112,7 +119,7 @@ mod tests {
 
     #[test]
     fn master_branch_warns() {
-        let result = should_warn("master", false);
+        let result = should_warn("master", false, false);
         assert_eq!(result.outcome, Outcome::Nudge);
         assert!(
             result
@@ -125,31 +132,31 @@ mod tests {
 
     #[test]
     fn feature_branch_allows() {
-        let result = should_warn("feat/new-feature", false);
+        let result = should_warn("feat/new-feature", false, false);
         assert_eq!(result.outcome, Outcome::Allow);
     }
 
     #[test]
     fn develop_branch_allows() {
-        let result = should_warn("develop", false);
+        let result = should_warn("develop", false, false);
         assert_eq!(result.outcome, Outcome::Allow);
     }
 
     #[test]
     fn already_warned_allows() {
-        let result = should_warn("main", true);
+        let result = should_warn("main", true, false);
         assert_eq!(result.outcome, Outcome::Allow);
     }
 
     #[test]
     fn already_warned_master_allows() {
-        let result = should_warn("master", true);
+        let result = should_warn("master", true, false);
         assert_eq!(result.outcome, Outcome::Allow);
     }
 
     #[test]
     fn empty_branch_allows() {
-        let result = should_warn("", false);
+        let result = should_warn("", false, false);
         assert_eq!(result.outcome, Outcome::Allow);
     }
 
@@ -178,13 +185,13 @@ mod tests {
 
     #[test]
     fn release_branch_allows() {
-        let result = should_warn("release/1.0", false);
+        let result = should_warn("release/1.0", false, false);
         assert_eq!(result.outcome, Outcome::Allow);
     }
 
     #[test]
     fn warn_message_contains_branch() {
-        let result = should_warn("master", false);
+        let result = should_warn("master", false, false);
         assert!(
             result
                 .message
@@ -215,7 +222,42 @@ mod tests {
     #[test]
     fn main_with_prefix_allows() {
         // "fix/main-page" is not the main branch
-        let result = should_warn("fix/main-page", false);
+        let result = should_warn("fix/main-page", false, false);
         assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- snooze (issue #16) ---
+
+    #[test]
+    fn snoozed_main_allows() {
+        // Active snooze suppresses the nudge even on a fresh session.
+        let result = should_warn("main", false, true);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn snoozed_master_allows() {
+        let result = should_warn("master", false, true);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn snoozed_takes_precedence_over_already_warned() {
+        // Both flags set is still allow — order doesn't matter.
+        let result = should_warn("main", true, true);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn warn_message_mentions_dismiss_command() {
+        let result = should_warn("main", false, false);
+        let msg = result
+            .message
+            .as_deref()
+            .expect("nudge should have a message");
+        assert!(
+            msg.contains("dismiss-main-branch-warn"),
+            "warn message should hint at the dismiss command: {msg}"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,12 @@ enum GuardrailsCommands {
     NudgeUpgradeAfterPush,
     /// Warn about untracked files during git commit operations
     WarnUntracked,
+    /// Snooze warn-main-branch for this repo for the given duration
+    DismissMainBranchWarn {
+        /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
+        #[arg(long = "for", default_value = "30m", value_name = "DURATION")]
+        for_: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -274,6 +280,11 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::WarnCronDatetime => "warn-cron-datetime",
             GuardrailsCommands::NudgeUpgradeAfterPush => "nudge-upgrade-after-push",
             GuardrailsCommands::WarnUntracked => "warn-untracked",
+            // dismiss-main-branch-warn is a CLI action, not a hook —
+            // it has no PreToolUse/PostToolUse wiring and isn't subject
+            // to CADENCE_DISABLE. Falling out of the Some(...) here is
+            // intentional; handle it specially below.
+            GuardrailsCommands::DismissMainBranchWarn { .. } => return None,
         }),
         Commands::Rules(r) => Some(match r {
             RulesCommands::ValidateFrontmatter => "validate-frontmatter",
@@ -520,6 +531,9 @@ fn main() {
                 &cadence_hooks_guardrails::warn_untracked::WarnUntrackedFiles,
                 pre,
             ),
+            GuardrailsCommands::DismissMainBranchWarn { for_ } => {
+                cadence_hooks_guardrails::dismiss_main_branch_warn::run_dismiss(&for_);
+            }
         },
         Commands::Rules(cmd) => match cmd {
             RulesCommands::ValidateFrontmatter => run_check_from_stdin(

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -91,6 +91,13 @@ const INTENTIONAL_UNFILTERED_BASH_HOOKS: &[&str] = &[
     "cadence warn-docs-update",      // catches gh pr create
 ];
 
+/// Binary subcommands that are user-facing CLI actions, not hooks. They have
+/// no PreToolUse/PostToolUse wiring and should not appear in any hooks.json.
+const NON_HOOK_BINARY_SUBCOMMANDS: &[&str] = &[
+    // Per-repo snooze writer for warn-main-branch — invoked by hand, not by Claude Code.
+    "guardrails dismiss-main-branch-warn",
+];
+
 /// Plugin name -> list of `<plugin> <subcommand>` strings referenced in its hooks.json.
 fn hooks_json_references() -> BTreeMap<String, Vec<HookRef>> {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -304,6 +311,7 @@ fn all_binary_subcommands_are_registered() {
             let group = cmd.split_whitespace().next().unwrap_or("");
             !shell_plugin_groups.contains(group)
         })
+        .filter(|cmd| !NON_HOOK_BINARY_SUBCOMMANDS.contains(&cmd.as_str()))
         .collect();
 
     assert!(


### PR DESCRIPTION
## Summary

Closes #16. Adds an opt-in, per-repo, time-bound snooze for the `warn-main-branch` hook so users intentionally working on `main` during quick wrap-up sessions aren't nudged on every Edit/Write.

```bash
# Default: 30 minutes
cadence-hooks guardrails dismiss-main-branch-warn

# Explicit duration
cadence-hooks guardrails dismiss-main-branch-warn --for 2h
```

## Design choices

The issue listed three options. This PR implements **Option B** (per-repo marker file with explicit dismiss command), with these specifics:

- **Marker location**: `<repo>/.git/cadence-hooks/main-branch-snoozed-until` — per-repo by construction, never committed (`.git/` is gitignored), survives session restarts.
- **Marker format**: a single Unix epoch-seconds line — trivial to inspect and zero parse ambiguity.
- **24h cap**: a forgotten snooze can't silently disable the warning indefinitely. Renew if you really want it.
- **Discoverability**: the warn message now points at the dismiss command, so users find it organically the first time the nudge fires. No need to RTFM.
- **Pure decision separation**: `should_warn(branch, already_warned, snoozed)` stays a pure function — IO (reading the marker) lives in the `Check::run` impl. Tests stay fast and don't need filesystem fixtures for the hot path.

## Why not the other options

- **Option A (env-var timestamp)**: env vars don't survive session restarts cleanly, and a numeric epoch is unergonomic to set by hand.
- **Option C (auto-backoff heuristic)**: relies on detecting "the user said stay on main" from prior assistant output. Brittle and invisible — you can't tell when it's snoozed or why.

## Test coverage

- **`dismiss_main_branch_warn` module** (16 tests): `parse_duration` accepts s/m/h/d, rejects bare numbers/zero/empty/unknown units; `is_snoozed_at` is a pure decision over `(marker_contents, now_epoch)` with edge cases around equal-to-now, trailing newlines, unparseable contents; `marker_path` produces the right path under `.git/`.
- **`warn_main_branch` module** (4 new tests): snoozed state suppresses the nudge on `main` and `master`, takes precedence over `already_warned`, and the warn message contains the dismiss command hint (regression-protected).
- **End-to-end smoke test**: ran the binary in a fresh `git init` repo with `--for 5m` — marker written correctly, confirmation message shows path and expiry epoch.
- **Hook audit**: added `NON_HOOK_BINARY_SUBCOMMANDS` exemption so the audit's "every subcommand must be in a hooks.json" rule doesn't fire on user-facing CLI actions.

`make ci` clean across all 245 guardrails tests and 962 workspace tests; no fmt/clippy issues.

## Test plan

- [ ] Edit on `main` without dismissing — warning fires once with the new dismiss hint visible
- [ ] Run `dismiss-main-branch-warn --for 30m` — confirmation message; subsequent edits on main don't warn
- [ ] After 30m elapses, edit on main — warning fires again
- [ ] `dismiss-main-branch-warn --for 25h` rejected with clear cap message
- [ ] `dismiss-main-branch-warn --for 0m` rejected as invalid
- [ ] `dismiss-main-branch-warn --for foo` rejected with format hint
- [ ] Run outside a git repo — clear error, exit 1
- [ ] Snoozing one repo doesn't affect another (marker is per-`.git/`)
