### PR TITLE
fix(ci): add concurrency to auto-tag and release workflows

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -8,6 +8,13 @@ on:
 permissions:
   contents: write
 
+# Serialize runs. Each run produces a unique artifact (a distinct git tag,
+# release, or formula update) so cancel-in-progress is false — we want
+# both to land in order, not lose the second to a cancellation.
+concurrency:
+  group: auto-tag
+  cancel-in-progress: false
+
 jobs:
   tag:
     name: Tag version bump

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,13 @@ permissions:
 env:
   CARGO_TERM_COLOR: always
 
+# Serialize runs. Each tag is a unique artifact (different version,
+# different release, different homebrew dispatch) so cancel-in-progress
+# is false — we queue rather than drop work.
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: false
+
 jobs:
   build:
     name: Build ${{ matrix.name }}


### PR DESCRIPTION
## What

Defense-in-depth concurrency blocks for the two cadence-hooks workflows that still lacked them, after #19 (beta-release) and homebrew-tap#1 (update-formula) fixed the races we'd actually hit.

## Workflows touched

### auto-tag.yml

```yaml
concurrency:
  group: auto-tag
  cancel-in-progress: false
```

If two Cargo.toml-changing commits land in rapid succession (uncommon but possible with stacked merges), parallel runs would both try to push the same git tag. `cancel-in-progress: false` queues — each runs against fresh state, sees the previous tag, and either no-ops or creates the next one.

### release.yml

```yaml
concurrency:
  group: release-${{ github.ref_name }}
  cancel-in-progress: false
```

**Per-tag group** so independent tags release in parallel — that's the common case. Retries or duplicate triggers against the SAME tag serialize. Each release is a unique artifact (version, GitHub release, Homebrew dispatch) so we queue, not cancel.

## Pattern reference

The "queue vs cancel" decision matrix from the recent fixes:

| Workflow | `cancel-in-progress` | Why |
|---|---|---|
| beta-release.yml (#19) | `true` | Beta represents "latest main" — earlier runs are stale, cancellable |
| homebrew-tap update-formula (homebrew-tap#1) | `false` | Each formula update is a distinct artifact, must land |
| **auto-tag.yml (this PR)** | `false` | Each tag is unique, queueing lets both land |
| **release.yml (this PR)** | `false` | Per-tag group; same tag retries queue, different tags run in parallel |

## Test plan
- [ ] CI passes
- [ ] Future rapid Cargo.toml bumps don't lose tags
- [ ] Independent tag pushes still release in parallel (per-tag grouping)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved reliability of automated tagging and release workflows by implementing concurrency controls that ensure sequential execution rather than canceling overlapping runs, allowing all tag, release, and formula updates to complete in order.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->