### PR TITLE
chore: bump version to 0.9.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -193,7 +193,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -202,7 +202,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "brush-parser",
  "regex",
@@ -212,7 +212,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -228,7 +228,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.8.0"
+version = "0.9.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.8.0"
+version = "0.9.0"
 edition = "2024"
 license = "BSL-1.1"
 authors = ["Cameron Sjo"]


### PR DESCRIPTION
## What

Promotes v0.8.0-beta.3 content to stable v0.9.0.

## What's new since v0.8.0

- **`CADENCE_EXTRA_HOSTS`** for self-hosted forges (#17, closes #15) — Gitea/Forgejo owner-match no longer blocks pushes when bare entries should match across multiple hosts you own.
- **`dismiss-main-branch-warn`** snooze command (#18, closes #16) — per-repo time-bound silencing of the warn-main-branch hook. Default 30 min, max 24h, marker lives at `.git/cadence-hooks/main-branch-snoozed-until`.
- **Issue templates + reporting docs** (#13) — bug report and feature request forms, README guidance for where to file what.
- **Beta release concurrency fix** (#19) — workflow no longer collides when multiple PRs merge in quick succession.

## After this merges

`auto-tag.yml` triggers on `Cargo.toml` changes pushed to main. Sequence:
1. `auto-tag.yml` creates tag `v0.9.0`
2. `release.yml` (triggered by `v*` tag push) builds platform binaries, publishes GitHub release, dispatches Homebrew tap update
3. `cadence-hooks-beta.3` content is promoted to stable; `brew upgrade cadence-hooks` picks up v0.9.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.9.0 released.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->