### PR TITLE
feat(core): add skip_at_effort() to Check trait

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,6 +34,29 @@ Requires Rust 2024 edition (1.85+).
 4. Add a subcommand variant in `src/main.rs`
 5. Write tests covering: allow, warn, block, edge cases, and bypass scenarios
 
+### Optional: effort-gating
+
+The `Check` trait exposes a `skip_at_effort()` method that defaults to an
+empty slice. Override it to short-circuit the check at specific effort
+levels (`$CLAUDE_EFFORT` from Claude Code; defaults to `"medium"` when
+unset):
+
+```rust
+impl Check for ExpensivePostScan {
+    fn name(&self) -> &str { "expensive-post-scan" }
+    fn run(&self, input: &HookInput) -> CheckResult { /* ... */ }
+
+    fn skip_at_effort(&self) -> &[&str] {
+        &["low"]  // skip when CLAUDE_EFFORT=low
+    }
+}
+```
+
+Most cadence-hooks checks are security/correctness invariants and should
+keep the default (always run). Use this only when the check is genuinely
+optional at the listed levels — typically heavy PostToolUse scans or
+diagnostics that have no value on trivial sessions.
+
 ## Testing Conventions
 
 - Test names describe the scenario: `bash_cat_example_redirect_to_env_blocked`

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -175,11 +175,34 @@ pub trait Check {
 
     /// Run the check against the given input.
     fn run(&self, input: &HookInput) -> CheckResult;
+
+    /// Effort levels at which this check should short-circuit to Allow
+    /// without running. Reads `$CLAUDE_EFFORT` (set by Claude Code per
+    /// dispatch; defaults to `"medium"` when unset).
+    ///
+    /// Empty (default) means "always run". Most cadence-hooks checks are
+    /// security/correctness invariants and should run at every effort
+    /// level — opt in here only when the check is genuinely optional at
+    /// the listed levels.
+    fn skip_at_effort(&self) -> &[&str] {
+        &[]
+    }
+}
+
+/// Pure: should `run_check` short-circuit for the given effort level?
+///
+/// `current` is `$CLAUDE_EFFORT` from the hook payload; `None` is
+/// treated as `"medium"` (Claude Code's documented default).
+fn should_skip_for_effort(skip_levels: &[&str], current: Option<&str>) -> bool {
+    let effective = current.unwrap_or("medium");
+    skip_levels.contains(&effective)
 }
 
 /// Run a single check, emit output, and exit.
 ///
 /// Routing:
+/// - `skip_at_effort()` matches `$CLAUDE_EFFORT` → silent Allow (exit 0),
+///   `check.run()` is not called.
 /// - Nudge → JSON to stdout with `additionalContext` (exit 0).
 ///   Claude Code parses this and injects the message into Claude's context.
 ///   The JSON format differs by event type (PreToolUse vs PostToolUse).
@@ -187,6 +210,11 @@ pub trait Check {
 ///   Claude Code feeds stderr back to Claude as an error.
 /// - Allow → silent exit 0.
 pub fn run_check(check: &dyn Check, input: &HookInput, event: HookEvent) -> ! {
+    let current_effort = std::env::var("CLAUDE_EFFORT").ok();
+    if should_skip_for_effort(check.skip_at_effort(), current_effort.as_deref()) {
+        process::exit(Outcome::Allow.code());
+    }
+
     let result = check.run(input);
     if let Some(msg) = &result.message {
         match result.outcome {
@@ -462,5 +490,70 @@ mod tests {
     fn file_path_normalizes_backslash() {
         let input = make_input(None, Some(r"C:\Users\.env"), None, None, None, None);
         assert_eq!(input.file_path().as_deref(), Some("C:/Users/.env"));
+    }
+
+    // --- effort gating ---
+
+    #[test]
+    fn effort_skip_empty_list_runs_at_every_level() {
+        assert!(!should_skip_for_effort(&[], Some("low")));
+        assert!(!should_skip_for_effort(&[], Some("medium")));
+        assert!(!should_skip_for_effort(&[], Some("high")));
+        assert!(!should_skip_for_effort(&[], None));
+    }
+
+    #[test]
+    fn effort_skip_matches_current_level() {
+        assert!(should_skip_for_effort(&["low"], Some("low")));
+        assert!(should_skip_for_effort(&["low", "medium"], Some("medium")));
+        assert!(should_skip_for_effort(&["high", "xhigh"], Some("xhigh")));
+    }
+
+    #[test]
+    fn effort_skip_does_not_match_other_levels() {
+        assert!(!should_skip_for_effort(&["low"], Some("medium")));
+        assert!(!should_skip_for_effort(&["low"], Some("high")));
+        assert!(!should_skip_for_effort(&["high"], Some("low")));
+    }
+
+    #[test]
+    fn effort_skip_unset_treats_as_medium() {
+        // Claude Code's documented default is "medium" when the field is
+        // absent from the payload, so the env var being unset should be
+        // equivalent to medium.
+        assert!(should_skip_for_effort(&["medium"], None));
+        assert!(!should_skip_for_effort(&["low"], None));
+        assert!(!should_skip_for_effort(&["high"], None));
+    }
+
+    #[test]
+    fn check_trait_default_skip_at_effort_is_empty() {
+        struct Stub;
+        impl Check for Stub {
+            fn name(&self) -> &str {
+                "stub"
+            }
+            fn run(&self, _input: &HookInput) -> CheckResult {
+                CheckResult::allow()
+            }
+        }
+        assert!(Stub.skip_at_effort().is_empty());
+    }
+
+    #[test]
+    fn check_trait_skip_at_effort_overridable() {
+        struct LowSkip;
+        impl Check for LowSkip {
+            fn name(&self) -> &str {
+                "low-skip"
+            }
+            fn run(&self, _input: &HookInput) -> CheckResult {
+                CheckResult::allow()
+            }
+            fn skip_at_effort(&self) -> &[&str] {
+                &["low"]
+            }
+        }
+        assert_eq!(LowSkip.skip_at_effort(), &["low"]);
     }
 }


### PR DESCRIPTION
## Summary

Adds a `skip_at_effort()` default method to the `Check` trait so individual
checks can opt out at specific effort levels without each implementer reading
`CLAUDE_EFFORT` by hand.

`run_check` reads the env var once per dispatch (default `"medium"` when
unset, per Claude Code's documented behavior) and short-circuits to a silent
`Allow` if the level matches one in `skip_at_effort()`. The pure decision
lives in `should_skip_for_effort` so the table is unit-testable without
forking a process.

## Motivation

Most cadence-hooks checks are security/correctness invariants and stay at
the empty default. The mechanism exists for:

- Heavy `PostToolUse` diagnostics that have no value on trivial sessions.
- Satellite plugins that want a uniform opt-in surface instead of scattered
  env-var guards.
- The cross-cutting effort-gating tracker over in
  `cameronsjo/claude-configurations#22`.

## Test plan

- [x] Pure function (`should_skip_for_effort`): empty list, matching level,
      non-matching level, `None` resolves to `"medium"`.
- [x] Trait default returns `&[]` for a stub that doesn't override.
- [x] Trait override returns the declared slice.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test --workspace` — 1,030 passed.

## Docs

Brief usage section added to `CONTRIBUTING.md` under "Adding a New Hook".

Closes #23.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Checks can now be conditionally skipped based on the `CLAUDE_EFFORT` environment variable, which defaults to "medium" when unset.
  * Individual checks support effort-based execution control for optimized performance.

* **Documentation**
  * Updated contribution guidelines with information on configuring effort-based check skipping behavior.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cameronsjo/cadence-hooks/pull/30)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->