### PR TITLE
feat(doctor): scan plugin hooks.json for shell-expansion bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,10 +9,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - `CADENCE_ALLOW_MAIN` env var permanently silences `warn-main-branch` for a repo. Set in `<repo>/.claude/settings.json` (project) or `~/.claude/settings.json` (user-global) under the `env` block. Truthy values: `1`, `true`, `yes` (case-insensitive). Useful for repos where main IS the working branch by design — personal scratchpads, dotfiles, vaults.
+- `cadence-hooks doctor` subcommand scans installed plugin `hooks.json` files for shell-expansion bugs (initially: single-quoted `${CLAUDE_PLUGIN_ROOT}` and bare env vars). Reports one block per offender; exits 1 when violations exist. `--root <dir>` overrides the default `~/.claude/plugins/cache` scan path. (#24)
+- `Check::skip_at_effort()` trait method lets individual checks opt out at specific `$CLAUDE_EFFORT` levels without each implementer reading the env var by hand. Default `&[]` preserves current behavior — opt in for heavy diagnostics that are optional on trivial sessions. (#23)
 
 ### Changed
 
 - `warn-main-branch` message now suggests `--for 2h` (was `30m`) and surfaces both silencing options: time-bounded snooze and permanent `CADENCE_ALLOW_MAIN` env var.
+
+### Fixed
+
+- `warn-main-branch` now scopes branch detection to the edited file's repo via `git -C`, resolves relative file paths against `HookInput.cwd`, and passes the resolved `repo_root` to the snooze lookup. Previously the hook resolved git context from the hook process's CWD, so editing inside a nested repo from a session whose CWD was the outer parent both fired wrong warnings and broke per-repo snooze suppression. (#26)
+- `prevent-secret-leaks` env-dump heuristic now position-checks chain segments with a quote-aware splitter instead of substring-matching. Eliminates false positives on benign commands containing `env` as a substring — branch names ending in `-env`, commit messages mentioning env vars, `gh env list`, `aws-vault env`, `direnv env`, `grep env_dump`, and heredocs inside `"$(...)"` no longer fire the nudge. (#22, #25)
 
 ## [0.8.0] - 2026-04-21
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,20 @@ export CADENCE_ALLOWED_OWNERS="cameron git.sjo.lol/cameron"
 
 Under Claude Code (detected via `CLAUDECODE=1`), the `configure` subcommand is hidden from `--help` and refuses to run interactively. `configure --list` remains available. Run `configure` from a real terminal to change hook state.
 
+### Auditing installed plugins
+
+`doctor` scans every plugin's `hooks.json` for shell-expansion bugs — primarily the single-quoted `${CLAUDE_PLUGIN_ROOT}` class, which the harness reports as a non-blocking failure with no surface to the user. Suitable for CI or one-shot audits.
+
+```bash
+# Scan the default location: ~/.claude/plugins/cache
+cadence-hooks doctor
+
+# Audit a specific tree (handy in CI before publishing a plugin)
+cadence-hooks doctor --root ./plugins
+```
+
+Exits 0 when clean, 1 when violations are found. Each violation prints the plugin, file, offending snippet, and the recommended fix.
+
 ### Snoozing warn-main-branch
 
 `warn-main-branch` fires once per session — but during quick wrap-up edits on a repo that's intentionally on `main`, even one nudge per session is noise. Silence it for a time-bound window per-repo:

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -1,0 +1,232 @@
+//! Scan installed plugin `hooks.json` files for shell-expansion bugs.
+//!
+//! The single-quoted `${CLAUDE_PLUGIN_ROOT}` pattern survived in production
+//! for months because the failure mode is silent: hooks return non-zero,
+//! the harness logs "non-blocking", and nothing surfaces to the user.
+//! Only `claude --doctor` exposes it, and most users never run it.
+//!
+//! This subcommand walks `~/.claude/plugins/cache/*/hooks/hooks.json`,
+//! flags known shell-expansion patterns, and exits non-zero when violations
+//! are found so it's usable as a CI check or a one-shot diagnostic.
+
+use std::path::{Path, PathBuf};
+
+/// Default scan root: Claude Code's installed-plugin cache.
+fn default_root() -> Option<PathBuf> {
+    let home = std::env::var("HOME").ok()?;
+    Some(PathBuf::from(home).join(".claude/plugins/cache"))
+}
+
+/// One detected issue in a hook command.
+struct Finding {
+    plugin: String,
+    file: PathBuf,
+    snippet: String,
+    diagnosis: &'static str,
+    remediation: &'static str,
+}
+
+impl Finding {
+    fn print(&self) {
+        // <plugin>: <file>: <diagnosis>
+        //   command: <snippet>
+        //   fix: <remediation>
+        println!(
+            "{}: {}: {}\n  command: {}\n  fix: {}",
+            self.plugin,
+            self.file.display(),
+            self.diagnosis,
+            self.snippet,
+            self.remediation
+        );
+    }
+}
+
+/// Single-quoted env-var pattern: `'${SOMETHING}'` or `'$SOMETHING'` won't
+/// expand in `/bin/sh`. Returns the matched substring for diagnostics.
+fn detect_single_quoted_envvar(command: &str) -> Option<&str> {
+    // Walk the string and look for `'$` that opens a single-quoted region
+    // containing an env-var expansion. We don't try to be a real shell
+    // parser — just match the most common failure pattern.
+    let bytes = command.as_bytes();
+    let mut i = 0;
+    while i + 1 < bytes.len() {
+        if bytes[i] == b'\'' && bytes[i + 1] == b'$' {
+            // Find the closing single quote.
+            if let Some(close_offset) = command[i + 1..].find('\'') {
+                let end = i + 1 + close_offset + 1;
+                let span = &command[i..end];
+                // Only flag if the dollar sign is followed by a var-name char
+                // or an open brace (the actual expansion form). `$5 charge`
+                // and similar literals should not fire.
+                let after_dollar = bytes.get(i + 2).copied();
+                let is_expansion = match after_dollar {
+                    Some(b'{') | Some(b'_') => true,
+                    Some(c) => c.is_ascii_alphabetic(),
+                    None => false,
+                };
+                if is_expansion {
+                    return Some(span);
+                }
+            }
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Walk a `hooks.json` blob's hook commands and collect findings.
+fn scan_hooks_json(plugin: &str, path: &Path, json: &serde_json::Value) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    let Some(hooks_obj) = json.get("hooks").and_then(|v| v.as_object()) else {
+        return findings;
+    };
+
+    for matchers in hooks_obj.values() {
+        let Some(matchers) = matchers.as_array() else {
+            continue;
+        };
+        for matcher_block in matchers {
+            let Some(hooks) = matcher_block.get("hooks").and_then(|v| v.as_array()) else {
+                continue;
+            };
+            for hook in hooks {
+                let Some(cmd) = hook.get("command").and_then(|v| v.as_str()) else {
+                    continue;
+                };
+                if let Some(span) = detect_single_quoted_envvar(cmd) {
+                    findings.push(Finding {
+                        plugin: plugin.to_string(),
+                        file: path.to_path_buf(),
+                        snippet: span.to_string(),
+                        diagnosis: "single-quoted env var won't expand in /bin/sh",
+                        remediation: "switch the single quotes around the expansion to double quotes",
+                    });
+                }
+            }
+        }
+    }
+
+    findings
+}
+
+/// Discover plugin dirs under `root` and scan each one's `hooks/hooks.json`.
+fn scan_root(root: &Path) -> Vec<Finding> {
+    let mut findings = Vec::new();
+
+    let Ok(entries) = std::fs::read_dir(root) else {
+        return findings;
+    };
+
+    for entry in entries.flatten() {
+        let plugin_dir = entry.path();
+        if !plugin_dir.is_dir() {
+            continue;
+        }
+        let plugin_name = plugin_dir
+            .file_name()
+            .and_then(|n| n.to_str())
+            .unwrap_or("<unknown>")
+            .to_string();
+        let hooks_path = plugin_dir.join("hooks/hooks.json");
+        if !hooks_path.exists() {
+            continue;
+        }
+        let Ok(content) = std::fs::read_to_string(&hooks_path) else {
+            continue;
+        };
+        let Ok(json) = serde_json::from_str::<serde_json::Value>(&content) else {
+            // Invalid JSON is its own bug, but not the one this check exists
+            // to catch. The plugin loader will surface it.
+            continue;
+        };
+        findings.extend(scan_hooks_json(&plugin_name, &hooks_path, &json));
+    }
+
+    findings
+}
+
+/// Entry point for the `doctor` subcommand. Returns the process exit code
+/// (0 clean, 1 violations found).
+///
+/// `root_override` lets tests redirect the scan; in normal use it's `None`
+/// and we fall back to `$HOME/.claude/plugins/cache`.
+pub fn run(root_override: Option<&Path>) -> u8 {
+    let root = match root_override {
+        Some(p) => p.to_path_buf(),
+        None => match default_root() {
+            Some(p) => p,
+            None => {
+                eprintln!("cadence-hooks doctor: $HOME not set; cannot locate plugin cache");
+                return 1;
+            }
+        },
+    };
+
+    if !root.exists() {
+        eprintln!(
+            "cadence-hooks doctor: scan root does not exist: {}",
+            root.display()
+        );
+        return 0;
+    }
+
+    let findings = scan_root(&root);
+
+    if findings.is_empty() {
+        println!("cadence-hooks doctor: clean ({} scanned)", root.display());
+        return 0;
+    }
+
+    println!(
+        "cadence-hooks doctor: {} finding(s) under {}:\n",
+        findings.len(),
+        root.display()
+    );
+    for finding in &findings {
+        finding.print();
+        println!();
+    }
+    1
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn detects_single_quoted_braced_envvar() {
+        let cmd = r#"'${CLAUDE_PLUGIN_ROOT}/hooks/run.sh' arg"#;
+        let span = detect_single_quoted_envvar(cmd).expect("should detect");
+        // The span covers the whole single-quoted region, not just the var.
+        assert!(span.starts_with("'${CLAUDE_PLUGIN_ROOT}"), "span: {span}");
+        assert!(span.ends_with('\''), "span: {span}");
+    }
+
+    #[test]
+    fn detects_single_quoted_bare_envvar() {
+        let cmd = r#"'$CLAUDE_PLUGIN_ROOT' arg"#;
+        let span = detect_single_quoted_envvar(cmd).expect("should detect");
+        assert!(span.contains("CLAUDE_PLUGIN_ROOT"), "span: {span}");
+    }
+
+    #[test]
+    fn does_not_flag_double_quoted_envvar() {
+        let cmd = r#""${CLAUDE_PLUGIN_ROOT}/hooks/run.sh" arg"#;
+        assert_eq!(detect_single_quoted_envvar(cmd), None);
+    }
+
+    #[test]
+    fn does_not_flag_unquoted_envvar() {
+        let cmd = "${CLAUDE_PLUGIN_ROOT}/hooks/run.sh arg";
+        assert_eq!(detect_single_quoted_envvar(cmd), None);
+    }
+
+    #[test]
+    fn does_not_flag_literal_dollar_in_single_quotes() {
+        // No var name after the dollar — likely a literal price or label.
+        let cmd = "echo '$5 charge'";
+        assert_eq!(detect_single_quoted_envvar(cmd), None);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ fn under_claude_code() -> bool {
 }
 
 mod configure;
+mod doctor;
 
 #[derive(Parser)]
 #[command(name = "cadence-hooks", version, about = "Compiled Claude Code hooks")]
@@ -51,6 +52,13 @@ enum Commands {
         /// Print current configuration without interactive mode
         #[arg(long)]
         list: bool,
+    },
+
+    /// Scan installed plugin hooks.json files for shell-expansion bugs
+    Doctor {
+        /// Scan a specific directory instead of ~/.claude/plugins/cache
+        #[arg(long, value_name = "DIR")]
+        root: Option<std::path::PathBuf>,
     },
 }
 
@@ -293,7 +301,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
         Commands::Obsidian(o) => Some(match o {
             ObsidianCommands::TrashGuard => "trash-guard",
         }),
-        Commands::List | Commands::Configure { .. } => None,
+        Commands::List | Commands::Configure { .. } | Commands::Doctor { .. } => None,
     }
 }
 
@@ -453,6 +461,9 @@ fn main() {
                 process::exit(1);
             }
             configure::run(list, HOOKS);
+        }
+        Commands::Doctor { root } => {
+            process::exit(doctor::run(root.as_deref()).into());
         }
         Commands::Cadence(cmd) => match cmd {
             CadenceCommands::Terminology => {

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -1,0 +1,170 @@
+//! Integration tests for `cadence-hooks doctor`.
+//!
+//! Build a fixture plugin cache in a tempdir, point doctor at it via
+//! `--root`, and assert exit code + stderr/stdout content.
+
+use std::process::Command;
+
+fn cadence_hooks() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cadence-hooks"))
+}
+
+/// Create `<root>/<plugin>/hooks/hooks.json` with the given JSON body.
+fn write_plugin(root: &std::path::Path, plugin: &str, hooks_json: &str) {
+    let dir = root.join(plugin).join("hooks");
+    std::fs::create_dir_all(&dir).unwrap();
+    std::fs::write(dir.join("hooks.json"), hooks_json).unwrap();
+}
+
+#[test]
+fn doctor_clean_cache_exits_zero() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_plugin(
+        tmp.path(),
+        "clean-plugin",
+        r#"{
+            "hooks": {
+                "PreToolUse": [{
+                    "hooks": [{ "command": "\"${CLAUDE_PLUGIN_ROOT}/hooks/run.sh\" arg" }]
+                }]
+            }
+        }"#,
+    );
+
+    let output = cadence_hooks()
+        .args(["doctor", "--root"])
+        .arg(tmp.path())
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("clean"),
+        "expected clean output, got: {stdout}"
+    );
+}
+
+#[test]
+fn doctor_detects_single_quoted_plugin_root() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_plugin(
+        tmp.path(),
+        "buggy-plugin",
+        r#"{
+            "hooks": {
+                "PreToolUse": [{
+                    "hooks": [{ "command": "'${CLAUDE_PLUGIN_ROOT}/hooks/run.sh' arg" }]
+                }]
+            }
+        }"#,
+    );
+
+    let output = cadence_hooks()
+        .args(["doctor", "--root"])
+        .arg(tmp.path())
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "should exit 1 when violations found. stdout: {}",
+        String::from_utf8_lossy(&output.stdout)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("buggy-plugin"),
+        "should name the plugin: {stdout}"
+    );
+    assert!(
+        stdout.contains("CLAUDE_PLUGIN_ROOT"),
+        "should quote the offending snippet: {stdout}"
+    );
+    assert!(
+        stdout.contains("single-quoted env var"),
+        "should explain the diagnosis: {stdout}"
+    );
+}
+
+#[test]
+fn doctor_handles_empty_root_directory() {
+    // No plugin subdirs at all — exit 0 with the clean message.
+    let tmp = tempfile::tempdir().unwrap();
+
+    let output = cadence_hooks()
+        .args(["doctor", "--root"])
+        .arg(tmp.path())
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn doctor_skips_plugins_without_hooks_json() {
+    // Plugin dir exists but has no hooks/hooks.json — doctor just ignores it.
+    let tmp = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(tmp.path().join("plugin-without-hooks")).unwrap();
+
+    let output = cadence_hooks()
+        .args(["doctor", "--root"])
+        .arg(tmp.path())
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn doctor_skips_invalid_json() {
+    // Garbage JSON shouldn't crash doctor — the plugin loader is the right
+    // place to surface JSON syntax errors.
+    let tmp = tempfile::tempdir().unwrap();
+    write_plugin(tmp.path(), "broken-plugin", "{ not valid json");
+
+    let output = cadence_hooks()
+        .args(["doctor", "--root"])
+        .arg(tmp.path())
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(output.status.code(), Some(0));
+}
+
+#[test]
+fn doctor_finds_violation_across_multiple_plugins() {
+    let tmp = tempfile::tempdir().unwrap();
+    write_plugin(
+        tmp.path(),
+        "clean-plugin",
+        r#"{ "hooks": { "PreToolUse": [{ "hooks": [{ "command": "\"${X}\"" }]}] }}"#,
+    );
+    write_plugin(
+        tmp.path(),
+        "buggy-plugin-a",
+        r#"{ "hooks": { "PreToolUse": [{ "hooks": [{ "command": "'${A}'" }]}] }}"#,
+    );
+    write_plugin(
+        tmp.path(),
+        "buggy-plugin-b",
+        r#"{ "hooks": { "PostToolUse": [{ "hooks": [{ "command": "'$B'" }]}] }}"#,
+    );
+
+    let output = cadence_hooks()
+        .args(["doctor", "--root"])
+        .arg(tmp.path())
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(output.status.code(), Some(1));
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(stdout.contains("buggy-plugin-a"));
+    assert!(stdout.contains("buggy-plugin-b"));
+    assert!(stdout.contains("2 finding"));
+}


### PR DESCRIPTION
## Summary

New `cadence-hooks doctor` subcommand walks `~/.claude/plugins/cache/*/hooks/hooks.json` and prints one block per command that contains a known shell-expansion bug. Designed to turn the silent failure mode of the single-quoted `${CLAUDE_PLUGIN_ROOT}` class (claude-configurations#23, #24) into a loud, one-shot diagnostic that's usable as a CI check.

```
$ cadence-hooks doctor
buggy-plugin: /Users/cameron/.claude/plugins/cache/buggy-plugin/hooks/hooks.json: single-quoted env var won't expand in /bin/sh
  command: '${CLAUDE_PLUGIN_ROOT}/hooks/run.sh'
  fix: switch the single quotes around the expansion to double quotes
```

Exits 0 when clean, 1 when findings exist.

## Detection

Initial pattern set:

- `'${VAR}'` — single-quoted braced env var
- `'$VAR'` — single-quoted bare env var

`$5 charge` and similar literals inside single quotes are explicitly skipped — the dollar sign is only flagged when followed by a var-name character or an open brace (the actual expansion form).

## Scope

Subcommand only. Auto-run at SessionStart is a deliberate follow-up — it needs hook plumbing and the subcommand-only diagnostic should ship first so users can wire it into CI or run it ad-hoc.

## Test plan

- [x] Unit tests for `detect_single_quoted_envvar` (braced, bare, double-quoted negative, unquoted negative, literal-dollar negative).
- [x] Integration tests with fixture plugin caches in `tempfile::tempdir()`: clean cache, single buggy plugin, multiple buggy plugins, empty root, plugin without `hooks/hooks.json`, garbage JSON.
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean.
- [x] `cargo test --workspace` — all passed.
- [x] Manual smoke against live `~/.claude/plugins/cache` — reports clean.

Closes #24.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `cadence-hooks doctor` subcommand to scan installed plugins for shell-expansion issues; supports `--root` override for alternate plugin cache directories.
  * Added `CADENCE_ALLOW_MAIN` environment variable to silence branch warnings.

* **Bug Fixes**
  * Improved `warn-main-branch` detection accuracy and updated messaging.
  * Reduced false positives in `prevent-secret-leaks` detection.

* **Documentation**
  * Updated README and CHANGELOG with new features and fixes.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cameronsjo/cadence-hooks/pull/31)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->