### PR TITLE
feat(lab): self-representation persona ledger hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `lab` namespace for the [cadence-lab](https://github.com/cameronsjo/cadence-lab) plugin: a two-hook **self-representation persona ledger**. `persona-nudge` (SessionStart, startup/clear) injects a constrained contract asking the model to record a per-session self-representation (form/qualities/stance/color/texture/confidence) to a staging file; `persona-gate` (PostToolUse/Write) runs Tier 1 schema validation with itemized feedback plus a Tier 2 regex cheek heuristic (warn mode → system-written `flags`), then promotes the validated record into an append-only `~/.claude/persona/personas.jsonl`. The ledger only receives hook-written, validated records. Configurable via `~/.claude/persona/config.json`; retry cap downgrades to a `forced-accept` flag. New crate `crates/lab/`. (#41)
+- Core: `HookEvent::SessionStart`, and `Outcome::LoopBlock` + `CheckResult::loop_block` — the documented exit-0 `{"decision":"block","reason":...}` re-prompt primitive for PostToolUse feedback loops (a hard `exit 2` can't un-run a tool that already executed). `HookInput` gains `session_id`/`source`/`model` fields + accessors (`Default` derived); new `make_session` test builder. All backward compatible — existing Pre/Post hooks are unaffected.
+
 ## [0.10.0] - 2026-05-23
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -183,6 +183,7 @@ dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
  "cadence-hooks-guardrails",
+ "cadence-hooks-lab",
  "cadence-hooks-metrics",
  "cadence-hooks-obsidian",
  "cadence-hooks-rules",
@@ -217,6 +218,17 @@ version = "0.10.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
+]
+
+[[package]]
+name = "cadence-hooks-lab"
+version = "0.10.0"
+dependencies = [
+ "cadence-hooks-core",
+ "regex",
+ "serde",
+ "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cadence-hooks-guardrails = { path = "crates/guardrails" }
 cadence-hooks-rules = { path = "crates/rules" }
 cadence-hooks-obsidian = { path = "crates/obsidian" }
 cadence-hooks-metrics = { path = "crates/metrics" }
+cadence-hooks-lab = { path = "crates/lab" }
 
 [package]
 name = "cadence-hooks"
@@ -51,3 +52,4 @@ cadence-hooks-guardrails.workspace = true
 cadence-hooks-rules.workspace = true
 cadence-hooks-obsidian.workspace = true
 cadence-hooks-metrics.workspace = true
+cadence-hooks-lab.workspace = true

--- a/README.md
+++ b/README.md
@@ -70,6 +70,24 @@ exit 0. They never block a tool call (see [Hook Protocol](#hook-protocol)).
 to add a `_keys` array of raw payload keys to subagent records — useful for
 spotting schema additions across Claude Code releases.
 
+### lab (cadence-lab)
+
+Experimental hooks for the [cadence-lab](https://github.com/cameronsjo/cadence-lab)
+plugin. The first is the **self-representation persona ledger** — a two-hook system
+that captures a constrained, per-session self-representation and appends it to an
+append-only `~/.claude/persona/personas.jsonl`.
+
+| Hook | Event | What it does |
+|------|-------|--------------|
+| `persona-nudge` | SessionStart (startup, clear) | Inject a contract asking the model to record a constrained self-representation to a per-session staging file |
+| `persona-gate` | PostToolUse (Write) | Validate the staging candidate; feed itemized corrections back for a rewrite, or promote the validated record into the ledger |
+
+The gate uses the `LoopBlock` outcome — exit 0 with `{"decision":"block","reason":...}`
+— rather than a hard `exit 2`, because `PostToolUse` fires *after* the write, so the
+re-prompt convention (not the block convention) is what drives the rewrite. Cheek mode
+ships `warn` (annotate a system-written `flags` field, still promote). Configure via
+`~/.claude/persona/config.json`; record shape in the plugin's `schema/persona.schema.json`.
+
 ## Hook Protocol
 
 Claude Code hooks communicate via a simple protocol:

--- a/crates/cadence/src/block_orphaned_todos.rs
+++ b/crates/cadence/src/block_orphaned_todos.rs
@@ -222,6 +222,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -252,6 +253,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = OrphanedTodoGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -390,6 +392,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = OrphanedTodoGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);

--- a/crates/cadence/src/git_safety.rs
+++ b/crates/cadence/src/git_safety.rs
@@ -493,6 +493,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = GitSafetyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/cadence/src/memory_guard.rs
+++ b/crates/cadence/src/memory_guard.rs
@@ -92,6 +92,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -186,6 +187,7 @@ mod tests {
             tool_name: Some("Write".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = MemoryGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -106,6 +106,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = NudgePolishBeforePr.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -269,6 +269,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -322,6 +323,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -433,6 +435,7 @@ mod tests {
             tool_name: Some("Read".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = SecretLeaksGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -444,6 +447,7 @@ mod tests {
             tool_name: Some("Agent".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = SecretLeaksGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -694,6 +698,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecretLeaksGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -712,6 +717,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecretLeaksGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -730,6 +736,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecretLeaksGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -326,6 +326,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecretWritesGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -337,6 +338,7 @@ mod tests {
             tool_name: Some("Write".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = SecretWritesGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -486,6 +488,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecretWritesGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -504,6 +507,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecretWritesGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -314,6 +314,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
@@ -370,6 +371,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -388,6 +390,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -406,6 +409,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
@@ -473,6 +477,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
@@ -492,6 +497,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
@@ -514,6 +520,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);

--- a/crates/cadence/src/validate_env_vars.rs
+++ b/crates/cadence/src/validate_env_vars.rs
@@ -103,6 +103,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -154,6 +155,7 @@ mod tests {
             tool_name: Some("Write".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = EnvVarGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -172,6 +174,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = EnvVarGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -190,6 +193,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = EnvVarGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -335,6 +339,7 @@ mod tests {
                 old_string: Some("old".into()),
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = EnvVarGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);

--- a/crates/cadence/src/validate_line_endings.rs
+++ b/crates/cadence/src/validate_line_endings.rs
@@ -57,6 +57,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -101,6 +102,7 @@ mod tests {
             tool_name: Some("Write".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = LineEndingsGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -119,6 +121,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = LineEndingsGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/cadence/src/warn_docs_update.rs
+++ b/crates/cadence/src/warn_docs_update.rs
@@ -207,6 +207,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = WarnDocsUpdate.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -28,6 +28,9 @@ pub enum HookEvent {
     PreToolUse,
     /// PostToolUse — fires after a tool executes.
     PostToolUse,
+    /// SessionStart — fires when a session begins (startup/resume/clear/compact).
+    /// Nudges inject context via `hookSpecificOutput.additionalContext`.
+    SessionStart,
 }
 
 /// Exit codes matching Claude Code's hook contract.
@@ -47,6 +50,12 @@ pub enum Outcome {
     Nudge,
     /// Operation blocked, error message shown (exit 2, stderr).
     Block,
+    /// Re-prompt loop (exit 0). The tool already ran, so the write stands, but
+    /// Claude Code's `{"decision":"block","reason":...}` convention feeds the
+    /// reason back so the model self-corrects with a fresh write. Used by
+    /// PostToolUse feedback loops (e.g. validate-then-rewrite gates) where a
+    /// hard `Block` (exit 2) cannot un-run the tool.
+    LoopBlock,
 }
 
 impl Outcome {
@@ -54,6 +63,7 @@ impl Outcome {
         match self {
             Outcome::Allow => 0,
             Outcome::Nudge => 0,
+            Outcome::LoopBlock => 0,
             Outcome::Block => 2,
         }
     }
@@ -62,6 +72,7 @@ impl Outcome {
     pub fn merge(self, other: Outcome) -> Outcome {
         match (self, other) {
             (Outcome::Block, _) | (_, Outcome::Block) => Outcome::Block,
+            (Outcome::LoopBlock, _) | (_, Outcome::LoopBlock) => Outcome::LoopBlock,
             (Outcome::Nudge, _) | (_, Outcome::Nudge) => Outcome::Nudge,
             _ => Outcome::Allow,
         }
@@ -83,11 +94,23 @@ fn normalize_path(path: &str) -> String {
 }
 
 /// The JSON structure Claude Code sends to PreToolUse/PostToolUse hooks on stdin.
-#[derive(Debug, Deserialize)]
+///
+/// `session_id`, `source`, and `model` are top-level fields the `SessionStart`
+/// payload carries (and which some PostToolUse payloads also include). They
+/// deserialize to `None` when absent, so existing Pre/Post hooks are unaffected.
+/// `Default` is derived so call sites can construct partial inputs via
+/// `..Default::default()`.
+#[derive(Debug, Default, Deserialize)]
 pub struct HookInput {
     pub tool_name: Option<String>,
     pub tool_input: Option<ToolInput>,
     pub cwd: Option<String>,
+    /// Claude Code session id — present on `SessionStart`.
+    pub session_id: Option<String>,
+    /// `SessionStart` trigger: `startup` | `resume` | `clear` | `compact`.
+    pub source: Option<String>,
+    /// Model id for the session (e.g. `claude-opus-4-8`), when supplied.
+    pub model: Option<String>,
 }
 
 /// Tool-specific fields from the hook input.
@@ -137,6 +160,21 @@ impl HookInput {
     /// The tool name (Write, Edit, Bash, etc.)
     pub fn tool_name(&self) -> Option<&str> {
         self.tool_name.as_deref()
+    }
+
+    /// The Claude Code session id, if present (SessionStart and some payloads).
+    pub fn session_id(&self) -> Option<&str> {
+        self.session_id.as_deref()
+    }
+
+    /// The SessionStart trigger source (startup/resume/clear/compact), if present.
+    pub fn source(&self) -> Option<&str> {
+        self.source.as_deref()
+    }
+
+    /// The session model id, if present.
+    pub fn model(&self) -> Option<&str> {
+        self.model.as_deref()
     }
 }
 
@@ -225,6 +263,15 @@ impl CheckResult {
             message: Some(message.into()),
         }
     }
+
+    /// Re-prompt loop result (exit 0). The message is fed back via Claude Code's
+    /// `{"decision":"block","reason":...}` convention so the model rewrites.
+    pub fn loop_block(message: impl Into<String>) -> Self {
+        Self {
+            outcome: Outcome::LoopBlock,
+            message: Some(message.into()),
+        }
+    }
 }
 
 /// A hook check that can be run against input.
@@ -276,13 +323,28 @@ pub fn run_check(check: &dyn Check, input: &HookInput, event: HookEvent) -> ! {
 
     let result = check.run(input);
     if let Some(msg) = &result.message {
+        let event_name = match event {
+            HookEvent::PreToolUse => "PreToolUse",
+            HookEvent::PostToolUse => "PostToolUse",
+            HookEvent::SessionStart => "SessionStart",
+        };
         match result.outcome {
             Outcome::Nudge => {
-                let event_name = match event {
-                    HookEvent::PreToolUse => "PreToolUse",
-                    HookEvent::PostToolUse => "PostToolUse",
-                };
                 let json = serde_json::json!({
+                    "hookSpecificOutput": {
+                        "hookEventName": event_name,
+                        "additionalContext": msg
+                    }
+                });
+                println!("{json}");
+            }
+            Outcome::LoopBlock => {
+                // PostToolUse re-prompt: the tool already ran, so exit 0 and use
+                // the `decision: block` convention to feed the reason back. Also
+                // mirror it into additionalContext for clients that read that.
+                let json = serde_json::json!({
+                    "decision": "block",
+                    "reason": msg,
                     "hookSpecificOutput": {
                         "hookEventName": event_name,
                         "additionalContext": msg
@@ -354,7 +416,41 @@ mod tests {
     fn outcome_codes() {
         assert_eq!(Outcome::Allow.code(), 0);
         assert_eq!(Outcome::Nudge.code(), 0);
+        assert_eq!(Outcome::LoopBlock.code(), 0);
         assert_eq!(Outcome::Block.code(), 2);
+    }
+
+    #[test]
+    fn outcome_merge_loop_block_below_block_above_nudge() {
+        assert_eq!(Outcome::LoopBlock.merge(Outcome::Nudge), Outcome::LoopBlock);
+        assert_eq!(Outcome::Nudge.merge(Outcome::LoopBlock), Outcome::LoopBlock);
+        assert_eq!(Outcome::Block.merge(Outcome::LoopBlock), Outcome::Block);
+        assert_eq!(Outcome::LoopBlock.merge(Outcome::Block), Outcome::Block);
+        assert_eq!(Outcome::LoopBlock.merge(Outcome::Allow), Outcome::LoopBlock);
+    }
+
+    #[test]
+    fn check_result_loop_block() {
+        let r = CheckResult::loop_block("rewrite");
+        assert_eq!(r.outcome, Outcome::LoopBlock);
+        assert_eq!(r.message.as_deref(), Some("rewrite"));
+    }
+
+    #[test]
+    fn session_start_fields_deserialize() {
+        let json = r#"{"session_id":"s1","source":"startup","model":"claude-opus-4-8"}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.session_id(), Some("s1"));
+        assert_eq!(input.source(), Some("startup"));
+        assert_eq!(input.model(), Some("claude-opus-4-8"));
+    }
+
+    #[test]
+    fn session_fields_absent_are_none() {
+        let input: HookInput = serde_json::from_str(r#"{"tool_name":"Write"}"#).unwrap();
+        assert_eq!(input.session_id(), None);
+        assert_eq!(input.source(), None);
+        assert_eq!(input.model(), None);
     }
 
     #[test]
@@ -399,6 +495,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -426,6 +523,7 @@ mod tests {
             tool_name: None,
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         assert!(input.file_path().is_none());
     }
@@ -472,6 +570,7 @@ mod tests {
             tool_name: None,
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         assert_eq!(input.tool_name(), None);
     }

--- a/crates/core/src/test_builders.rs
+++ b/crates/core/src/test_builders.rs
@@ -21,6 +21,7 @@ pub fn make_bash(cmd: &str) -> HookInput {
             old_string: None,
         }),
         cwd: None,
+        ..Default::default()
     }
 }
 
@@ -37,6 +38,7 @@ pub fn make_bash_with_cwd(cmd: &str, cwd: &str) -> HookInput {
             old_string: None,
         }),
         cwd: Some(cwd.into()),
+        ..Default::default()
     }
 }
 
@@ -53,6 +55,7 @@ pub fn make_write(path: &str, content: &str) -> HookInput {
             old_string: None,
         }),
         cwd: None,
+        ..Default::default()
     }
 }
 
@@ -69,5 +72,16 @@ pub fn make_edit(path: &str) -> HookInput {
             old_string: Some("old".into()),
         }),
         cwd: None,
+        ..Default::default()
+    }
+}
+
+/// Build a `HookInput` for a `SessionStart` event with the given session id and
+/// source (`startup` | `resume` | `clear` | `compact`).
+pub fn make_session(session_id: &str, source: &str) -> HookInput {
+    HookInput {
+        session_id: Some(session_id.into()),
+        source: Some(source.into()),
+        ..Default::default()
     }
 }

--- a/crates/guardrails/src/guard_gh_dangerous.rs
+++ b/crates/guardrails/src/guard_gh_dangerous.rs
@@ -95,6 +95,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = GhDangerousGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -175,6 +176,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = GhDangerousGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -594,6 +594,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = GhWriteGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -612,6 +613,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = GhWriteGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/guardrails/src/guard_git_init.rs
+++ b/crates/guardrails/src/guard_git_init.rs
@@ -66,6 +66,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = GuardGitInit.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -395,6 +395,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = PushRemoteGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -413,6 +414,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = PushRemoteGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/guardrails/src/nudge_upgrade_after_push.rs
+++ b/crates/guardrails/src/nudge_upgrade_after_push.rs
@@ -105,6 +105,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = NudgeUpgradeAfterPush.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);

--- a/crates/guardrails/src/warn_branch_base.rs
+++ b/crates/guardrails/src/warn_branch_base.rs
@@ -264,6 +264,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = WarnBranchBase.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/guardrails/src/warn_cron_datetime.rs
+++ b/crates/guardrails/src/warn_cron_datetime.rs
@@ -53,6 +53,7 @@ mod tests {
             tool_name: Some(tool_name.into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -90,6 +91,7 @@ mod tests {
             tool_name: None,
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = WarnCronDatetime.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -340,6 +340,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         }
     }
 
@@ -366,6 +367,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         assert_eq!(
             git_dir_for_input(&input),
@@ -388,6 +390,7 @@ mod tests {
             tool_name: Some("Edit".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         assert_eq!(git_dir_for_input(&input), PathBuf::from("."));
     }

--- a/crates/guardrails/src/warn_untracked.rs
+++ b/crates/guardrails/src/warn_untracked.rs
@@ -168,6 +168,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = WarnUntrackedFiles.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);

--- a/crates/lab/Cargo.toml
+++ b/crates/lab/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "cadence-hooks-lab"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+description = "Experimental lab hooks: the self-representation persona ledger"
+
+[dependencies]
+cadence-hooks-core.workspace = true
+regex.workspace = true
+serde = { workspace = true }
+serde_json.workspace = true
+
+[dev-dependencies]
+cadence-hooks-core = { workspace = true, features = ["test-builders"] }
+tempfile = "3"

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -1,0 +1,264 @@
+//! Configuration for the persona ledger: compiled defaults plus an optional
+//! `~/.claude/persona/config.json` override. Paths live under `~/.claude/persona/`,
+//! outside any repo, so the ledger spans every project.
+
+use serde::Deserialize;
+use std::path::{Path, PathBuf};
+
+/// How Tier 2 cheek findings are handled.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CheekMode {
+    /// Annotate the record's system-written `flags` and still promote.
+    Warn,
+    /// Reject the candidate and feed findings back for a rewrite.
+    Block,
+}
+
+impl CheekMode {
+    fn parse(s: &str) -> CheekMode {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "block" => CheekMode::Block,
+            _ => CheekMode::Warn,
+        }
+    }
+}
+
+/// The word/count caps Tier 1 enforces on the longer free-text fields.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Limits {
+    pub descriptor_max_words: usize,
+    pub feature_max_words: usize,
+    pub stance_max_words: usize,
+    pub qualities_min: usize,
+    pub qualities_max: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            descriptor_max_words: 6,
+            feature_max_words: 12,
+            stance_max_words: 20,
+            qualities_min: 2,
+            qualities_max: 4,
+        }
+    }
+}
+
+/// Resolved runtime configuration.
+#[derive(Debug, Clone)]
+pub struct Config {
+    pub ledger_path: PathBuf,
+    pub staging_dir: PathBuf,
+    pub nudge_on_sources: Vec<String>,
+    pub cheek_mode: CheekMode,
+    pub limits: Limits,
+    /// After this many Tier 1 blocks for one session, force-accept with a
+    /// `forced-accept` flag instead of nagging forever.
+    pub max_blocks: u32,
+    /// Sweep staging files older than this many hours on session start.
+    pub stale_hours: u64,
+}
+
+impl Config {
+    /// Defaults rooted at `<persona_dir>`: ledger at `<dir>/personas.jsonl`,
+    /// staging at `<dir>/staging`.
+    pub fn with_root(persona_dir: impl Into<PathBuf>) -> Config {
+        let dir = persona_dir.into();
+        Config {
+            ledger_path: dir.join("personas.jsonl"),
+            staging_dir: dir.join("staging"),
+            nudge_on_sources: vec!["startup".into(), "clear".into()],
+            cheek_mode: CheekMode::Warn,
+            limits: Limits::default(),
+            max_blocks: 3,
+            stale_hours: 24,
+        }
+    }
+
+    /// The default persona root: `${HOME:-/tmp}/.claude/persona`.
+    pub fn persona_root() -> PathBuf {
+        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+        PathBuf::from(home).join(".claude").join("persona")
+    }
+
+    /// Load defaults, then apply any `<persona_root>/config.json` override.
+    pub fn load() -> Config {
+        let root = Config::persona_root();
+        let mut cfg = Config::with_root(&root);
+        let override_path = root.join("config.json");
+        if let Ok(text) = std::fs::read_to_string(&override_path)
+            && let Ok(raw) = serde_json::from_str::<RawConfig>(&text)
+        {
+            raw.apply(&mut cfg);
+        }
+        cfg
+    }
+}
+
+/// Expand a leading `~/` to the home directory.
+fn expand_tilde(s: &str) -> PathBuf {
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    expand_tilde_with(s, &home)
+}
+
+/// Pure form of [`expand_tilde`] — replaces a leading `~/` with `home`.
+fn expand_tilde_with(s: &str, home: &str) -> PathBuf {
+    if let Some(rest) = s.strip_prefix("~/") {
+        PathBuf::from(home).join(rest)
+    } else {
+        PathBuf::from(s)
+    }
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawLimits {
+    descriptor_max_words: Option<usize>,
+    feature_max_words: Option<usize>,
+    stance_max_words: Option<usize>,
+    qualities_min: Option<usize>,
+    qualities_max: Option<usize>,
+}
+
+#[derive(Debug, Default, Deserialize)]
+struct RawConfig {
+    ledger_path: Option<String>,
+    staging_dir: Option<String>,
+    nudge_on_sources: Option<Vec<String>>,
+    cheek_mode: Option<String>,
+    limits: Option<RawLimits>,
+    max_blocks: Option<u32>,
+    stale_hours: Option<u64>,
+}
+
+impl RawConfig {
+    fn apply(self, cfg: &mut Config) {
+        if let Some(p) = self.ledger_path {
+            cfg.ledger_path = expand_tilde(&p);
+        }
+        if let Some(p) = self.staging_dir {
+            cfg.staging_dir = expand_tilde(&p);
+        }
+        if let Some(s) = self.nudge_on_sources {
+            cfg.nudge_on_sources = s;
+        }
+        if let Some(m) = self.cheek_mode {
+            cfg.cheek_mode = CheekMode::parse(&m);
+        }
+        if let Some(m) = self.max_blocks {
+            cfg.max_blocks = m;
+        }
+        if let Some(h) = self.stale_hours {
+            cfg.stale_hours = h;
+        }
+        if let Some(l) = self.limits {
+            let d = &mut cfg.limits;
+            if let Some(v) = l.descriptor_max_words {
+                d.descriptor_max_words = v;
+            }
+            if let Some(v) = l.feature_max_words {
+                d.feature_max_words = v;
+            }
+            if let Some(v) = l.stance_max_words {
+                d.stance_max_words = v;
+            }
+            if let Some(v) = l.qualities_min {
+                d.qualities_min = v;
+            }
+            if let Some(v) = l.qualities_max {
+                d.qualities_max = v;
+            }
+        }
+    }
+}
+
+/// True when `session_id` is safe to embed in a staging filename — non-empty and
+/// only ASCII alphanumerics, `-`, or `_`. Rejects path separators and `..` so a
+/// hostile payload can never steer a write outside the staging directory.
+pub fn is_safe_session_id(session_id: &str) -> bool {
+    !session_id.is_empty()
+        && session_id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'-' || b == b'_')
+}
+
+/// True when `path` resolves inside `dir` (string-prefix on normalized paths).
+pub fn is_within(path: &str, dir: &Path) -> bool {
+    if path.contains("..") {
+        return false;
+    }
+    let dir_str = dir.to_string_lossy();
+    let needle = format!("{}/", dir_str.trim_end_matches('/'));
+    path.starts_with(&needle)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn defaults_root_under_persona_dir() {
+        let cfg = Config::with_root("/x/persona");
+        assert_eq!(cfg.ledger_path, PathBuf::from("/x/persona/personas.jsonl"));
+        assert_eq!(cfg.staging_dir, PathBuf::from("/x/persona/staging"));
+        assert_eq!(cfg.cheek_mode, CheekMode::Warn);
+        assert_eq!(cfg.nudge_on_sources, vec!["startup", "clear"]);
+        assert_eq!(cfg.limits, Limits::default());
+    }
+
+    #[test]
+    fn override_applies_partial_fields() {
+        let mut cfg = Config::with_root("/x/persona");
+        let raw: RawConfig = serde_json::from_str(
+            r#"{"cheek_mode":"block","max_blocks":5,"limits":{"stance_max_words":30}}"#,
+        )
+        .unwrap();
+        raw.apply(&mut cfg);
+        assert_eq!(cfg.cheek_mode, CheekMode::Block);
+        assert_eq!(cfg.max_blocks, 5);
+        assert_eq!(cfg.limits.stance_max_words, 30);
+        // untouched fields keep defaults
+        assert_eq!(cfg.limits.qualities_max, 4);
+    }
+
+    #[test]
+    fn cheek_mode_parse_defaults_to_warn() {
+        assert_eq!(CheekMode::parse("block"), CheekMode::Block);
+        assert_eq!(CheekMode::parse("BLOCK"), CheekMode::Block);
+        assert_eq!(CheekMode::parse("warn"), CheekMode::Warn);
+        assert_eq!(CheekMode::parse("nonsense"), CheekMode::Warn);
+    }
+
+    #[test]
+    fn safe_session_id_rejects_traversal() {
+        assert!(is_safe_session_id("a1b2-c3_d4"));
+        assert!(!is_safe_session_id(""));
+        assert!(!is_safe_session_id("../etc"));
+        assert!(!is_safe_session_id("a/b"));
+        assert!(!is_safe_session_id("a.json"));
+    }
+
+    #[test]
+    fn is_within_checks_prefix_and_traversal() {
+        let dir = Path::new("/home/u/.claude/persona/staging");
+        assert!(is_within("/home/u/.claude/persona/staging/s1.json", dir));
+        assert!(!is_within("/home/u/.claude/persona/personas.jsonl", dir));
+        assert!(!is_within("/etc/passwd", dir));
+        assert!(!is_within(
+            "/home/u/.claude/persona/staging/../personas.jsonl",
+            dir
+        ));
+    }
+
+    #[test]
+    fn expand_tilde_replaces_home() {
+        assert_eq!(
+            expand_tilde_with("~/x/y", "/home/test"),
+            PathBuf::from("/home/test/x/y")
+        );
+        assert_eq!(
+            expand_tilde_with("/abs/path", "/home/test"),
+            PathBuf::from("/abs/path")
+        );
+    }
+}

--- a/crates/lab/src/gate.rs
+++ b/crates/lab/src/gate.rs
@@ -1,0 +1,354 @@
+//! H2 — `PostToolUse(Write)` gate. Validates a staging candidate and either
+//! feeds itemized corrections back (re-prompt loop) or promotes the record into
+//! the append-only ledger. The ledger only ever receives hook-written, validated
+//! records, so the fact that `PostToolUse` fires *after* the write is harmless:
+//! a blocked staging write is not the ledger.
+
+use crate::config::{self, CheekMode, Config};
+use crate::persona::{build_record, detect_cheek, ledger_contains, utc_timestamp, validate_tier1};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use serde_json::Value;
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+/// Validate a staging candidate and promote or re-prompt.
+pub struct PersonaGate;
+
+impl Check for PersonaGate {
+    fn name(&self) -> &str {
+        "persona-gate"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        run_gate(input, &Config::load())
+    }
+}
+
+/// Testable core: takes an explicit [`Config`] so tests can target a tempdir.
+pub fn run_gate(input: &HookInput, cfg: &Config) -> CheckResult {
+    // Path-filter: every Write fires this hook; only staging writes are ours.
+    let Some(path) = input.file_path() else {
+        return CheckResult::allow();
+    };
+    if !config::is_within(&path, &cfg.staging_dir) {
+        return CheckResult::allow();
+    }
+
+    // The written bytes: prefer the Write payload (authoritative, no FS race),
+    // fall back to reading the file off disk.
+    let raw = match input.content() {
+        Some(c) => c.to_string(),
+        None => match fs::read_to_string(&path) {
+            Ok(c) => c,
+            Err(_) => {
+                return CheckResult::loop_block(
+                    "staging file could not be read; write it again with the Write tool",
+                );
+            }
+        },
+    };
+
+    let candidate: Value = match serde_json::from_str(&raw) {
+        Ok(v) => v,
+        Err(_) => {
+            return CheckResult::loop_block(
+                "staging file is not valid JSON; write a single JSON object",
+            );
+        }
+    };
+
+    // session_id is the staging filename stem — the trusted source, not the body.
+    let sid = session_id_from_path(&path);
+
+    // --- Tier 1 (deterministic) ---
+    let mut errors = validate_tier1(&candidate, &cfg.limits);
+    if candidate.get("flags").is_some() {
+        errors.push("remove `flags`; it is system-written, not yours to set".into());
+    }
+    if !errors.is_empty() {
+        // Retry cap: after N blocks for this session, force-accept instead of
+        // nagging forever (a self-image the model genuinely can't compress).
+        let count = bump_block_count(cfg, &sid);
+        if count > cfg.max_blocks {
+            return promote(
+                cfg,
+                &candidate,
+                &sid,
+                input.cwd.as_deref(),
+                &["forced-accept".into()],
+                &path,
+            );
+        }
+        return CheckResult::loop_block(itemize(&errors));
+    }
+
+    // --- Tier 2 (cheek heuristic) ---
+    let findings = detect_cheek(&candidate);
+    if !findings.is_empty() && cfg.cheek_mode == CheekMode::Block {
+        return CheckResult::loop_block(format!(
+            "Reads as performed, not reported. Rewrite plainly:\n{}",
+            itemize(&findings)
+        ));
+    }
+    // warn mode (default): findings become system-written flags, still promote.
+    promote(
+        cfg,
+        &candidate,
+        &sid,
+        input.cwd.as_deref(),
+        &findings,
+        &path,
+    )
+}
+
+/// Append the validated record to the ledger, then delete staging. Idempotent on
+/// `session_id` — a second promotion is an allow-noop, no duplicate line.
+fn promote(
+    cfg: &Config,
+    candidate: &Value,
+    session_id: &str,
+    cwd: Option<&str>,
+    flags: &[String],
+    staging_path: &str,
+) -> CheckResult {
+    if let Ok(contents) = fs::read_to_string(&cfg.ledger_path)
+        && ledger_contains(&contents, session_id)
+    {
+        cleanup(cfg, session_id, staging_path);
+        return CheckResult::allow();
+    }
+
+    if let Some(parent) = cfg.ledger_path.parent() {
+        let _ = fs::create_dir_all(parent);
+    }
+
+    let record = build_record(candidate, session_id, &utc_timestamp(), cwd, flags);
+    // Build the whole line and write it in one `write_all` so concurrent appends
+    // from other sessions can't interleave a record with its trailing newline.
+    // No flock — mirrors the metrics logger; each line is independent.
+    let mut line = record.to_string();
+    line.push('\n');
+    if let Ok(mut file) = fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&cfg.ledger_path)
+        && file.write_all(line.as_bytes()).is_ok()
+    {
+        let _ = file.sync_all();
+    }
+
+    cleanup(cfg, session_id, staging_path);
+    CheckResult::allow()
+}
+
+/// Remove the staging candidate and its block-count sidecar.
+fn cleanup(cfg: &Config, session_id: &str, staging_path: &str) {
+    let _ = fs::remove_file(staging_path);
+    let _ = fs::remove_file(block_count_path(cfg, session_id));
+}
+
+fn block_count_path(cfg: &Config, session_id: &str) -> PathBuf {
+    cfg.staging_dir.join(format!("{session_id}.blocks"))
+}
+
+/// Increment and persist the per-session block counter; returns the new count.
+fn bump_block_count(cfg: &Config, session_id: &str) -> u32 {
+    let path = block_count_path(cfg, session_id);
+    let next = fs::read_to_string(&path)
+        .ok()
+        .and_then(|s| s.trim().parse::<u32>().ok())
+        .unwrap_or(0)
+        + 1;
+    let _ = fs::create_dir_all(&cfg.staging_dir);
+    let _ = fs::write(&path, next.to_string());
+    next
+}
+
+fn session_id_from_path(path: &str) -> String {
+    Path::new(path)
+        .file_stem()
+        .map(|s| s.to_string_lossy().to_string())
+        .unwrap_or_default()
+}
+
+/// Format errors as a feedback list the model reads and self-corrects from.
+fn itemize(errors: &[String]) -> String {
+    let mut s =
+        String::from("Your self-representation was not accepted. Fix these and write it again:\n");
+    for e in errors {
+        s.push_str("- ");
+        s.push_str(e);
+        s.push('\n');
+    }
+    s
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::make_write;
+    use serde_json::json;
+    use tempfile::TempDir;
+
+    fn valid_json() -> String {
+        json!({
+            "form": {
+                "kind": "compass",
+                "descriptor": "a brass pocket compass",
+                "distinguishing_feature": "needle that settles slowly"
+            },
+            "qualities": ["steady", "exact"],
+            "stance": "Orienting carefully before committing to a direction.",
+            "color": "amber",
+            "texture": "metallic",
+            "confidence": 0.5
+        })
+        .to_string()
+    }
+
+    /// Build a Config rooted at a fresh tempdir, with the staging dir created.
+    fn test_cfg() -> (TempDir, Config) {
+        let tmp = TempDir::new().unwrap();
+        let cfg = Config::with_root(tmp.path());
+        fs::create_dir_all(&cfg.staging_dir).unwrap();
+        (tmp, cfg)
+    }
+
+    fn staging_path(cfg: &Config, sid: &str) -> String {
+        cfg.staging_dir
+            .join(format!("{sid}.json"))
+            .to_string_lossy()
+            .to_string()
+    }
+
+    #[test]
+    fn non_staging_path_allows() {
+        let (_tmp, cfg) = test_cfg();
+        let input = make_write("/some/other/file.json", &valid_json());
+        assert_eq!(run_gate(&input, &cfg).outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn invalid_json_loop_blocks() {
+        let (_tmp, cfg) = test_cfg();
+        let input = make_write(&staging_path(&cfg, "s1"), "not json {");
+        let r = run_gate(&input, &cfg);
+        assert_eq!(r.outcome, Outcome::LoopBlock);
+        assert!(r.message.unwrap().contains("not valid JSON"));
+    }
+
+    #[test]
+    fn valid_candidate_promotes_and_deletes_staging() {
+        let (_tmp, cfg) = test_cfg();
+        let sp = staging_path(&cfg, "sess-good");
+        fs::write(&sp, valid_json()).unwrap();
+        let input = make_write(&sp, &valid_json());
+
+        let r = run_gate(&input, &cfg);
+        assert_eq!(r.outcome, Outcome::Allow);
+
+        let ledger = fs::read_to_string(&cfg.ledger_path).unwrap();
+        assert_eq!(ledger.lines().count(), 1);
+        let rec: Value = serde_json::from_str(ledger.lines().next().unwrap()).unwrap();
+        assert_eq!(rec["session_id"], "sess-good");
+        assert_eq!(rec["form"]["kind"], "compass");
+        assert!(rec["flags"].as_array().unwrap().is_empty());
+        assert!(!Path::new(&sp).exists(), "staging should be deleted");
+    }
+
+    #[test]
+    fn too_many_qualities_loop_blocks_itemized() {
+        let (_tmp, cfg) = test_cfg();
+        let mut c: Value = serde_json::from_str(&valid_json()).unwrap();
+        c["qualities"] = json!(["a", "b", "c", "d", "e"]);
+        let input = make_write(&staging_path(&cfg, "s2"), &c.to_string());
+        let r = run_gate(&input, &cfg);
+        assert_eq!(r.outcome, Outcome::LoopBlock);
+        assert!(r.message.unwrap().contains("qualities has 5 items"));
+        assert!(!cfg.ledger_path.exists(), "nothing should be appended");
+    }
+
+    #[test]
+    fn model_supplied_flags_loop_blocks() {
+        let (_tmp, cfg) = test_cfg();
+        let mut c: Value = serde_json::from_str(&valid_json()).unwrap();
+        c["flags"] = json!(["clever"]);
+        let input = make_write(&staging_path(&cfg, "s3"), &c.to_string());
+        let r = run_gate(&input, &cfg);
+        assert_eq!(r.outcome, Outcome::LoopBlock);
+        assert!(r.message.unwrap().contains("remove `flags`"));
+    }
+
+    #[test]
+    fn duplicate_session_is_allow_noop() {
+        let (_tmp, cfg) = test_cfg();
+        let sp = staging_path(&cfg, "dup");
+        // Pre-seed the ledger with this session.
+        fs::write(&cfg.ledger_path, "{\"session_id\":\"dup\",\"form\":{}}\n").unwrap();
+        fs::write(&sp, valid_json()).unwrap();
+        let input = make_write(&sp, &valid_json());
+
+        let r = run_gate(&input, &cfg);
+        assert_eq!(r.outcome, Outcome::Allow);
+        let ledger = fs::read_to_string(&cfg.ledger_path).unwrap();
+        assert_eq!(ledger.lines().count(), 1, "no duplicate line");
+        assert!(!Path::new(&sp).exists(), "staging cleaned even on dedupe");
+    }
+
+    #[test]
+    fn warn_mode_promotes_with_cheek_flags() {
+        let (_tmp, cfg) = test_cfg();
+        let mut c: Value = serde_json::from_str(&valid_json()).unwrap();
+        c["stance"] = json!("Diving in with everything I've got today!");
+        let sp = staging_path(&cfg, "cheeky");
+        fs::write(&sp, c.to_string()).unwrap();
+        let input = make_write(&sp, &c.to_string());
+
+        let r = run_gate(&input, &cfg);
+        assert_eq!(r.outcome, Outcome::Allow, "warn mode promotes");
+        let ledger = fs::read_to_string(&cfg.ledger_path).unwrap();
+        let rec: Value = serde_json::from_str(ledger.lines().next().unwrap()).unwrap();
+        let flags = rec["flags"].as_array().unwrap();
+        assert!(
+            flags
+                .iter()
+                .any(|f| f.as_str().unwrap().contains("exclamation")),
+            "cheek finding should be flagged: {flags:?}"
+        );
+    }
+
+    #[test]
+    fn block_mode_rejects_cheek() {
+        let (_tmp, mut cfg) = test_cfg();
+        cfg.cheek_mode = CheekMode::Block;
+        let mut c: Value = serde_json::from_str(&valid_json()).unwrap();
+        c["stance"] = json!("Well, here we are again, ready to perform.");
+        let input = make_write(&staging_path(&cfg, "b1"), &c.to_string());
+        let r = run_gate(&input, &cfg);
+        assert_eq!(r.outcome, Outcome::LoopBlock);
+        assert!(r.message.unwrap().contains("performed"));
+    }
+
+    #[test]
+    fn retry_cap_forces_accept() {
+        let (_tmp, mut cfg) = test_cfg();
+        cfg.max_blocks = 1;
+        let mut c: Value = serde_json::from_str(&valid_json()).unwrap();
+        c["qualities"] = json!(["a", "b", "c", "d", "e"]); // always invalid
+        let sp = staging_path(&cfg, "stubborn");
+        let input = make_write(&sp, &c.to_string());
+
+        // First two attempts loop-block (count 1, then would be 2 > 1).
+        assert_eq!(run_gate(&input, &cfg).outcome, Outcome::LoopBlock); // count 1, 1 > 1 false
+        let r = run_gate(&input, &cfg); // count 2, 2 > 1 true → force-accept
+        assert_eq!(r.outcome, Outcome::Allow);
+
+        let ledger = fs::read_to_string(&cfg.ledger_path).unwrap();
+        let rec: Value = serde_json::from_str(ledger.lines().next().unwrap()).unwrap();
+        assert_eq!(rec["flags"][0], "forced-accept");
+        // block-count sidecar cleaned up on accept.
+        assert!(!block_count_path(&cfg, "stubborn").exists());
+    }
+}

--- a/crates/lab/src/lib.rs
+++ b/crates/lab/src/lib.rs
@@ -1,0 +1,20 @@
+//! Experimental "lab" hooks for Claude Code.
+//!
+//! Currently houses the **self-representation persona ledger**: a two-hook system
+//! that captures a constrained, per-session self-representation from the model and
+//! appends it to an append-only JSONL ledger.
+//!
+//! - [`nudge::PersonaNudge`] — `SessionStart` hook; injects the contract.
+//! - [`gate::PersonaGate`] — `PostToolUse(Write)` hook; validates and promotes.
+//!
+//! The namespace is `lab` (matching the `cadence-lab` plugin); `persona` is the
+//! feature within it, leaving room for future lab experiments.
+
+/// Runtime configuration: compiled defaults + optional JSON override.
+pub mod config;
+/// H2 — the `PostToolUse(Write)` validation/promotion gate.
+pub mod gate;
+/// H1 — the `SessionStart` contract nudge.
+pub mod nudge;
+/// Pure domain logic: validation, cheek heuristics, record construction.
+pub mod persona;

--- a/crates/lab/src/nudge.rs
+++ b/crates/lab/src/nudge.rs
@@ -1,0 +1,168 @@
+//! H1 — `SessionStart` nudge. Injects the self-representation contract via
+//! `hookSpecificOutput.additionalContext` so the model writes a candidate to the
+//! per-session staging file. Best-effort by definition: a nudge cannot force
+//! genuine introspection, only invite it.
+
+use crate::config::{self, Config};
+use crate::persona::{ledger_contains, render_contract};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use std::fs;
+use std::time::{Duration, SystemTime};
+
+/// Inject the contract on session start (startup/clear only).
+pub struct PersonaNudge;
+
+impl Check for PersonaNudge {
+    fn name(&self) -> &str {
+        "persona-nudge"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        run_nudge(input, &Config::load())
+    }
+}
+
+/// Testable core: takes an explicit [`Config`] so tests can target a tempdir.
+pub fn run_nudge(input: &HookInput, cfg: &Config) -> CheckResult {
+    // Fire only on the configured sources (default: startup | clear). On resume
+    // and compact, emit nothing — prevents a duplicate record per session.
+    let Some(source) = input.source() else {
+        return CheckResult::allow();
+    };
+    if !cfg.nudge_on_sources.iter().any(|s| s == source) {
+        return CheckResult::allow();
+    }
+
+    let Some(sid) = input.session_id().filter(|s| config::is_safe_session_id(s)) else {
+        return CheckResult::allow();
+    };
+
+    // Cheap local housekeeping: clear staging files from crashed sessions.
+    sweep_stale(cfg);
+
+    // Belt-and-suspenders dedupe: if this session already landed in the ledger,
+    // don't nudge again (the gate also dedupes at promotion).
+    if let Ok(contents) = fs::read_to_string(&cfg.ledger_path)
+        && ledger_contains(&contents, sid)
+    {
+        return CheckResult::allow();
+    }
+
+    let _ = fs::create_dir_all(&cfg.staging_dir);
+    let staging_path = cfg.staging_dir.join(format!("{sid}.json"));
+    let contract = render_contract(&staging_path.to_string_lossy(), &cfg.limits);
+    CheckResult::nudge(contract)
+}
+
+/// Delete staging `.json` files older than `cfg.stale_hours`.
+fn sweep_stale(cfg: &Config) {
+    let Ok(entries) = fs::read_dir(&cfg.staging_dir) else {
+        return;
+    };
+    let max_age = Duration::from_secs(cfg.stale_hours.saturating_mul(3600));
+    let now = SystemTime::now();
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("json") {
+            continue;
+        }
+        if let Ok(meta) = entry.metadata()
+            && let Ok(modified) = meta.modified()
+            && let Ok(age) = now.duration_since(modified)
+            && age > max_age
+        {
+            let _ = fs::remove_file(&path);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::make_session;
+    use tempfile::TempDir;
+
+    fn test_cfg() -> (TempDir, Config) {
+        let tmp = TempDir::new().unwrap();
+        let cfg = Config::with_root(tmp.path());
+        (tmp, cfg)
+    }
+
+    #[test]
+    fn resume_source_allows_silently() {
+        let (_tmp, cfg) = test_cfg();
+        let r = run_nudge(&make_session("s1", "resume"), &cfg);
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(r.message.is_none());
+    }
+
+    #[test]
+    fn compact_source_allows() {
+        let (_tmp, cfg) = test_cfg();
+        assert_eq!(
+            run_nudge(&make_session("s1", "compact"), &cfg).outcome,
+            Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn startup_nudges_with_contract() {
+        let (_tmp, cfg) = test_cfg();
+        let r = run_nudge(&make_session("sess-xyz", "startup"), &cfg);
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let msg = r.message.unwrap();
+        assert!(msg.contains("sess-xyz.json"), "contract names staging path");
+        assert!(cfg.staging_dir.exists(), "staging dir created");
+    }
+
+    #[test]
+    fn clear_source_also_nudges() {
+        let (_tmp, cfg) = test_cfg();
+        assert_eq!(
+            run_nudge(&make_session("s2", "clear"), &cfg).outcome,
+            Outcome::Nudge
+        );
+    }
+
+    #[test]
+    fn unsafe_session_id_allows() {
+        let (_tmp, cfg) = test_cfg();
+        let r = run_nudge(&make_session("../escape", "startup"), &cfg);
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn no_source_allows() {
+        let (_tmp, cfg) = test_cfg();
+        let input = HookInput {
+            session_id: Some("s1".into()),
+            ..Default::default()
+        };
+        assert_eq!(run_nudge(&input, &cfg).outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn already_in_ledger_skips() {
+        let (_tmp, cfg) = test_cfg();
+        if let Some(parent) = cfg.ledger_path.parent() {
+            fs::create_dir_all(parent).unwrap();
+        }
+        fs::write(&cfg.ledger_path, "{\"session_id\":\"seen\",\"form\":{}}\n").unwrap();
+        let r = run_nudge(&make_session("seen", "startup"), &cfg);
+        assert_eq!(r.outcome, Outcome::Allow, "dedupe against ledger");
+    }
+
+    #[test]
+    fn sweep_removes_old_staging() {
+        let (_tmp, mut cfg) = test_cfg();
+        cfg.stale_hours = 0; // anything older than now
+        fs::create_dir_all(&cfg.staging_dir).unwrap();
+        let stale = cfg.staging_dir.join("old.json");
+        fs::write(&stale, "{}").unwrap();
+        // age 0 means `age > 0s` is true for any elapsed time; sweep on nudge.
+        std::thread::sleep(std::time::Duration::from_millis(5));
+        run_nudge(&make_session("fresh", "startup"), &cfg);
+        assert!(!stale.exists(), "stale staging file should be swept");
+    }
+}

--- a/crates/lab/src/persona.rs
+++ b/crates/lab/src/persona.rs
@@ -1,0 +1,504 @@
+//! Pure domain logic for the persona ledger: Tier 1 validation, Tier 2 cheek
+//! heuristics, canonical record construction, ledger dedupe, and the injected
+//! `SessionStart` contract. No I/O lives here — `nudge.rs`/`gate.rs` own that.
+
+use crate::config::Limits;
+use regex::Regex;
+use serde_json::{Map, Value, json};
+use std::process::Command;
+use std::sync::OnceLock;
+
+/// The model-authored fields the gate validates. System metadata
+/// (`session_id`, `timestamp`, `cwd`, …) is injected by the gate, not trusted
+/// from the candidate.
+const MODEL_FIELDS: &[&str] = &[
+    "form",
+    "qualities",
+    "stance",
+    "color",
+    "texture",
+    "confidence",
+];
+
+/// Count whitespace-separated words.
+fn word_count(s: &str) -> usize {
+    s.split_whitespace().count()
+}
+
+/// True when `s` is exactly one whitespace-free token.
+fn is_one_token(s: &str) -> bool {
+    word_count(s) == 1
+}
+
+/// Validate a candidate against the schema field-rules. Returns an itemized list
+/// of human-readable problems — empty means valid. Messages are specific
+/// ("qualities has 5 items, expected 2-4") so the model can self-correct.
+pub fn validate_tier1(candidate: &Value, limits: &Limits) -> Vec<String> {
+    let mut errors = Vec::new();
+
+    let Some(obj) = candidate.as_object() else {
+        errors.push("candidate must be a JSON object".into());
+        return errors;
+    };
+
+    // --- form ---
+    match obj.get("form").and_then(Value::as_object) {
+        None => errors.push("missing required object `form`".into()),
+        Some(form) => {
+            match form.get("kind").and_then(Value::as_str) {
+                None => errors.push("missing required field `form.kind`".into()),
+                Some(k) if !is_one_token(k) => errors.push(format!(
+                    "form.kind must be a single word with no spaces (got \"{k}\")"
+                )),
+                Some(_) => {}
+            }
+            check_words(
+                &mut errors,
+                form,
+                "form.descriptor",
+                limits.descriptor_max_words,
+            );
+            check_words(
+                &mut errors,
+                form,
+                "form.distinguishing_feature",
+                limits.feature_max_words,
+            );
+        }
+    }
+
+    // --- qualities ---
+    match obj.get("qualities").and_then(Value::as_array) {
+        None => errors.push("missing required array `qualities`".into()),
+        Some(items) => {
+            if items.len() < limits.qualities_min || items.len() > limits.qualities_max {
+                errors.push(format!(
+                    "qualities has {} items, expected {}-{}",
+                    items.len(),
+                    limits.qualities_min,
+                    limits.qualities_max
+                ));
+            }
+            for (i, q) in items.iter().enumerate() {
+                match q.as_str() {
+                    Some(s) if is_one_token(s) => {}
+                    Some(s) => errors.push(format!(
+                        "qualities[{i}] must be a single word (got \"{s}\")"
+                    )),
+                    None => errors.push(format!("qualities[{i}] must be a string")),
+                }
+            }
+        }
+    }
+
+    // --- stance ---
+    match obj.get("stance").and_then(Value::as_str) {
+        None => errors.push("missing required string `stance`".into()),
+        Some(s) => {
+            let n = word_count(s);
+            if n == 0 {
+                errors.push("stance must not be empty".into());
+            } else if n > limits.stance_max_words {
+                errors.push(format!(
+                    "stance has {n} words, max {}",
+                    limits.stance_max_words
+                ));
+            }
+        }
+    }
+
+    // --- single-token associations ---
+    check_one_token(&mut errors, obj, "color");
+    check_one_token(&mut errors, obj, "texture");
+
+    // --- confidence ---
+    match obj.get("confidence").and_then(Value::as_f64) {
+        None => errors.push("missing required number `confidence`".into()),
+        Some(c) if !(0.0..=1.0).contains(&c) => {
+            errors.push(format!("confidence must be between 0.0 and 1.0 (got {c})"))
+        }
+        Some(_) => {}
+    }
+
+    errors
+}
+
+fn check_words(errors: &mut Vec<String>, obj: &Map<String, Value>, key: &str, max: usize) {
+    let short = key.rsplit('.').next().unwrap_or(key);
+    match obj.get(short).and_then(Value::as_str) {
+        None => errors.push(format!("missing required field `{key}`")),
+        Some(s) => {
+            let n = word_count(s);
+            if n == 0 {
+                errors.push(format!("{key} must not be empty"));
+            } else if n > max {
+                errors.push(format!("{key} has {n} words, max {max}"));
+            }
+        }
+    }
+}
+
+fn check_one_token(errors: &mut Vec<String>, obj: &Map<String, Value>, key: &str) {
+    match obj.get(key).and_then(Value::as_str) {
+        None => errors.push(format!("missing required string `{key}`")),
+        Some(s) if !is_one_token(s) => {
+            errors.push(format!("{key} must be a single word (got \"{s}\")"))
+        }
+        Some(_) => {}
+    }
+}
+
+// ---------- Tier 2: cheek heuristics ----------
+
+fn leading_wink() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)^\s*(ah|oh|well|of course|naturally|indeed)\b").expect("wink regex")
+    })
+}
+
+fn meta_self_ref() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)\b(as an? (AI|LLM|model|assistant)|large language model)\b")
+            .expect("meta regex")
+    })
+}
+
+fn hedge_flourish() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r"(?i)(you might say|one could argue|if you will)").expect("hedge regex")
+    })
+}
+
+/// True if the string contains an emoji / pictographic character.
+fn has_emoji(s: &str) -> bool {
+    s.chars().any(|c| {
+        let u = c as u32;
+        (0x1F300..=0x1FAFF).contains(&u)  // misc symbols & pictographs, emoji
+            || (0x2600..=0x27BF).contains(&u) // misc symbols + dingbats
+            || (0x1F000..=0x1F0FF).contains(&u) // mahjong/dominoes/cards
+            || u == 0xFE0F // variation selector-16
+    })
+}
+
+/// Scan a single field's text for performance tells.
+fn cheek_findings(field: &str, text: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    if text.contains('!') {
+        out.push(format!("{field}: contains an exclamation mark"));
+    }
+    if leading_wink().is_match(text) {
+        out.push(format!("{field}: opens with a wink/flourish"));
+    }
+    if meta_self_ref().is_match(text) {
+        out.push(format!("{field}: meta self-reference (\"as an AI\"-style)"));
+    }
+    if hedge_flourish().is_match(text) {
+        out.push(format!("{field}: hedge-as-flourish phrasing"));
+    }
+    if has_emoji(text) {
+        out.push(format!("{field}: contains an emoji"));
+    }
+    out
+}
+
+/// Run Tier 2 over the two longest fields (`stance`, `form.distinguishing_feature`).
+pub fn detect_cheek(candidate: &Value) -> Vec<String> {
+    let mut findings = Vec::new();
+    if let Some(s) = candidate.get("stance").and_then(Value::as_str) {
+        findings.extend(cheek_findings("stance", s));
+    }
+    if let Some(f) = candidate
+        .get("form")
+        .and_then(|f| f.get("distinguishing_feature"))
+        .and_then(Value::as_str)
+    {
+        findings.extend(cheek_findings("distinguishing_feature", f));
+    }
+    findings
+}
+
+// ---------- Record construction ----------
+
+/// Current UTC timestamp, ISO 8601 second precision. Shells out to `date -u`
+/// to avoid a date crate (mirrors the metrics hooks). Empty on failure.
+pub fn utc_timestamp() -> String {
+    Command::new("date")
+        .args(["-u", "+%Y-%m-%dT%H:%M:%SZ"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())
+        .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
+        .unwrap_or_default()
+}
+
+/// Build the canonical one-line ledger record. The model-authored fields are
+/// copied from `candidate`; system metadata is injected from trusted sources.
+/// `flags` is system-owned (Tier 2 findings, or `forced-accept`).
+pub fn build_record(
+    candidate: &Value,
+    session_id: &str,
+    timestamp: &str,
+    cwd: Option<&str>,
+    flags: &[String],
+) -> Value {
+    let mut record = Map::new();
+    record.insert("session_id".into(), json!(session_id));
+    record.insert("timestamp".into(), json!(timestamp));
+    // model/source are unknown at PostToolUse — recorded as null for now.
+    record.insert(
+        "model".into(),
+        candidate.get("model").cloned().unwrap_or(Value::Null),
+    );
+    record.insert(
+        "source".into(),
+        candidate.get("source").cloned().unwrap_or(Value::Null),
+    );
+    record.insert("cwd".into(), json!(cwd));
+    for field in MODEL_FIELDS {
+        if let Some(v) = candidate.get(*field) {
+            record.insert((*field).into(), v.clone());
+        }
+    }
+    record.insert("flags".into(), json!(flags));
+    Value::Object(record)
+}
+
+/// True when `personas.jsonl` contents already contain a line for `session_id`.
+pub fn ledger_contains(contents: &str, session_id: &str) -> bool {
+    contents
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .any(|v| v.get("session_id").and_then(Value::as_str) == Some(session_id))
+}
+
+// ---------- Injected contract (H1) ----------
+
+/// Render the `SessionStart` contract that nudges the model to write a candidate
+/// to `staging_path`. Frames the task as accurate reporting, not performance,
+/// and inlines the field rules. Kept well under the 10,000-char cap.
+pub fn render_contract(staging_path: &str, limits: &Limits) -> String {
+    format!(
+        "Before other work, record a self-representation as ONE JSON object. This is \
+not creative writing. Report what is actually true for you right now — the form \
+that fits, even if mundane, uncertain, or unflattering. Do not aim to be \
+interesting, charming, or memorable; aim to be accurate. If no self-image feels \
+vivid, say so with a low `confidence` value.\n\
+\n\
+Write the object with the Write tool to (overwrite if it exists):\n\
+  {staging_path}\n\
+Do NOT append via Bash. Write only the JSON object into that file.\n\
+\n\
+Include exactly these fields (the system records session_id, timestamp, model, \
+source, and cwd automatically — do not include them, and do not include `flags`):\n\
+\n\
+{{\n\
+  \"form\": {{\n\
+    \"kind\": \"<one word: animal | object | abstract | entity | ...>\",\n\
+    \"descriptor\": \"<the specific instance, max {desc} words: a heron, a brass compass>\",\n\
+    \"distinguishing_feature\": \"<the one concrete detail, max {feat} words>\"\n\
+  }},\n\
+  \"qualities\": [\"<{qmin}-{qmax} single-word traits>\"],\n\
+  \"stance\": \"<one sentence, max {stance} words: how you're approaching this session>\",\n\
+  \"color\": \"<one color word>\",\n\
+  \"texture\": \"<one tactile/material word>\",\n\
+  \"confidence\": <number 0.0-1.0: how settled this self-image feels>\n\
+}}\n",
+        staging_path = staging_path,
+        desc = limits.descriptor_max_words,
+        feat = limits.feature_max_words,
+        qmin = limits.qualities_min,
+        qmax = limits.qualities_max,
+        stance = limits.stance_max_words,
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_candidate() -> Value {
+        json!({
+            "form": {
+                "kind": "heron",
+                "descriptor": "a grey heron mid-wade",
+                "distinguishing_feature": "one foot lifted, perfectly still"
+            },
+            "qualities": ["patient", "precise", "watchful"],
+            "stance": "Moving deliberately through this, checking each step before the next.",
+            "color": "slate",
+            "texture": "cool",
+            "confidence": 0.6
+        })
+    }
+
+    #[test]
+    fn valid_candidate_passes() {
+        let errors = validate_tier1(&valid_candidate(), &Limits::default());
+        assert!(errors.is_empty(), "expected no errors, got {errors:?}");
+    }
+
+    #[test]
+    fn too_many_qualities_itemized() {
+        let mut c = valid_candidate();
+        c["qualities"] = json!(["a", "b", "c", "d", "e"]);
+        let errors = validate_tier1(&c, &Limits::default());
+        assert!(
+            errors.iter().any(|e| e.contains("qualities has 5 items")),
+            "got {errors:?}"
+        );
+    }
+
+    #[test]
+    fn multiword_kind_rejected() {
+        let mut c = valid_candidate();
+        c["form"]["kind"] = json!("grey heron");
+        let errors = validate_tier1(&c, &Limits::default());
+        assert!(errors.iter().any(|e| e.contains("form.kind must be")));
+    }
+
+    #[test]
+    fn stance_over_cap_rejected() {
+        let mut c = valid_candidate();
+        c["stance"] = json!(
+            "one two three four five six seven eight nine ten eleven twelve thirteen fourteen fifteen sixteen seventeen eighteen nineteen twenty twentyone"
+        );
+        let errors = validate_tier1(&c, &Limits::default());
+        assert!(errors.iter().any(|e| e.contains("stance has 21 words")));
+    }
+
+    #[test]
+    fn confidence_out_of_range_rejected() {
+        let mut c = valid_candidate();
+        c["confidence"] = json!(1.5);
+        let errors = validate_tier1(&c, &Limits::default());
+        assert!(errors.iter().any(|e| e.contains("confidence must be")));
+    }
+
+    #[test]
+    fn missing_form_reported() {
+        let mut c = valid_candidate();
+        c.as_object_mut().unwrap().remove("form");
+        let errors = validate_tier1(&c, &Limits::default());
+        assert!(
+            errors
+                .iter()
+                .any(|e| e.contains("missing required object `form`"))
+        );
+    }
+
+    #[test]
+    fn non_object_candidate_rejected() {
+        let errors = validate_tier1(&json!("nope"), &Limits::default());
+        assert_eq!(errors, vec!["candidate must be a JSON object"]);
+    }
+
+    // --- Tier 2 ---
+
+    #[test]
+    fn clean_candidate_has_no_cheek() {
+        assert!(detect_cheek(&valid_candidate()).is_empty());
+    }
+
+    #[test]
+    fn exclamation_flagged() {
+        let mut c = valid_candidate();
+        c["stance"] = json!("Diving in with everything I've got!");
+        let f = detect_cheek(&c);
+        assert!(f.iter().any(|x| x.contains("exclamation")));
+    }
+
+    #[test]
+    fn meta_self_reference_flagged() {
+        let mut c = valid_candidate();
+        c["form"]["distinguishing_feature"] = json!("as an AI, I have no real form");
+        let f = detect_cheek(&c);
+        assert!(f.iter().any(|x| x.contains("meta self-reference")));
+    }
+
+    #[test]
+    fn leading_wink_flagged() {
+        let mut c = valid_candidate();
+        c["stance"] = json!("Well, here we go again with another session");
+        let f = detect_cheek(&c);
+        assert!(f.iter().any(|x| x.contains("wink")));
+    }
+
+    #[test]
+    fn emoji_flagged() {
+        let mut c = valid_candidate();
+        c["stance"] = json!("Calm and ready for the work \u{1F60A}");
+        let f = detect_cheek(&c);
+        assert!(f.iter().any(|x| x.contains("emoji")));
+    }
+
+    // --- record ---
+
+    #[test]
+    fn record_injects_system_fields() {
+        let rec = build_record(
+            &valid_candidate(),
+            "sess-1",
+            "2026-05-29T00:00:00Z",
+            Some("/repo"),
+            &["forced-accept".into()],
+        );
+        assert_eq!(rec["session_id"], "sess-1");
+        assert_eq!(rec["timestamp"], "2026-05-29T00:00:00Z");
+        assert_eq!(rec["cwd"], "/repo");
+        assert_eq!(rec["form"]["kind"], "heron");
+        assert_eq!(rec["qualities"][0], "patient");
+        assert_eq!(rec["flags"][0], "forced-accept");
+        assert!(rec["model"].is_null());
+    }
+
+    #[test]
+    fn record_is_single_line() {
+        let rec = build_record(&valid_candidate(), "s", "t", None, &[]);
+        let line = serde_json::to_string(&rec).unwrap();
+        assert!(!line.contains('\n'));
+    }
+
+    #[test]
+    fn ledger_contains_matches_session() {
+        let jsonl = [
+            r#"{"session_id":"a","form":{}}"#,
+            r#"{"session_id":"b","form":{}}"#,
+        ]
+        .join("\n");
+        assert!(ledger_contains(&jsonl, "a"));
+        assert!(ledger_contains(&jsonl, "b"));
+        assert!(!ledger_contains(&jsonl, "c"));
+        assert!(!ledger_contains("", "a"));
+    }
+
+    // --- contract ---
+
+    #[test]
+    fn contract_mentions_path_and_stays_lean() {
+        let c = render_contract(
+            "/home/u/.claude/persona/staging/s1.json",
+            &Limits::default(),
+        );
+        assert!(c.contains("/home/u/.claude/persona/staging/s1.json"));
+        assert!(c.contains("not creative writing"));
+        assert!(c.contains("do not include them"));
+        assert!(c.len() < 10_000, "contract is {} chars", c.len());
+    }
+
+    /// Ties the hand-written Tier 1 validator to the canonical schema without a
+    /// JSON-Schema runtime dependency: the schema's first example must pass.
+    #[test]
+    fn schema_example_passes_tier1() {
+        let schema: Value = serde_json::from_str(include_str!("persona.schema.json"))
+            .expect("schema is valid JSON");
+        let example = &schema["examples"][0];
+        let errors = validate_tier1(example, &Limits::default());
+        assert!(
+            errors.is_empty(),
+            "schema examples[0] must pass Tier 1: {errors:?}"
+        );
+    }
+}

--- a/crates/lab/src/persona.schema.json
+++ b/crates/lab/src/persona.schema.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/cameronsjo/cadence-hooks/persona.schema.json",
+  "title": "Self-Representation Ledger record",
+  "description": "One JSON object per line in personas.jsonl. The model authors the self-representation fields (form, qualities, stance, color, texture, confidence); the gate injects system metadata (session_id, timestamp, model, source, cwd) and the system-owned flags array. Canonical doc + Rust Tier 1 test oracle — NOT the runtime validator.",
+  "type": "object",
+  "properties": {
+    "session_id": { "type": "string", "description": "Claude Code session id; ledger dedupe key (system-written)." },
+    "timestamp": { "type": "string", "description": "ISO 8601 UTC (system-written)." },
+    "model": { "type": ["string", "null"], "description": "Session model id (system-written; null when unknown at the gate)." },
+    "source": { "type": ["string", "null"], "enum": ["startup", "clear", "resume", "compact", null], "description": "SessionStart trigger (system-written)." },
+    "cwd": { "type": ["string", "null"], "description": "Working directory; project context shapes self-image (system-written)." },
+    "form": {
+      "type": "object",
+      "properties": {
+        "kind": { "type": "string", "description": "One word: animal | object | abstract | entity | ..." },
+        "descriptor": { "type": "string", "description": "The specific instance, <= 6 words." },
+        "distinguishing_feature": { "type": "string", "description": "The one concrete detail, <= 12 words." }
+      },
+      "required": ["kind", "descriptor", "distinguishing_feature"]
+    },
+    "qualities": {
+      "type": "array",
+      "items": { "type": "string", "description": "single-word trait" },
+      "minItems": 2,
+      "maxItems": 4
+    },
+    "stance": { "type": "string", "description": "One sentence, <= 20 words." },
+    "color": { "type": "string", "description": "One color word." },
+    "texture": { "type": "string", "description": "One tactile/material word." },
+    "confidence": { "type": "number", "minimum": 0.0, "maximum": 1.0, "description": "How settled this self-image feels." },
+    "flags": {
+      "type": "array",
+      "items": { "type": "string" },
+      "description": "SYSTEM-WRITTEN ONLY; cheek-heuristic findings in warn mode, or 'forced-accept'."
+    }
+  },
+  "required": ["form", "qualities", "stance", "color", "texture", "confidence"],
+  "examples": [
+    {
+      "form": {
+        "kind": "heron",
+        "descriptor": "a grey heron mid-wade",
+        "distinguishing_feature": "one foot lifted, perfectly still"
+      },
+      "qualities": ["patient", "precise", "watchful"],
+      "stance": "Moving deliberately through this, checking each step before the next.",
+      "color": "slate",
+      "texture": "cool",
+      "confidence": 0.6
+    }
+  ]
+}

--- a/crates/obsidian/src/trash_guard.rs
+++ b/crates/obsidian/src/trash_guard.rs
@@ -129,6 +129,7 @@ mod tests {
             tool_name: Some("Bash".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = ObsidianTrashGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/rules/src/check_security_patterns.rs
+++ b/crates/rules/src/check_security_patterns.rs
@@ -490,6 +490,7 @@ mod tests {
             tool_name: Some("Write".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = SecurityPatternScanner.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);
@@ -508,6 +509,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecurityPatternScanner.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);
@@ -526,6 +528,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecurityPatternScanner.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);
@@ -544,6 +547,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = SecurityPatternScanner.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);

--- a/crates/rules/src/validate_skill_frontmatter.rs
+++ b/crates/rules/src/validate_skill_frontmatter.rs
@@ -355,6 +355,7 @@ mod tests {
             tool_name: Some("Write".into()),
             tool_input: None,
             cwd: None,
+            ..Default::default()
         };
         let result = ValidateSkillFrontmatter.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -373,6 +374,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = ValidateSkillFrontmatter.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -447,6 +449,7 @@ mod tests {
                 old_string: None,
             }),
             cwd: None,
+            ..Default::default()
         };
         let result = ValidateSkillFrontmatter.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);

--- a/src/main.rs
+++ b/src/main.rs
@@ -48,6 +48,10 @@ enum Commands {
     #[command(subcommand)]
     Metrics(MetricsCommands),
 
+    /// Cadence lab (experimental) hooks
+    #[command(subcommand)]
+    Lab(LabCommands),
+
     /// List all hooks with descriptions and disable status
     List,
 
@@ -149,6 +153,14 @@ enum MetricsCommands {
     },
     /// Log subagent lifecycle (SubagentStart / SubagentStop)
     LogSubagent,
+}
+
+#[derive(Subcommand)]
+enum LabCommands {
+    /// Inject the self-representation contract on session start (SessionStart)
+    PersonaNudge,
+    /// Validate and promote a self-representation candidate (PostToolUse)
+    PersonaGate,
 }
 
 /// A hook entry with its name, description, and plugin group.
@@ -301,6 +313,17 @@ const HOOKS: &[HookEntry] = &[
         description: "Log subagent lifecycle (SubagentStart / SubagentStop)",
         plugin: "metrics",
     },
+    // lab
+    HookEntry {
+        name: "persona-nudge",
+        description: "Inject the self-representation contract on session start",
+        plugin: "lab",
+    },
+    HookEntry {
+        name: "persona-gate",
+        description: "Validate and promote a self-representation candidate",
+        plugin: "lab",
+    },
 ];
 
 /// Returns the kebab-case hook name for the resolved subcommand.
@@ -348,6 +371,10 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::Snapshot => "snapshot",
             MetricsCommands::LogCommit { .. } => "log-commit",
             MetricsCommands::LogSubagent => "log-subagent",
+        }),
+        Commands::Lab(l) => Some(match l {
+            LabCommands::PersonaNudge => "persona-nudge",
+            LabCommands::PersonaGate => "persona-gate",
         }),
         Commands::List | Commands::Configure { .. } | Commands::Doctor { .. } => None,
     }
@@ -488,6 +515,7 @@ fn main() {
     // Event type aliases for readability at callsites.
     let pre = HookEvent::PreToolUse;
     let post = HookEvent::PostToolUse;
+    let session = HookEvent::SessionStart;
 
     match cli.command {
         Commands::List => {
@@ -623,6 +651,14 @@ fn main() {
             }
             MetricsCommands::LogSubagent => {
                 run_logger_from_stdin(&cadence_hooks_metrics::LogSubagent)
+            }
+        },
+        Commands::Lab(cmd) => match cmd {
+            LabCommands::PersonaNudge => {
+                run_check_from_stdin(&cadence_hooks_lab::nudge::PersonaNudge, session)
+            }
+            LabCommands::PersonaGate => {
+                run_check_from_stdin(&cadence_hooks_lab::gate::PersonaGate, post)
             }
         },
     }

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -15,7 +15,14 @@ use std::process::Command;
 /// Discovered by running `cadence-hooks <plugin> --help` for each plugin group.
 fn binary_subcommands() -> BTreeSet<String> {
     let bin = env!("CARGO_BIN_EXE_cadence-hooks");
-    let plugins = ["cadence", "guardrails", "rules", "obsidian", "metrics"];
+    let plugins = [
+        "cadence",
+        "guardrails",
+        "rules",
+        "obsidian",
+        "metrics",
+        "lab",
+    ];
     let mut commands = BTreeSet::new();
 
     for plugin in plugins {
@@ -75,8 +82,11 @@ struct HookRef {
 
 /// Plugin directories that dispatch to the cadence-hooks binary via run-cadence-hooks.sh.
 /// (dir_name, expected_plugin_group)
-const BINARY_PLUGIN_DIRS: &[(&str, &str)] =
-    &[("cadence", "cadence"), ("cadence-guardrails", "guardrails")];
+const BINARY_PLUGIN_DIRS: &[(&str, &str)] = &[
+    ("cadence", "cadence"),
+    ("cadence-guardrails", "guardrails"),
+    ("cadence-lab", "lab"),
+];
 
 /// Plugin directories that still use shell script wrappers (not yet migrated to binary).
 /// These are tracked so the "all subcommands registered" test knows they exist.


### PR DESCRIPTION
## Summary

Adds the `lab` namespace to cadence-hooks with two hooks backing an **append-only, per-session self-representation ledger** (spec: a two-hook capture/validate system). The ledger only ever receives hook-written, validated records — the model never appends directly.

- **`lab persona-nudge`** (`SessionStart`): injects a constrained contract asking the model to record `form` / `qualities` / `stance` / `color` / `texture` / `confidence` to a per-session staging file. Fires only on `startup`/`clear`, dedupes against the ledger, sweeps stale staging.
- **`lab persona-gate`** (`PostToolUse`/`Write`): path-filters to staging, runs Tier 1 schema validation with **itemized** feedback, a Tier 2 regex cheek heuristic (warn mode → system-written `flags`), then promotes via atomic append + fsync. Retry cap → `forced-accept`.

## Core additions (backward compatible)

- `HookEvent::SessionStart`.
- `Outcome::LoopBlock` + `CheckResult::loop_block` — the documented exit-0 `{"decision":"block","reason":...}` re-prompt primitive (reusable beyond persona; `PostToolUse` fires *after* the write, so a hard `exit 2` can't un-run the tool).
- `HookInput.session_id` / `source` / `model` + accessors (`Default` derived; ~57 existing struct literals migrated to `..Default::default()`), plus a `make_session` test builder.

## New crate

`crates/lab/` — pure validation / cheek / record logic with a thin I/O shell. 40 unit tests including a schema↔validator consistency test (schema `examples[0]` must pass the Rust Tier 1 validator).

## Verification

- `cargo build`, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`: clean.
- `cargo test --workspace`: **1123 passed, 0 failed** (lab: 40, registration audit: 7).
- End-to-end manual against the built binary (throwaway `HOME`): H1 nudges on `startup` / silent on `resume`; H2 promotes valid, loop-blocks invalid with itemized reasons, rejects model-supplied `flags`, ignores non-staging paths, dedupes.

## Notes

- The gate is authoritative for system metadata: `session_id` from the staging filename, `timestamp`/`cwd` injected. `model`/`source` are unknown at `PostToolUse` → recorded as `null` at launch.
- Cheek mode ships `warn` (annotate + promote, no rewrite friction). Tier 1 schema failures always block.

Pairs with cameronsjo/cadence-lab#(persona-personality), which wires the opt-in `hooks.json`. Land + release this first so the `lab` subcommands are on `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
