### PR TITLE
fix(pre-commit): re-stage only originally-staged Rust files

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -9,7 +9,10 @@ set -euo pipefail
 # Capture the Rust files already staged for this commit, *before* fmt runs.
 # Once cargo fmt rewrites the tree we can no longer tell "was staged" apart
 # from "fmt just touched it", so the snapshot has to happen up front.
-staged_rs="$(git diff --cached --name-only -- '*.rs')"
+# --diff-filter=ACMR keeps only files that still exist (Added/Copied/Modified/
+# Renamed) and drops staged deletions — fmt can't reformat a deleted file, and
+# `git add` on a removed path would error under `set -e`.
+staged_rs="$(git diff --cached --name-only --diff-filter=ACMR -- '*.rs')"
 
 # No staged Rust → nothing to format or re-stage.
 if [[ -z "${staged_rs}" ]]; then

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,16 +1,24 @@
 #!/usr/bin/env bash
-# Pre-commit hook: auto-format with cargo fmt
-# If formatting changes are needed, applies them and amends the staged files.
+# Pre-commit hook: auto-format staged Rust with cargo fmt.
+#
+# Re-stages only the Rust files that were already staged for this commit, so
+# fmt churn in unstaged files — mid-feature WIP, or a deliberate partial
+# `git add -p` — never sneaks into the commit.
 set -euo pipefail
 
-# Only run if Rust files are staged
-if ! git diff --cached --name-only | grep -qE '\.rs$'; then
+# Capture the Rust files already staged for this commit, *before* fmt runs.
+# Once cargo fmt rewrites the tree we can no longer tell "was staged" apart
+# from "fmt just touched it", so the snapshot has to happen up front.
+staged_rs="$(git diff --cached --name-only -- '*.rs')"
+
+# No staged Rust → nothing to format or re-stage.
+if [[ -z "${staged_rs}" ]]; then
   exit 0
 fi
 
-# Run cargo fmt and stage any changes.
-# `grep` returns 1 when there are no fmt-induced changes; with `pipefail` that
-# would abort the hook even though nothing went wrong. Tolerate the empty
-# pipeline so a clean commit isn't blocked.
 cargo fmt --all --quiet
-git diff --name-only | { grep -E '\.rs$' || true; } | xargs -r git add
+
+# Re-stage only the originally-staged Rust files, picking up any fmt edits.
+while IFS= read -r file; do
+  [[ -n "${file}" ]] && git add -- "${file}"
+done <<< "${staged_rs}"


### PR DESCRIPTION
## What

The `.githooks/pre-commit` hook re-added Rust files using `git diff --name-only` (the working-tree view) after `cargo fmt --all`. That swept in any `.rs` file differing from the index — including changes deliberately left unstaged via `git add -p` or mid-feature WIP — widening the commit beyond what was intended.

Surfaced by CodeRabbit on PR #28.

## How

Snapshot the staged Rust set with `git diff --cached --name-only -- '*.rs'` **before** fmt runs, then re-add only that set. Capturing first is required: once fmt rewrites the tree, "was staged" and "fmt just touched it" are indistinguishable. The snapshot also doubles as the early-exit guard, so the staged-files query runs once instead of twice.

## Tests

Verified with a throwaway-repo behavioral test (stubbed `cargo` mutating both a staged and an unstaged `.rs`):

- **New hook:** only the originally-staged file lands in the commit; the unstaged WIP edit stays dirty; the fmt edit to the staged file is preserved.
- **Old hook (control):** `unstaged.rs` leaks into the commit — bug reproduced, confirming the test is meaningful.

shellcheck clean, `bash -n` clean.

Closes #29


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the pre-commit formatting hook to more accurately detect and format only staged Rust files, avoiding unintended changes.
  * Ensures no work is done if no Rust files are staged and reliably re-stages only those files after formatting, resulting in a more consistent and predictable commit workflow.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cameronsjo/cadence-hooks/pull/37?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->