### PR TITLE
docs: note security-patterns is a zero-config baseline

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,10 @@ Hooks are organized by the plugin they serve:
 | `validate-frontmatter` | PreToolUse (Write, Edit) | Validate SKILL.md and command frontmatter |
 | `security-patterns` | PreToolUse (Write, Edit) | Scan for security anti-patterns |
 
+`security-patterns` is a **zero-config, no-API baseline** — a per-edit pattern scan with no
+setup. For configurable patterns plus model-backed diff and commit review, install the
+official `security-guidance` plugin (`/plugin install security-guidance@claude-plugins-official`).
+
 ### obsidian (cadence-obsidian)
 
 | Hook | Event | What it does |


### PR DESCRIPTION
Adds a one-line note under the rules hooks table clarifying that security-patterns is a zero-config, no-API baseline, and pointing to the official security-guidance plugin for configurable patterns plus model-backed diff/commit review. Companion to the cadence-rules in-session-security-review PR. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README documentation to clarify the `security-patterns` hook's capabilities as a zero-config baseline pattern scanning tool, with guidance for users seeking more advanced configurable security analysis features.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cameronsjo/cadence-hooks/pull/40?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->