### PR TITLE
fix(ci): serialize beta releases to prevent tag collisions

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -7,6 +7,14 @@ on:
 permissions:
   contents: write
 
+# Serialize beta releases. When multiple commits land in quick succession,
+# we only want a beta for the latest main — earlier in-flight runs get
+# cancelled. Without this, parallel runs read the same tag state, all
+# compute the same NEXT_NUM, and all but one collide on `gh release create`.
+concurrency:
+  group: beta-release
+  cancel-in-progress: true
+
 env:
   CARGO_TERM_COLOR: always
 


### PR DESCRIPTION
## What

Adds a concurrency group to the Beta Release workflow so parallel runs serialize instead of racing.

```yaml
concurrency:
  group: beta-release
  cancel-in-progress: true
```

## Why

When multiple PRs merge in quick succession, parallel beta-release runs all read the same git-tag state, compute the same `NEXT_NUM`, and try to create the same tag. First wins; others fail with `a release with the same tag name already exists`.

Caught on 2026-04-26 — PRs #13, #17, #18 merged within 6 seconds.

| Run | Commit | PR | Result |
|-----|--------|----|--------|
| 24964851026 | d9c867c | #17 (extra-hosts) | created v0.8.0-beta.2 |
| 24964851868 | fdd7fa6 | #18 (snooze) | failed: tag exists |
| 24964852873 | 64c67fc | #13 (templates) | failed: tag exists |

Result: `v0.8.0-beta.2` contains the binary from PR #17 only, missing PR #18 and PR #13 work. Stale relative to main HEAD.

## Fix semantics

`cancel-in-progress: true` is the right choice for beta releases — when a new push arrives during a run, the in-progress one is cancelled and the new one starts. We only want a beta for the latest main, never a stale snapshot.

## After this merges

The merge itself triggers a fresh run on a now-up-to-date main. It reads tags, sees `v0.8.0-beta.2` already exists, increments to `v0.8.0-beta.3`, and produces a binary that includes all four PRs' work (#13, #17, #18, plus this fix).

## Test plan
- [x] Commit pushed to feature branch
- [ ] CI passes on the feature branch
- [ ] Merge triggers a beta-release run that produces v0.8.0-beta.3
- [ ] No collision on subsequent rapid pushes (will surface naturally next time multiple PRs merge close together)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved beta release workflow reliability by ensuring only one concurrent release process runs at a time, preventing version conflicts and ensuring smooth, sequential beta release deployments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->