### PR TITLE
feat: three new guardrail checks — guard-dotfiles, guard-pr-issue-link, verify-pr-autoclose

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.swp
 *.swo
 .DS_Store
+.review-loop.local.md

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,7 @@ version = "0.11.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
+ "serde_json",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Hooks are organized by the plugin they serve:
 | `warn-untracked` | PreToolUse (Bash) | Warn about untracked files during git commit |
 | `check-idle-return` | PreToolUse | Nudge after idle periods between edits |
 | `nudge-upgrade-after-push` | PostToolUse (Bash) | Nudge to schedule a brew upgrade after pushing cadence-hooks to main |
+| `guard-dotfiles` | PreToolUse (Edit, Write) | Block direct edits to production dotfiles (opt-in via `CADENCE_GUARD_DOTFILES=1`) |
+| `guard-pr-issue-link` | PreToolUse (Bash) | Block `gh pr create` without a closing issue keyword (`Closes #N`) in the body |
+| `verify-pr-autoclose` | PostToolUse (Bash) | Verify issue auto-close refs after PR create; close stragglers after merge |
 
 ### rules
 
@@ -186,6 +189,8 @@ All cadence-hooks config lives under the `CADENCE_*` prefix. `OBSIDIAN_VAULT` is
 | `CADENCE_ALLOWED_REPOS` | `guard-gh-write` | Space or comma-separated `owner/repo` pairs |
 | `CADENCE_EXTRA_HOSTS` | `guard-push-remote`, `guard-gh-write` | Self-hosted forge hosts that bare entries (`cameron`) should match in addition to the default host |
 | `CADENCE_GH_STRICT_LOOPS` | `guard-gh-write` | Set to `1` to block all looped gh writes lacking `-R`, even provably deterministic ones |
+| `CADENCE_GUARD_DOTFILES` | `guard-dotfiles` | Set to `1` to block direct edits to production dotfiles (clean no-op otherwise) |
+| `GH_AUTOCLOSE_WAIT_SECONDS` | `verify-pr-autoclose` | Seconds to wait after `gh pr merge` before checking for straggler issues (default 10) |
 | `OBSIDIAN_VAULT` | `trash-guard` | Absolute path to Obsidian vault |
 
 #### Allowlist host scoping

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -104,6 +104,9 @@ fn normalize_path(path: &str) -> String {
 pub struct HookInput {
     pub tool_name: Option<String>,
     pub tool_input: Option<ToolInput>,
+    /// The tool response (stdout, stderr) from the tool execution.
+    /// Available in PostToolUse hooks — absent in PreToolUse and SessionStart.
+    pub tool_response: Option<ToolResponse>,
     pub cwd: Option<String>,
     /// Claude Code session id — present on `SessionStart`.
     pub session_id: Option<String>,
@@ -122,6 +125,17 @@ pub struct ToolInput {
     pub content: Option<String>,
     pub new_string: Option<String>,
     pub old_string: Option<String>,
+}
+
+/// The tool response, available in PostToolUse hooks.
+///
+/// Claude Code sends the tool's stdout (and optionally stderr) back in the
+/// hook payload so post-processing hooks can inspect the result without
+/// re-running the command.
+#[derive(Debug, Default, Deserialize)]
+pub struct ToolResponse {
+    pub stdout: Option<String>,
+    pub stderr: Option<String>,
 }
 
 impl HookInput {
@@ -175,6 +189,13 @@ impl HookInput {
     /// The session model id, if present.
     pub fn model(&self) -> Option<&str> {
         self.model.as_deref()
+    }
+
+    /// The stdout from the tool response (PostToolUse only).
+    pub fn tool_response_stdout(&self) -> Option<&str> {
+        self.tool_response
+            .as_ref()
+            .and_then(|tr| tr.stdout.as_deref())
     }
 }
 

--- a/crates/core/src/shell.rs
+++ b/crates/core/src/shell.rs
@@ -38,6 +38,52 @@ pub fn strip_quotes(s: &str) -> String {
     result
 }
 
+/// Split a shell command into whitespace-separated tokens, honoring quotes.
+///
+/// Content inside matching `'` or `"` pairs stays in one token with the quotes
+/// stripped, so `--body "see --flag x"` yields `["--body", "see --flag x"]` —
+/// quoted text can never masquerade as a flag. Unmatched quotes consume the
+/// rest of the string. This is flag/argument extraction, not shell execution:
+/// no escape sequences, expansions, or operator splitting.
+pub fn tokenize(command: &str) -> Vec<String> {
+    let mut tokens = Vec::new();
+    let mut current = String::new();
+    let mut in_token = false;
+    let mut quote: Option<char> = None;
+
+    for c in command.chars() {
+        match quote {
+            Some(q) => {
+                if c == q {
+                    quote = None;
+                } else {
+                    current.push(c);
+                }
+            }
+            None => match c {
+                '\'' | '"' => {
+                    quote = Some(c);
+                    in_token = true;
+                }
+                c if c.is_whitespace() => {
+                    if in_token {
+                        tokens.push(std::mem::take(&mut current));
+                        in_token = false;
+                    }
+                }
+                _ => {
+                    current.push(c);
+                    in_token = true;
+                }
+            },
+        }
+    }
+    if in_token {
+        tokens.push(current);
+    }
+    tokens
+}
+
 /// Extract `(host, "owner/repo")` from any git remote URL format.
 ///
 /// Handles:
@@ -197,6 +243,54 @@ mod tests {
         assert_eq!(
             strip_quotes("gh pr create --title 'test' --body \"desc\""),
             "gh pr create --title  --body "
+        );
+    }
+
+    // --- tokenize ---
+
+    #[test]
+    fn tokenize_splits_on_whitespace() {
+        assert_eq!(tokenize("gh pr create"), vec!["gh", "pr", "create"]);
+    }
+
+    #[test]
+    fn tokenize_keeps_double_quoted_content_in_one_token() {
+        assert_eq!(
+            tokenize(r#"gh pr create --body "see --body-file foo""#),
+            vec!["gh", "pr", "create", "--body", "see --body-file foo"]
+        );
+    }
+
+    #[test]
+    fn tokenize_keeps_single_quoted_content_in_one_token() {
+        assert_eq!(
+            tokenize("gh pr create -F 'my body files/pr.md'"),
+            vec!["gh", "pr", "create", "-F", "my body files/pr.md"]
+        );
+    }
+
+    #[test]
+    fn tokenize_joins_adjacent_quoted_and_bare_text() {
+        // Shell semantics: abc"def" is one word.
+        assert_eq!(tokenize(r#"echo abc"def ghi""#), vec!["echo", "abcdef ghi"]);
+    }
+
+    #[test]
+    fn tokenize_preserves_empty_quoted_token() {
+        assert_eq!(tokenize(r#"echo "" world"#), vec!["echo", "", "world"]);
+    }
+
+    #[test]
+    fn tokenize_handles_empty_and_whitespace_input() {
+        assert_eq!(tokenize(""), Vec::<String>::new());
+        assert_eq!(tokenize("   "), Vec::<String>::new());
+    }
+
+    #[test]
+    fn tokenize_unmatched_quote_consumes_rest() {
+        assert_eq!(
+            tokenize(r#"echo "unclosed rest of line"#),
+            vec!["echo", "unclosed rest of line"]
         );
     }
 

--- a/crates/core/src/test_builders.rs
+++ b/crates/core/src/test_builders.rs
@@ -6,7 +6,7 @@
 //! cadence-hooks-core = { workspace = true, features = ["test-builders"] }
 //! ```
 
-use crate::{HookInput, ToolInput};
+use crate::{HookInput, ToolInput, ToolResponse};
 
 /// Build a `HookInput` for a `Bash` tool invocation.
 pub fn make_bash(cmd: &str) -> HookInput {
@@ -70,6 +70,30 @@ pub fn make_edit(path: &str) -> HookInput {
             content: None,
             new_string: Some("new".into()),
             old_string: Some("old".into()),
+        }),
+        cwd: None,
+        ..Default::default()
+    }
+}
+
+/// Build a `HookInput` for a PostToolUse `Bash` invocation with a tool response stdout.
+///
+/// Used to test PostToolUse checks that inspect the command's output (e.g.
+/// `verify-pr-autoclose` which reads the PR URL from `gh pr create` stdout).
+pub fn make_bash_post_tool_use(cmd: &str, stdout: &str) -> HookInput {
+    HookInput {
+        tool_name: Some("Bash".into()),
+        tool_input: Some(ToolInput {
+            file_path: None,
+            path: None,
+            command: Some(cmd.into()),
+            content: None,
+            new_string: None,
+            old_string: None,
+        }),
+        tool_response: Some(ToolResponse {
+            stdout: Some(stdout.into()),
+            stderr: None,
         }),
         cwd: None,
         ..Default::default()

--- a/crates/guardrails/Cargo.toml
+++ b/crates/guardrails/Cargo.toml
@@ -8,6 +8,7 @@ description = "Git guardrails hooks: push protection, gh write guards, idle dete
 [dependencies]
 cadence-hooks-core.workspace = true
 regex.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 cadence-hooks-core = { workspace = true, features = ["test-builders"] }

--- a/crates/guardrails/src/guard_dotfiles.rs
+++ b/crates/guardrails/src/guard_dotfiles.rs
@@ -69,7 +69,7 @@ impl Check for GuardDotfiles {
             return CheckResult::allow();
         }
 
-        let enabled = std::env::var("CADENCE_GUARD_DOTFILES").is_ok_and(|v| v == "1");
+        let enabled = std::env::var("CADENCE_GUARD_DOTFILES").as_deref() == Ok("1");
         let home = std::env::var("HOME").unwrap_or_default();
 
         // Resolve target: file_path first, then command (per spec fallback)

--- a/crates/guardrails/src/guard_dotfiles.rs
+++ b/crates/guardrails/src/guard_dotfiles.rs
@@ -1,0 +1,248 @@
+//! Guard against direct edits to production dotfiles.
+//!
+//! Users who manage dotfiles with chezmoi should edit the source templates
+//! (`~/.dotfiles/dot_<name>`) and run `chezmoi apply`, not edit the deployed
+//! files directly. This check blocks edits to the protected set and redirects
+//! to the correct workflow.
+//!
+//! **Opt-in:** Set `CADENCE_GUARD_DOTFILES=1` to enable. When unset (or any
+//! value other than `"1"`), the check is a clean no-op.
+
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+
+/// The set of production dotfiles that must not be edited directly.
+const PROTECTED_BASENAMES: &[&str] = &[
+    ".zshrc",
+    ".zprofile",
+    ".zshenv",
+    ".aliases",
+    ".functions",
+    ".gitconfig",
+    ".tmux.conf",
+];
+
+/// Pure decision function — no env reads, no I/O.
+///
+/// Returns `Some(deny_message)` if the target should be blocked, `None` to allow.
+///
+/// # Arguments
+/// * `enabled` — whether `CADENCE_GUARD_DOTFILES=1` is set
+/// * `home`    — the user's home directory (e.g. `/Users/cameron`)
+/// * `target`  — the file path from the tool input (already resolved)
+pub fn judge_dotfile(enabled: bool, home: &str, target: &str) -> Option<String> {
+    if !enabled {
+        return None;
+    }
+
+    // Exact match only — no prefix/suffix checks, no symlink resolution.
+    // $HOME/.zshrc blocks; $HOME/.zshrc.local does not.
+    for basename in PROTECTED_BASENAMES {
+        let protected = format!("{home}/{basename}");
+        if target == protected {
+            // Strip the leading dot to get the chezmoi source name:
+            //   .zshrc    → dot_zshrc
+            //   .tmux.conf → dot_tmux.conf
+            let chezmoi_name = format!("dot_{}", basename.trim_start_matches('.'));
+            return Some(format!(
+                "🚫 guard-dotfiles: Direct edit to production dotfile blocked.\n   \
+                 Found:  {target}\n   \
+                 Fix:    Edit ~/.dotfiles/{chezmoi_name} instead, then run 'chezmoi apply'",
+            ));
+        }
+    }
+
+    None
+}
+
+/// Guards against direct edits to chezmoi-managed production dotfiles.
+pub struct GuardDotfiles;
+
+impl Check for GuardDotfiles {
+    fn name(&self) -> &str {
+        "guard-dotfiles"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        // Only applies to Edit and Write tools
+        let tool = input.tool_name().unwrap_or("");
+        if tool != "Edit" && tool != "Write" {
+            return CheckResult::allow();
+        }
+
+        let enabled = std::env::var("CADENCE_GUARD_DOTFILES").is_ok_and(|v| v == "1");
+        let home = std::env::var("HOME").unwrap_or_default();
+
+        // Resolve target: file_path first, then command (per spec fallback)
+        let target = input
+            .file_path()
+            .or_else(|| input.command().map(|s| s.to_string()))
+            .unwrap_or_default();
+
+        match judge_dotfile(enabled, &home, &target) {
+            Some(msg) => CheckResult::block(msg),
+            None => CheckResult::allow(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::{make_bash, make_edit, make_write};
+
+    const HOME: &str = "/Users/cameron";
+
+    fn zshrc() -> String {
+        format!("{HOME}/.zshrc")
+    }
+    fn gitconfig() -> String {
+        format!("{HOME}/.gitconfig")
+    }
+    fn tmux_conf() -> String {
+        format!("{HOME}/.tmux.conf")
+    }
+    fn zshrc_local() -> String {
+        format!("{HOME}/.zshrc.local")
+    }
+    fn project_file() -> String {
+        format!("{HOME}/project/foo.py")
+    }
+
+    // --- derived test cases from the spec ---
+
+    // Case 1: enabled + $HOME/.zshrc → deny, message names dot_zshrc + chezmoi apply
+    #[test]
+    fn enabled_zshrc_is_blocked() {
+        let msg = judge_dotfile(true, HOME, &zshrc());
+        assert!(msg.is_some(), "expected block for ~/.zshrc");
+        let msg = msg.unwrap();
+        assert!(
+            msg.contains("dot_zshrc"),
+            "message should name dot_zshrc, got: {msg}"
+        );
+        assert!(
+            msg.contains("chezmoi apply"),
+            "message should mention chezmoi apply, got: {msg}"
+        );
+    }
+
+    // Case 2: enabled + $HOME/.gitconfig → deny, names dot_gitconfig
+    #[test]
+    fn enabled_gitconfig_is_blocked() {
+        let msg = judge_dotfile(true, HOME, &gitconfig());
+        assert!(msg.is_some(), "expected block for ~/.gitconfig");
+        let msg = msg.unwrap();
+        assert!(
+            msg.contains("dot_gitconfig"),
+            "message should name dot_gitconfig, got: {msg}"
+        );
+    }
+
+    // Case 3: enabled + $HOME/.zshrc.local → allow (not exact match)
+    #[test]
+    fn enabled_zshrc_local_is_allowed() {
+        let result = judge_dotfile(true, HOME, &zshrc_local());
+        assert!(result.is_none(), "~/.zshrc.local should be allowed");
+    }
+
+    // Case 4: enabled + $HOME/project/foo.py → allow
+    #[test]
+    fn enabled_non_dotfile_is_allowed() {
+        let result = judge_dotfile(true, HOME, &project_file());
+        assert!(result.is_none(), "a non-dotfile should be allowed");
+    }
+
+    // Case 5: enabled + $HOME/.tmux.conf → deny, names dot_tmux.conf
+    #[test]
+    fn enabled_tmux_conf_is_blocked() {
+        let msg = judge_dotfile(true, HOME, &tmux_conf());
+        assert!(msg.is_some(), "expected block for ~/.tmux.conf");
+        let msg = msg.unwrap();
+        assert!(
+            msg.contains("dot_tmux.conf"),
+            "message should name dot_tmux.conf, got: {msg}"
+        );
+    }
+
+    // Case 6: disabled + $HOME/.zshrc → allow (feature off)
+    #[test]
+    fn disabled_zshrc_is_allowed() {
+        let result = judge_dotfile(false, HOME, &zshrc());
+        assert!(result.is_none(), "feature disabled should always allow");
+    }
+
+    // Case 7: command-only input (no file_path) → allow unless it equals a protected path
+    // The spec says: allow unless the command string equals a protected path literal
+    #[test]
+    fn command_only_non_path_is_allowed() {
+        // A typical bash command string is not a protected path
+        let result = judge_dotfile(true, HOME, "cat ~/.zshrc | grep alias");
+        assert!(
+            result.is_none(),
+            "command string (not a protected path) should allow"
+        );
+    }
+
+    // --- edge cases ---
+
+    #[test]
+    fn all_protected_files_blocked_when_enabled() {
+        let protected = [
+            ".zshrc",
+            ".zprofile",
+            ".zshenv",
+            ".aliases",
+            ".functions",
+            ".gitconfig",
+            ".tmux.conf",
+        ];
+        for name in protected {
+            let path = format!("{HOME}/{name}");
+            let msg = judge_dotfile(true, HOME, &path);
+            assert!(msg.is_some(), "expected block for ~/{name}, got None");
+        }
+    }
+
+    #[test]
+    fn empty_target_is_allowed() {
+        let result = judge_dotfile(true, HOME, "");
+        assert!(result.is_none(), "empty target should always allow");
+    }
+
+    #[test]
+    fn tilde_prefixed_path_is_not_matched() {
+        // The check uses $HOME expansion; a literal "~/.zshrc" string
+        // (not expanded) should not be blocked — we match the $HOME form only.
+        let result = judge_dotfile(true, HOME, "~/.zshrc");
+        assert!(result.is_none(), "literal tilde path should not be matched");
+    }
+
+    // --- Check::run integration (plumbing) ---
+
+    #[test]
+    fn bash_tool_is_not_filtered_by_check() {
+        // guard-dotfiles only watches Edit|Write — Bash must always pass through
+        let input = make_bash("cat ~/.zshrc");
+        let result = GuardDotfiles.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn edit_tool_delegated_to_pure_fn() {
+        // The pure function is tested above; this just verifies the
+        // Check::run plumbing calls it (outcome is Allow because no env var set)
+        let input = make_edit(&zshrc());
+        let result = GuardDotfiles.run(&input);
+        // CADENCE_GUARD_DOTFILES is not set in test env, so should allow
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn write_tool_delegated_to_pure_fn() {
+        let input = make_write(&zshrc(), "# content");
+        let result = GuardDotfiles.run(&input);
+        // CADENCE_GUARD_DOTFILES is not set in test env, so should allow
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+}

--- a/crates/guardrails/src/guard_pr_issue_link.rs
+++ b/crates/guardrails/src/guard_pr_issue_link.rs
@@ -6,16 +6,10 @@
 //! when `--body-file`/`-F` is present, the file's contents are also scanned so
 //! the keyword inside the file is not false-blocked.
 
+use crate::issue_refs::has_closing_keyword;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
-
-// Closing keyword regex — case-insensitive, matches the closing keyword immediately
-// followed by optional whitespace and a #N issue reference.
-static CLOSING_KEYWORD: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+")
-        .expect("closing keyword pattern should compile")
-});
 
 // Matches `--body-file <path>` or `-F <path>` in the command.
 static BODY_FILE_FLAG: LazyLock<Regex> = LazyLock::new(|| {
@@ -49,13 +43,13 @@ pub(crate) fn judge_pr_create(command: &str, body_file_contents: Option<&str>) -
     }
 
     // Check the inline command text for a closing keyword
-    if CLOSING_KEYWORD.is_match(command) {
+    if has_closing_keyword(command) {
         return None;
     }
 
     // Check the body file contents when provided
     if let Some(contents) = body_file_contents {
-        if CLOSING_KEYWORD.is_match(contents) {
+        if has_closing_keyword(contents) {
             return None;
         }
         // Body file was provided but contains no keyword — deny

--- a/crates/guardrails/src/guard_pr_issue_link.rs
+++ b/crates/guardrails/src/guard_pr_issue_link.rs
@@ -1,0 +1,286 @@
+//! Block `gh pr create` when the PR body has no closing keyword linking to an issue.
+//!
+//! Detects `gh pr create` commands and ensures the PR body contains a recognized
+//! closing keyword (`closes`, `fixes`, `resolves` and their variants) followed by
+//! an issue reference (`#N`). Port improvement over the original Bash version:
+//! when `--body-file`/`-F` is present, the file's contents are also scanned so
+//! the keyword inside the file is not false-blocked.
+
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use regex::Regex;
+use std::sync::LazyLock;
+
+// Closing keyword regex — case-insensitive, matches the closing keyword immediately
+// followed by optional whitespace and a #N issue reference.
+static CLOSING_KEYWORD: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(close[sd]?|fix(e[sd])?|resolve[sd]?)\s+#[0-9]+")
+        .expect("closing keyword pattern should compile")
+});
+
+// Matches `--body-file <path>` or `-F <path>` in the command.
+static BODY_FILE_FLAG: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?:--body-file|-F)\s+(\S+)").expect("body-file flag pattern should compile")
+});
+
+/// Extract the path argument from `--body-file <path>` or `-F <path>`.
+///
+/// Pure: no I/O. Returns `None` when neither flag is present.
+pub(crate) fn extract_body_file_path(command: &str) -> Option<String> {
+    BODY_FILE_FLAG
+        .captures(command)
+        .and_then(|caps| caps.get(1))
+        .map(|m| {
+            m.as_str()
+                .trim_matches(|c| c == '"' || c == '\'')
+                .to_string()
+        })
+}
+
+/// Pure decision function. Returns `Some(deny_message)` when the PR should be
+/// blocked, `None` when it should be allowed.
+///
+/// `body_file_contents` carries the body file's text when `--body-file`/`-F` is
+/// present and the file was successfully read; `None` when the flag is absent OR
+/// when the file could not be read (fail-closed in the latter case).
+pub(crate) fn judge_pr_create(command: &str, body_file_contents: Option<&str>) -> Option<String> {
+    // Only guard `gh pr create`
+    if !command.contains("gh pr create") {
+        return None;
+    }
+
+    // Check the inline command text for a closing keyword
+    if CLOSING_KEYWORD.is_match(command) {
+        return None;
+    }
+
+    // Check the body file contents when provided
+    if let Some(contents) = body_file_contents {
+        if CLOSING_KEYWORD.is_match(contents) {
+            return None;
+        }
+        // Body file was provided but contains no keyword — deny
+        return Some(deny_message());
+    }
+
+    // No body-file provided (or it couldn't be read — fail closed): deny
+    Some(deny_message())
+}
+
+fn deny_message() -> String {
+    "🚫 git-guardrails: PR body must include a closing keyword linking to a GitHub Issue\n   \
+     (e.g., 'Closes #123').\n   \
+     Fix: add 'Closes #N', 'Fixes #N', or 'Resolves #N' to the PR body before creating."
+        .to_string()
+}
+
+/// Blocks `gh pr create` when no closing keyword is found in the PR body.
+pub struct PrIssueLinkGuard;
+
+impl Check for PrIssueLinkGuard {
+    fn name(&self) -> &str {
+        "guard-pr-issue-link"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(command) = input.command() else {
+            return CheckResult::allow();
+        };
+
+        // Fast-path: not a gh pr create
+        if !command.contains("gh pr create") {
+            return CheckResult::allow();
+        }
+
+        // Extract --body-file/-F path and try to read the file
+        let body_file_contents: Option<String> =
+            extract_body_file_path(command).and_then(|path| std::fs::read_to_string(&path).ok());
+
+        match judge_pr_create(command, body_file_contents.as_deref()) {
+            Some(msg) => CheckResult::block(msg),
+            None => CheckResult::allow(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::test_builders::make_bash;
+
+    // ---- Pure function tests (judge_pr_create) ----
+
+    // Test case 1: non-gh-pr-create command — allow
+    #[test]
+    fn non_pr_create_command_allowed() {
+        assert!(judge_pr_create("git status", None).is_none());
+    }
+
+    // Test case 2: inline body with "Closes #N" — allow
+    #[test]
+    fn inline_body_closes_allowed() {
+        assert!(judge_pr_create(r#"gh pr create --title x --body "Closes #12""#, None).is_none());
+    }
+
+    // Test case 3: case-insensitive — "fixes #7" — allow
+    #[test]
+    fn inline_body_fixes_lowercase_allowed() {
+        assert!(judge_pr_create(r#"gh pr create --title x --body "fixes #7""#, None).is_none());
+    }
+
+    // Test case 4: "Resolved #9" — allow (resolve[sd]? matches Resolved)
+    #[test]
+    fn inline_body_resolved_allowed() {
+        assert!(judge_pr_create(r#"gh pr create --title x --body "Resolved #9""#, None).is_none());
+    }
+
+    // Test case 5: no closing keyword in inline body — deny
+    #[test]
+    fn inline_body_no_keyword_denied() {
+        assert!(judge_pr_create(r#"gh pr create --title x --body "no link here""#, None).is_some());
+    }
+
+    // Test case 6: --body-file with keyword in file — allow (port improvement)
+    #[test]
+    fn body_file_with_keyword_allowed() {
+        let file_contents = "This PR closes #42 by implementing the feature.";
+        assert!(judge_pr_create("gh pr create -t x -F body.md", Some(file_contents)).is_none());
+    }
+
+    // Test case 6b: --body-file flag present but file unreadable — deny (fail closed)
+    #[test]
+    fn body_file_unreadable_denied() {
+        // body_file_contents = None means the file could not be read
+        // When there's a -F flag but we pass None, judge_pr_create should deny
+        // (this is the fail-closed behavior for unreadable body files)
+        // The command has -F so extract_body_file_path would return Some(path),
+        // but the file read fails, so body_file_contents is None.
+        // judge_pr_create receives None and denies because no keyword in command either.
+        assert!(judge_pr_create("gh pr create -t x -F /nonexistent/body.md", None).is_some());
+    }
+
+    // Test case 7: "#5" without closing keyword — deny
+    #[test]
+    fn bare_issue_reference_without_keyword_denied() {
+        assert!(judge_pr_create(r#"gh pr create --body "see #5""#, None).is_some());
+    }
+
+    // Test case 8: gh pr list — allow
+    #[test]
+    fn gh_pr_list_allowed() {
+        assert!(judge_pr_create("gh pr list", None).is_none());
+    }
+
+    // Extra: long-form --body-file flag with keyword in file — allow
+    #[test]
+    fn long_form_body_file_with_keyword_allowed() {
+        let file_contents = "Fixes #99\n\nDetailed description here.";
+        assert!(
+            judge_pr_create(
+                "gh pr create --title 'fix thing' --body-file body.md",
+                Some(file_contents)
+            )
+            .is_none()
+        );
+    }
+
+    // Extra: body file with no keyword — deny
+    #[test]
+    fn body_file_without_keyword_denied() {
+        let file_contents = "This is a detailed description with no issue link.";
+        assert!(judge_pr_create("gh pr create -t x -F body.md", Some(file_contents)).is_some());
+    }
+
+    // Extra: "Closes" uppercase — allow (case insensitive)
+    #[test]
+    fn closes_uppercase_allowed() {
+        assert!(judge_pr_create(r#"gh pr create --body "CLOSES #10""#, None).is_none());
+    }
+
+    // Extra: "Resolves #N" — allow
+    #[test]
+    fn resolves_allowed() {
+        assert!(judge_pr_create(r#"gh pr create --body "Resolves #88""#, None).is_none());
+    }
+
+    // Extra: "Fixed #N" — allow
+    #[test]
+    fn fixed_allowed() {
+        assert!(judge_pr_create(r#"gh pr create --body "Fixed #3""#, None).is_none());
+    }
+
+    // ---- extract_body_file_path tests (pure parser) ----
+
+    #[test]
+    fn extracts_long_form_body_file_path() {
+        let cmd = "gh pr create --title x --body-file ./my-body.md";
+        assert_eq!(
+            extract_body_file_path(cmd),
+            Some("./my-body.md".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_short_form_body_file_path() {
+        let cmd = "gh pr create -t x -F body.md";
+        assert_eq!(extract_body_file_path(cmd), Some("body.md".to_string()));
+    }
+
+    #[test]
+    fn extracts_body_file_path_strips_quotes() {
+        let cmd = r#"gh pr create --body-file "path/to/body.md""#;
+        assert_eq!(
+            extract_body_file_path(cmd),
+            Some("path/to/body.md".to_string())
+        );
+    }
+
+    #[test]
+    fn returns_none_when_no_body_file_flag() {
+        let cmd = r#"gh pr create --title x --body "Closes #1""#;
+        assert!(extract_body_file_path(cmd).is_none());
+    }
+
+    // ---- Check::run integration tests ----
+
+    #[test]
+    fn check_blocks_pr_create_without_keyword() {
+        let result = PrIssueLinkGuard.run(&make_bash(
+            r#"gh pr create --title "my PR" --body "no issue link""#,
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn check_allows_pr_create_with_keyword() {
+        let result = PrIssueLinkGuard.run(&make_bash(
+            r#"gh pr create --title "my PR" --body "Closes #5""#,
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn check_allows_non_pr_create() {
+        let result = PrIssueLinkGuard.run(&make_bash("git status"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn check_allows_no_command() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: None,
+            cwd: None,
+            ..Default::default()
+        };
+        let result = PrIssueLinkGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn deny_message_includes_fix_line() {
+        let msg = deny_message();
+        assert!(msg.contains("Closes #N"));
+        assert!(msg.contains("Fixes #N"));
+        assert!(msg.contains("Resolves #N"));
+    }
+}

--- a/crates/guardrails/src/guard_pr_issue_link.rs
+++ b/crates/guardrails/src/guard_pr_issue_link.rs
@@ -7,6 +7,7 @@
 //! the keyword inside the file is not false-blocked.
 
 use crate::issue_refs::has_closing_keyword;
+use cadence_hooks_core::shell::strip_quotes;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
@@ -30,38 +31,48 @@ pub(crate) fn extract_body_file_path(command: &str) -> Option<String> {
         })
 }
 
+/// Resolution of the `--body-file`/`-F` flag on a `gh pr create` command.
+#[derive(Debug)]
+pub(crate) enum BodyFile {
+    /// No body-file flag present.
+    Absent,
+    /// Flag present; the file was read successfully.
+    Contents(String),
+    /// Flag present but the file could not be read (race, permissions, path).
+    Unreadable,
+}
+
 /// Pure decision function. Returns `Some(deny_message)` when the PR should be
 /// blocked, `None` when it should be allowed.
-///
-/// `body_file_contents` carries the body file's text when `--body-file`/`-F` is
-/// present and the file was successfully read; `None` when the flag is absent OR
-/// when the file could not be read (fail-closed in the latter case).
-pub(crate) fn judge_pr_create(command: &str, body_file_contents: Option<&str>) -> Option<String> {
-    // Only guard `gh pr create`
-    if !command.contains("gh pr create") {
+pub(crate) fn judge_pr_create(command: &str, body_file: &BodyFile) -> Option<String> {
+    // Only guard `gh pr create`. Strip quoted regions first so text like
+    // `echo "gh pr create ..."` is treated as data, not a command.
+    if !strip_quotes(command).contains("gh pr create") {
         return None;
     }
 
-    // Check the inline command text for a closing keyword
+    // Check the inline command text for a closing keyword. The keyword lives
+    // inside the quoted `--body "..."` string, so this checks the raw command.
     if has_closing_keyword(command) {
         return None;
     }
 
-    // Check the body file contents when provided
-    if let Some(contents) = body_file_contents {
-        if has_closing_keyword(contents) {
-            return None;
-        }
-        // Body file was provided but contains no keyword — deny
-        return Some(deny_message());
+    match body_file {
+        // File read and contains a keyword — allow.
+        BodyFile::Contents(contents) if has_closing_keyword(contents) => None,
+        // File read but no keyword anywhere — deny.
+        BodyFile::Contents(_) => Some(deny_message()),
+        // Flag present but the file could not be read — fail OPEN (ADR-0001).
+        // This is the guard's own verification failure (write/hook race,
+        // permissions, path resolution), not the user's violation.
+        BodyFile::Unreadable => None,
+        // No body file and no keyword in the command — deny.
+        BodyFile::Absent => Some(deny_message()),
     }
-
-    // No body-file provided (or it couldn't be read — fail closed): deny
-    Some(deny_message())
 }
 
 fn deny_message() -> String {
-    "🚫 git-guardrails: PR body must include a closing keyword linking to a GitHub Issue\n   \
+    "🚫 guard-pr-issue-link: PR body must include a closing keyword linking to a GitHub Issue\n   \
      (e.g., 'Closes #123').\n   \
      Fix: add 'Closes #N', 'Fixes #N', or 'Resolves #N' to the PR body before creating."
         .to_string()
@@ -80,16 +91,21 @@ impl Check for PrIssueLinkGuard {
             return CheckResult::allow();
         };
 
-        // Fast-path: not a gh pr create
-        if !command.contains("gh pr create") {
+        // Fast-path: not a gh pr create (quoted occurrences are data, not commands)
+        if !strip_quotes(command).contains("gh pr create") {
             return CheckResult::allow();
         }
 
-        // Extract --body-file/-F path and try to read the file
-        let body_file_contents: Option<String> =
-            extract_body_file_path(command).and_then(|path| std::fs::read_to_string(&path).ok());
+        // Resolve the body file (if any) into the three-state BodyFile.
+        let body_file = match extract_body_file_path(command) {
+            None => BodyFile::Absent,
+            Some(path) => match std::fs::read_to_string(&path) {
+                Ok(contents) => BodyFile::Contents(contents),
+                Err(_) => BodyFile::Unreadable,
+            },
+        };
 
-        match judge_pr_create(command, body_file_contents.as_deref()) {
+        match judge_pr_create(command, &body_file) {
             Some(msg) => CheckResult::block(msg),
             None => CheckResult::allow(),
         }
@@ -106,72 +122,111 @@ mod tests {
     // Test case 1: non-gh-pr-create command — allow
     #[test]
     fn non_pr_create_command_allowed() {
-        assert!(judge_pr_create("git status", None).is_none());
+        assert!(judge_pr_create("git status", &BodyFile::Absent).is_none());
     }
 
     // Test case 2: inline body with "Closes #N" — allow
     #[test]
     fn inline_body_closes_allowed() {
-        assert!(judge_pr_create(r#"gh pr create --title x --body "Closes #12""#, None).is_none());
+        assert!(
+            judge_pr_create(
+                r#"gh pr create --title x --body "Closes #12""#,
+                &BodyFile::Absent
+            )
+            .is_none()
+        );
     }
 
     // Test case 3: case-insensitive — "fixes #7" — allow
     #[test]
     fn inline_body_fixes_lowercase_allowed() {
-        assert!(judge_pr_create(r#"gh pr create --title x --body "fixes #7""#, None).is_none());
+        assert!(
+            judge_pr_create(
+                r#"gh pr create --title x --body "fixes #7""#,
+                &BodyFile::Absent
+            )
+            .is_none()
+        );
     }
 
     // Test case 4: "Resolved #9" — allow (resolve[sd]? matches Resolved)
     #[test]
     fn inline_body_resolved_allowed() {
-        assert!(judge_pr_create(r#"gh pr create --title x --body "Resolved #9""#, None).is_none());
+        assert!(
+            judge_pr_create(
+                r#"gh pr create --title x --body "Resolved #9""#,
+                &BodyFile::Absent
+            )
+            .is_none()
+        );
     }
 
     // Test case 5: no closing keyword in inline body — deny
     #[test]
     fn inline_body_no_keyword_denied() {
-        assert!(judge_pr_create(r#"gh pr create --title x --body "no link here""#, None).is_some());
+        assert!(
+            judge_pr_create(
+                r#"gh pr create --title x --body "no link here""#,
+                &BodyFile::Absent
+            )
+            .is_some()
+        );
     }
 
     // Test case 6: --body-file with keyword in file — allow (port improvement)
     #[test]
     fn body_file_with_keyword_allowed() {
-        let file_contents = "This PR closes #42 by implementing the feature.";
-        assert!(judge_pr_create("gh pr create -t x -F body.md", Some(file_contents)).is_none());
+        let contents = BodyFile::Contents("This PR closes #42 by implementing the feature.".into());
+        assert!(judge_pr_create("gh pr create -t x -F body.md", &contents).is_none());
     }
 
-    // Test case 6b: --body-file flag present but file unreadable — deny (fail closed)
+    // Test case 6b: --body-file flag present but file unreadable — fail OPEN (ADR-0001).
+    // An unreadable file is the guard's own verification failure (write/hook race,
+    // permissions, path resolution) — never block the user on it.
     #[test]
-    fn body_file_unreadable_denied() {
-        // body_file_contents = None means the file could not be read
-        // When there's a -F flag but we pass None, judge_pr_create should deny
-        // (this is the fail-closed behavior for unreadable body files)
-        // The command has -F so extract_body_file_path would return Some(path),
-        // but the file read fails, so body_file_contents is None.
-        // judge_pr_create receives None and denies because no keyword in command either.
-        assert!(judge_pr_create("gh pr create -t x -F /nonexistent/body.md", None).is_some());
+    fn body_file_unreadable_fails_open() {
+        assert!(
+            judge_pr_create(
+                "gh pr create -t x -F /nonexistent/body.md",
+                &BodyFile::Unreadable
+            )
+            .is_none()
+        );
     }
 
     // Test case 7: "#5" without closing keyword — deny
     #[test]
     fn bare_issue_reference_without_keyword_denied() {
-        assert!(judge_pr_create(r#"gh pr create --body "see #5""#, None).is_some());
+        assert!(judge_pr_create(r#"gh pr create --body "see #5""#, &BodyFile::Absent).is_some());
     }
 
     // Test case 8: gh pr list — allow
     #[test]
     fn gh_pr_list_allowed() {
-        assert!(judge_pr_create("gh pr list", None).is_none());
+        assert!(judge_pr_create("gh pr list", &BodyFile::Absent).is_none());
+    }
+
+    // Quoted occurrence: 'gh pr create' inside a quoted string is data, not a
+    // command — must not trigger the guard.
+    #[test]
+    fn quoted_pr_create_text_not_guarded() {
+        assert!(
+            judge_pr_create(
+                r#"echo "gh pr create needs a closing keyword in its body""#,
+                &BodyFile::Absent
+            )
+            .is_none()
+        );
     }
 
     // Extra: long-form --body-file flag with keyword in file — allow
     #[test]
     fn long_form_body_file_with_keyword_allowed() {
-        let file_contents = "Fixes #99\n\nDetailed description here.";
+        let contents = BodyFile::Contents("Fixes #99\n\nDetailed description here.".into());
         assert!(
             judge_pr_create(
                 "gh pr create --title 'fix thing' --body-file body.md",
-                Some(file_contents)
+                &contents
             )
             .is_none()
         );
@@ -180,26 +235,31 @@ mod tests {
     // Extra: body file with no keyword — deny
     #[test]
     fn body_file_without_keyword_denied() {
-        let file_contents = "This is a detailed description with no issue link.";
-        assert!(judge_pr_create("gh pr create -t x -F body.md", Some(file_contents)).is_some());
+        let contents =
+            BodyFile::Contents("This is a detailed description with no issue link.".into());
+        assert!(judge_pr_create("gh pr create -t x -F body.md", &contents).is_some());
     }
 
     // Extra: "Closes" uppercase — allow (case insensitive)
     #[test]
     fn closes_uppercase_allowed() {
-        assert!(judge_pr_create(r#"gh pr create --body "CLOSES #10""#, None).is_none());
+        assert!(
+            judge_pr_create(r#"gh pr create --body "CLOSES #10""#, &BodyFile::Absent).is_none()
+        );
     }
 
     // Extra: "Resolves #N" — allow
     #[test]
     fn resolves_allowed() {
-        assert!(judge_pr_create(r#"gh pr create --body "Resolves #88""#, None).is_none());
+        assert!(
+            judge_pr_create(r#"gh pr create --body "Resolves #88""#, &BodyFile::Absent).is_none()
+        );
     }
 
     // Extra: "Fixed #N" — allow
     #[test]
     fn fixed_allowed() {
-        assert!(judge_pr_create(r#"gh pr create --body "Fixed #3""#, None).is_none());
+        assert!(judge_pr_create(r#"gh pr create --body "Fixed #3""#, &BodyFile::Absent).is_none());
     }
 
     // ---- extract_body_file_path tests (pure parser) ----
@@ -258,6 +318,15 @@ mod tests {
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
+    // Check::run with an unreadable body file — fail open end-to-end.
+    #[test]
+    fn check_allows_unreadable_body_file() {
+        let result = PrIssueLinkGuard.run(&make_bash(
+            "gh pr create -t x --body-file /nonexistent/dir/body-that-cannot-exist.md",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
     #[test]
     fn check_allows_no_command() {
         let input = HookInput {
@@ -276,5 +345,16 @@ mod tests {
         assert!(msg.contains("Closes #N"));
         assert!(msg.contains("Fixes #N"));
         assert!(msg.contains("Resolves #N"));
+    }
+
+    // The deny message names this check (not the legacy plugin name) so a
+    // blocked user can find the responsible guard.
+    #[test]
+    fn deny_message_names_the_check() {
+        let msg = deny_message();
+        assert!(
+            msg.contains("guard-pr-issue-link:"),
+            "deny message should name the check, got: {msg}"
+        );
     }
 }

--- a/crates/guardrails/src/guard_pr_issue_link.rs
+++ b/crates/guardrails/src/guard_pr_issue_link.rs
@@ -7,28 +7,30 @@
 //! the keyword inside the file is not false-blocked.
 
 use crate::issue_refs::has_closing_keyword;
-use cadence_hooks_core::shell::strip_quotes;
+use cadence_hooks_core::shell::{strip_quotes, tokenize};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
-use regex::Regex;
-use std::sync::LazyLock;
 
-// Matches `--body-file <path>` or `-F <path>` in the command. Quote-aware:
-// double-quoted and single-quoted paths (which may contain spaces) are
-// captured whole; bare paths capture up to the next whitespace.
-static BODY_FILE_FLAG: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r#"(?:--body-file|-F)\s+(?:"([^"]+)"|'([^']+)'|(\S+))"#)
-        .expect("body-file flag pattern should compile")
-});
-
-/// Extract the path argument from `--body-file <path>` or `-F <path>`.
+/// Extract the path argument from `--body-file <path>`, `--body-file=<path>`,
+/// or `-F <path>`.
 ///
-/// Pure: no I/O. Returns `None` when neither flag is present.
+/// Pure: no I/O. Returns `None` when no body-file flag is present.
+///
+/// Operates on shell tokens, not the raw string, so flag-looking text inside
+/// quoted arguments (`--body "see --body-file foo"`) is data, never a flag —
+/// a raw regex scan there would conjure a phantom unreadable file and fail
+/// the guard open.
 pub(crate) fn extract_body_file_path(command: &str) -> Option<String> {
-    let caps = BODY_FILE_FLAG.captures(command)?;
-    caps.get(1)
-        .or_else(|| caps.get(2))
-        .or_else(|| caps.get(3))
-        .map(|m| m.as_str().to_string())
+    let tokens = tokenize(command);
+    let mut iter = tokens.into_iter();
+    while let Some(token) = iter.next() {
+        if token == "--body-file" || token == "-F" {
+            return iter.next();
+        }
+        if let Some(path) = token.strip_prefix("--body-file=") {
+            return Some(path.to_string());
+        }
+    }
+    None
 }
 
 /// Resolution of the `--body-file`/`-F` flag on a `gh pr create` command.
@@ -294,6 +296,30 @@ mod tests {
         assert!(extract_body_file_path(cmd).is_none());
     }
 
+    // `--body-file` appearing inside quoted body text is data, not a flag.
+    // Treating it as a flag turns the phantom (unreadable) path into a
+    // fail-open bypass: no keyword anywhere, yet the PR is allowed.
+    #[test]
+    fn quoted_body_text_mentioning_body_file_is_not_a_flag() {
+        let cmd = r#"gh pr create --title x --body "see --body-file foo""#;
+        assert!(extract_body_file_path(cmd).is_none());
+    }
+
+    #[test]
+    fn quoted_body_text_mentioning_short_flag_is_not_a_flag() {
+        let cmd = r#"gh pr create --title x --body "pass -F notes.md to gh""#;
+        assert!(extract_body_file_path(cmd).is_none());
+    }
+
+    // gh accepts `--body-file=path` — must resolve the same as the spaced form,
+    // otherwise the flag goes undetected and a keyword-bearing file is ignored
+    // (false block).
+    #[test]
+    fn extracts_equals_form_body_file_path() {
+        let cmd = "gh pr create --title x --body-file=./body.md";
+        assert_eq!(extract_body_file_path(cmd), Some("./body.md".to_string()));
+    }
+
     // Quoted paths containing spaces must be captured whole — truncating at the
     // first space makes the file unreadable, and the fail-open path would then
     // let an unverified PR through.
@@ -337,6 +363,16 @@ mod tests {
     fn check_allows_non_pr_create() {
         let result = PrIssueLinkGuard.run(&make_bash("git status"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // End-to-end: quoted body text mentioning --body-file must NOT become a
+    // phantom unreadable file (which would fail open). No keyword → block.
+    #[test]
+    fn check_blocks_quoted_body_file_mention_without_keyword() {
+        let result = PrIssueLinkGuard.run(&make_bash(
+            r#"gh pr create --title x --body "see --body-file foo""#,
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     // Check::run with an unreadable body file — fail open end-to-end.

--- a/crates/guardrails/src/guard_pr_issue_link.rs
+++ b/crates/guardrails/src/guard_pr_issue_link.rs
@@ -12,23 +12,23 @@ use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
 
-// Matches `--body-file <path>` or `-F <path>` in the command.
+// Matches `--body-file <path>` or `-F <path>` in the command. Quote-aware:
+// double-quoted and single-quoted paths (which may contain spaces) are
+// captured whole; bare paths capture up to the next whitespace.
 static BODY_FILE_FLAG: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?:--body-file|-F)\s+(\S+)").expect("body-file flag pattern should compile")
+    Regex::new(r#"(?:--body-file|-F)\s+(?:"([^"]+)"|'([^']+)'|(\S+))"#)
+        .expect("body-file flag pattern should compile")
 });
 
 /// Extract the path argument from `--body-file <path>` or `-F <path>`.
 ///
 /// Pure: no I/O. Returns `None` when neither flag is present.
 pub(crate) fn extract_body_file_path(command: &str) -> Option<String> {
-    BODY_FILE_FLAG
-        .captures(command)
-        .and_then(|caps| caps.get(1))
-        .map(|m| {
-            m.as_str()
-                .trim_matches(|c| c == '"' || c == '\'')
-                .to_string()
-        })
+    let caps = BODY_FILE_FLAG.captures(command)?;
+    caps.get(1)
+        .or_else(|| caps.get(2))
+        .or_else(|| caps.get(3))
+        .map(|m| m.as_str().to_string())
 }
 
 /// Resolution of the `--body-file`/`-F` flag on a `gh pr create` command.
@@ -292,6 +292,27 @@ mod tests {
     fn returns_none_when_no_body_file_flag() {
         let cmd = r#"gh pr create --title x --body "Closes #1""#;
         assert!(extract_body_file_path(cmd).is_none());
+    }
+
+    // Quoted paths containing spaces must be captured whole — truncating at the
+    // first space makes the file unreadable, and the fail-open path would then
+    // let an unverified PR through.
+    #[test]
+    fn extracts_double_quoted_path_with_spaces() {
+        let cmd = r#"gh pr create -F "docs/pr bodies/body.md""#;
+        assert_eq!(
+            extract_body_file_path(cmd),
+            Some("docs/pr bodies/body.md".to_string())
+        );
+    }
+
+    #[test]
+    fn extracts_single_quoted_path_with_spaces() {
+        let cmd = "gh pr create --body-file 'my body files/pr.md'";
+        assert_eq!(
+            extract_body_file_path(cmd),
+            Some("my body files/pr.md".to_string())
+        );
     }
 
     // ---- Check::run integration tests ----

--- a/crates/guardrails/src/issue_refs.rs
+++ b/crates/guardrails/src/issue_refs.rs
@@ -13,7 +13,9 @@ use std::sync::LazyLock;
 /// Matches: closes, closed, close, fixes, fixed, fix, resolves, resolved, resolve.
 /// Case-insensitive; captures the digit string after `#`.
 static CLOSING_KW_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([0-9]+)")
+    // Word boundaries keep substring hits ("discloses", "prefixes") from
+    // counting as closing keywords.
+    Regex::new(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s+#([0-9]+)\b")
         .expect("pattern should compile")
 });
 
@@ -61,6 +63,15 @@ mod tests {
     fn has_closing_keyword_rejects_bare_refs() {
         assert!(!has_closing_keyword("see #9 for context"));
         assert!(!has_closing_keyword("no reference at all"));
+    }
+
+    #[test]
+    fn does_not_match_keyword_inside_larger_word() {
+        // "discloses", "prefixes", "unresolves" contain closing keywords as
+        // substrings — they are not closing references.
+        assert!(!has_closing_keyword("this discloses #2 publicly"));
+        assert!(!has_closing_keyword("prefixes #3 with a dash"));
+        assert!(extract_refs("discloses #2 and prefixes #3").is_empty());
     }
 
     #[test]

--- a/crates/guardrails/src/issue_refs.rs
+++ b/crates/guardrails/src/issue_refs.rs
@@ -1,0 +1,80 @@
+//! Shared closing-keyword detection for GitHub issue references.
+//!
+//! Both `guard_pr_issue_link` (boolean: does the PR body link an issue?) and
+//! `verify_pr_autoclose` (extraction: which issues does it close?) recognize
+//! the same GitHub closing keywords. One regex serves both so the pattern
+//! cannot drift between guards.
+
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Regex for issue-closing keywords followed by a `#<number>` ref.
+///
+/// Matches: closes, closed, close, fixes, fixed, fix, resolves, resolved, resolve.
+/// Case-insensitive; captures the digit string after `#`.
+static CLOSING_KW_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([0-9]+)")
+        .expect("pattern should compile")
+});
+
+/// True when `text` contains at least one closing-keyword issue reference.
+pub fn has_closing_keyword(text: &str) -> bool {
+    CLOSING_KW_RE.is_match(text)
+}
+
+/// Extract sorted, deduplicated issue numbers from closing-keyword references.
+///
+/// Finds all `closes #N`, `fixes #N`, `resolves #N` (and inflected variants),
+/// case-insensitively. Returns issue numbers sorted ascending with duplicates removed.
+pub fn extract_refs(text: &str) -> Vec<u64> {
+    let mut nums: Vec<u64> = CLOSING_KW_RE
+        .captures_iter(text)
+        .filter_map(|cap| cap.get(1)?.as_str().parse::<u64>().ok())
+        .collect();
+    nums.sort_unstable();
+    nums.dedup();
+    nums
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn has_closing_keyword_matches_all_variants() {
+        for text in [
+            "Closes #1",
+            "closed #2",
+            "close #3",
+            "Fixes #4",
+            "fixed #5",
+            "fix #6",
+            "Resolves #7",
+            "resolved #8",
+            "resolve #9",
+        ] {
+            assert!(has_closing_keyword(text), "should match: {text}");
+        }
+    }
+
+    #[test]
+    fn has_closing_keyword_rejects_bare_refs() {
+        assert!(!has_closing_keyword("see #9 for context"));
+        assert!(!has_closing_keyword("no reference at all"));
+    }
+
+    #[test]
+    fn extract_refs_and_has_closing_keyword_agree() {
+        // The boolean and the extraction views of the same regex must agree.
+        let with_refs = "Closes #12 and fixes #3";
+        let without = "related to #4";
+        assert_eq!(
+            has_closing_keyword(with_refs),
+            !extract_refs(with_refs).is_empty()
+        );
+        assert_eq!(
+            has_closing_keyword(without),
+            !extract_refs(without).is_empty()
+        );
+    }
+}

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -19,6 +19,8 @@ pub mod guard_git_init;
 pub mod guard_pr_issue_link;
 /// Block `git push` to remotes owned by others.
 pub mod guard_push_remote;
+/// Shared closing-keyword detection for GitHub issue references.
+pub mod issue_refs;
 /// Nudge to schedule a brew upgrade after pushing cadence-hooks to main.
 pub mod nudge_upgrade_after_push;
 /// Warn about broken issue refs on PR create; close straggler issues on PR merge.

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -7,6 +7,8 @@
 pub mod check_idle_return;
 /// Per-repo snooze command + helper consumed by `warn_main_branch`.
 pub mod dismiss_main_branch_warn;
+/// Block direct edits to production dotfiles; redirect to chezmoi source.
+pub mod guard_dotfiles;
 /// Block irreversible `gh` operations (repo delete).
 pub mod guard_gh_dangerous;
 /// Block `gh` write operations targeting repos you don't own.

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -15,6 +15,8 @@ pub mod guard_gh_dangerous;
 pub mod guard_gh_write;
 /// Nudge to scaffold project standards after `git init`.
 pub mod guard_git_init;
+/// Block `gh pr create` when the PR body has no closing keyword linking to an issue.
+pub mod guard_pr_issue_link;
 /// Block `git push` to remotes owned by others.
 pub mod guard_push_remote;
 /// Nudge to schedule a brew upgrade after pushing cadence-hooks to main.

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -21,6 +21,8 @@ pub mod guard_pr_issue_link;
 pub mod guard_push_remote;
 /// Nudge to schedule a brew upgrade after pushing cadence-hooks to main.
 pub mod nudge_upgrade_after_push;
+/// Warn about broken issue refs on PR create; close straggler issues on PR merge.
+pub mod verify_pr_autoclose;
 /// Warn when creating a branch from a non-main base.
 pub mod warn_branch_base;
 /// Remind to check datetime before scheduling cron jobs.

--- a/crates/guardrails/src/verify_pr_autoclose.rs
+++ b/crates/guardrails/src/verify_pr_autoclose.rs
@@ -220,8 +220,9 @@ pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) -> Option<Stri
 
 /// Close straggler issues that GitHub's auto-close missed after a PR merge.
 ///
-/// Waits `wait_secs` (injected via `clock`) to give GitHub time to auto-close,
-/// then checks each referenced issue. If still OPEN, closes it via `gh issue close`
+/// Reads the merged PR's body and, only when it references issues, waits
+/// `wait_secs` (injected via `clock`) to give GitHub time to auto-close, then
+/// checks each referenced issue. If still OPEN, closes it via `gh issue close`
 /// with a commit-citing comment. Returns a summary message naming the closed
 /// issues, or `None` when there was nothing to do. The caller routes the
 /// message through `CheckResult::nudge` so Claude sees it.
@@ -243,9 +244,8 @@ pub fn handle_merge(
         }
     };
 
-    clock.sleep_secs(wait_secs);
-
-    // Fetch body + mergeCommit
+    // Fetch body + mergeCommit first — the merged PR's body doesn't change,
+    // so there's no need to wait before reading it.
     let pr_json = gh.run(&[
         "pr",
         "view",
@@ -275,6 +275,10 @@ pub fn handle_merge(
         return None;
     }
 
+    // Only now pay the auto-close wait: there are refs to verify, and GitHub
+    // needs time to fire its own auto-close before we check issue states.
+    clock.sleep_secs(wait_secs);
+
     let short_sha = if merge_sha.len() >= 7 {
         &merge_sha[..7]
     } else {
@@ -283,6 +287,9 @@ pub fn handle_merge(
 
     let mut closed: Vec<String> = Vec::new();
 
+    // One `gh issue view` per ref. Refs per PR are typically 1-2 and this path
+    // already waited `wait_secs` — batching via GraphQL isn't worth the extra
+    // I/O-seam complexity.
     for issue in &refs {
         if fetch_issue_state(gh, *issue, slug) != IssueState::Open {
             continue;
@@ -756,6 +763,25 @@ mod tests {
         assert!(
             clock.sleep_calls.borrow().is_empty(),
             "should not sleep when PR number unresolvable"
+        );
+        assert!(gh.close_calls.borrow().is_empty());
+    }
+
+    // A merge whose PR body has no closing-keyword refs has nothing to verify —
+    // the auto-close wait must not be paid (it stalls the session for wait_secs).
+    #[test]
+    fn merge_body_without_refs_skips_sleep() {
+        let gh = FakeGh::new()
+            .with_pr_body("routine maintenance, no issue references")
+            .with_merge_commit("abc1234def456");
+
+        let clock = FakeClock::new();
+        let msg = handle_merge("owner/repo", "gh pr merge 9 --squash", &gh, &clock, 10);
+
+        assert_eq!(msg, None);
+        assert!(
+            clock.sleep_calls.borrow().is_empty(),
+            "no refs to verify — the auto-close wait should be skipped"
         );
         assert!(gh.close_calls.borrow().is_empty());
     }

--- a/crates/guardrails/src/verify_pr_autoclose.rs
+++ b/crates/guardrails/src/verify_pr_autoclose.rs
@@ -103,8 +103,9 @@ impl GhRunner for RealGhRunner {
         if !output.status.success() {
             return None;
         }
-        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
-        (!s.is_empty()).then_some(s)
+        // Success with empty stdout is still success — `gh issue close` writes
+        // its confirmation to stderr, so an empty stdout must not read as failure.
+        Some(String::from_utf8_lossy(&output.stdout).trim().to_string())
     }
 }
 

--- a/crates/guardrails/src/verify_pr_autoclose.rs
+++ b/crates/guardrails/src/verify_pr_autoclose.rs
@@ -1,0 +1,859 @@
+//! Advisory check: warn about broken issue refs on `gh pr create`; close
+//! straggler issues on `gh pr merge` that GitHub's auto-close didn't fire for.
+//!
+//! PostToolUse Bash hook — **always exit 0** (never blocks). Side-effecting:
+//! `handle_merge` may close open issues via `gh issue close`.
+//!
+//! Config knob: `GH_AUTOCLOSE_WAIT_SECONDS` (default `10`).
+
+use cadence_hooks_core::shell::{git_command, host_and_repo_from_url};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use regex::Regex;
+use std::sync::LazyLock;
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+/// Regex for issue-closing keywords followed by a `#<number>` ref.
+///
+/// Matches: closes, closed, close, fixes, fixed, fix, resolves, resolved, resolve
+/// Case-insensitive; captures the digit string after `#`.
+static CLOSING_KW_RE: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([0-9]+)")
+        .expect("pattern should compile")
+});
+
+/// Extract sorted, deduplicated issue numbers from closing-keyword references.
+///
+/// Finds all `closes #N`, `fixes #N`, `resolves #N` (and inflected variants),
+/// case-insensitively. Returns issue numbers sorted ascending with duplicates removed.
+pub fn extract_refs(text: &str) -> Vec<u64> {
+    let mut nums: Vec<u64> = CLOSING_KW_RE
+        .captures_iter(text)
+        .filter_map(|cap| cap.get(1)?.as_str().parse::<u64>().ok())
+        .collect();
+    nums.sort_unstable();
+    nums.dedup();
+    nums
+}
+
+/// Parse a git remote URL into `(host, "owner/repo")`.
+///
+/// Returns:
+/// - `Some((None, slug))` for public GitHub (`github.com`)
+/// - `Some((Some(host), slug))` for enterprise GitHub hosts
+/// - `None` for local paths or unparseable URLs
+///
+/// Delegates to `host_and_repo_from_url` for URL parsing, which correctly
+/// strips `.git` suffixes and handles dots in repo names.
+pub fn parse_remote(url: &str) -> Option<(Option<String>, String)> {
+    let (host, slug) = host_and_repo_from_url(url)?;
+    if host == "github.com" {
+        Some((None, slug))
+    } else {
+        Some((Some(host), slug))
+    }
+}
+
+/// Extract the PR number from `gh pr create` stdout.
+///
+/// Looks for the first `/pull/<N>` URL in the output (the URL `gh` prints on success).
+pub fn pr_number_from_create_stdout(stdout: &str) -> Option<u64> {
+    static RE: LazyLock<Regex> =
+        LazyLock::new(|| Regex::new(r"/pull/([0-9]+)").expect("pattern should compile"));
+    RE.captures(stdout)?.get(1)?.as_str().parse().ok()
+}
+
+/// Extract the PR number from a `gh pr merge` command string.
+///
+/// Looks for the first bare integer token after `gh pr merge`. Returns `None`
+/// when no number is present (bare `gh pr merge --squash` falls back to the
+/// current-branch PR at runtime).
+pub fn pr_number_from_merge_cmd(cmd: &str) -> Option<u64> {
+    // Find "gh pr merge" then scan tokens after it for a bare integer
+    let after = cmd.split("gh pr merge").nth(1)?;
+    for token in after.split_whitespace() {
+        if token.starts_with('-') {
+            continue;
+        }
+        if let Ok(n) = token.parse::<u64>() {
+            return Some(n);
+        }
+        // First non-flag, non-integer token → stop (e.g. a branch name)
+        break;
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// I/O traits (injected for testability)
+// ---------------------------------------------------------------------------
+
+/// Runs `gh` CLI commands, returning trimmed stdout on success or `None` on error.
+pub trait GhRunner {
+    fn run(&self, args: &[&str]) -> Option<String>;
+}
+
+/// Sleeps for a given number of seconds (injectable so tests don't actually sleep).
+pub trait Clock {
+    fn sleep_secs(&self, secs: u64);
+}
+
+// ---------------------------------------------------------------------------
+// Real I/O implementations
+// ---------------------------------------------------------------------------
+
+/// Production `gh` runner: shells out to the system `gh` binary.
+pub struct RealGhRunner;
+
+impl GhRunner for RealGhRunner {
+    fn run(&self, args: &[&str]) -> Option<String> {
+        let output = std::process::Command::new("gh").args(args).output().ok()?;
+        if output.status.success() {
+            let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if s.is_empty() { None } else { Some(s) }
+        } else {
+            None
+        }
+    }
+}
+
+/// Production clock: delegates to `std::thread::sleep`.
+pub struct RealClock;
+
+impl Clock for RealClock {
+    fn sleep_secs(&self, secs: u64) {
+        std::thread::sleep(std::time::Duration::from_secs(secs));
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handle-create flow
+// ---------------------------------------------------------------------------
+
+/// Issue state as returned by `gh issue view --json state`.
+#[derive(Debug, PartialEq, Eq)]
+enum IssueState {
+    Open,
+    Closed,
+    Missing,
+}
+
+/// Parse the state string from `gh issue view --json state -q .state`.
+fn parse_issue_state(raw: Option<String>) -> IssueState {
+    match raw.as_deref() {
+        Some("OPEN") => IssueState::Open,
+        Some("CLOSED") => IssueState::Closed,
+        _ => IssueState::Missing,
+    }
+}
+
+/// Fetch and classify the state of a single issue.
+fn fetch_issue_state(gh: &dyn GhRunner, issue: u64, slug: &str) -> IssueState {
+    let raw = gh.run(&[
+        "issue",
+        "view",
+        &issue.to_string(),
+        "--json",
+        "state",
+        "-q",
+        ".state",
+        "-R",
+        slug,
+    ]);
+    parse_issue_state(raw)
+}
+
+/// Warn about broken issue references in a newly-created PR.
+///
+/// Fetches the PR body, extracts closing-keyword refs, and warns to stderr
+/// for any ref that is CLOSED (auto-close can't re-fire) or MISSING (not found).
+/// Silent on the happy path (all refs OPEN, or no refs at all).
+pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) {
+    let Some(pr_num) = pr_number_from_create_stdout(stdout) else {
+        return;
+    };
+
+    // Fetch the PR body as JSON then extract the body field
+    let body_json = match gh.run(&[
+        "pr",
+        "view",
+        &pr_num.to_string(),
+        "--json",
+        "body",
+        "-R",
+        slug,
+    ]) {
+        Some(j) => j,
+        None => return,
+    };
+
+    // Parse body from JSON: {"body":"..."} — use serde_json for correctness
+    let body: String = match serde_json::from_str::<serde_json::Value>(&body_json) {
+        Ok(v) => v
+            .get("body")
+            .and_then(serde_json::Value::as_str)
+            .unwrap_or("")
+            .to_string(),
+        Err(_) => body_json, // fall back to raw if not JSON
+    };
+
+    let refs = extract_refs(&body);
+    if refs.is_empty() {
+        return;
+    }
+
+    let mut warnings: Vec<String> = Vec::new();
+    for issue in &refs {
+        match fetch_issue_state(gh, *issue, slug) {
+            IssueState::Open => {} // happy path
+            IssueState::Closed => {
+                warnings.push(format!(
+                    "  - #{issue} already CLOSED — auto-close cannot re-fire"
+                ));
+            }
+            IssueState::Missing => {
+                warnings.push(format!("  - #{issue} not found in {slug}"));
+            }
+        }
+    }
+
+    if !warnings.is_empty() {
+        eprintln!(
+            "verify-pr-autoclose: PR #{pr_num} has broken references:\n{}",
+            warnings.join("\n")
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handle-merge flow
+// ---------------------------------------------------------------------------
+
+/// Close straggler issues that GitHub's auto-close missed after a PR merge.
+///
+/// Waits `wait_secs` (injected via `clock`) to give GitHub time to auto-close,
+/// then checks each referenced issue. If still OPEN, closes it via `gh issue close`
+/// with a commit-citing comment. Reports closed issues to stderr.
+pub fn handle_merge(slug: &str, cmd: &str, gh: &dyn GhRunner, clock: &dyn Clock, wait_secs: u64) {
+    // Resolve PR number: from command or from `gh pr view`
+    let pr_num = match pr_number_from_merge_cmd(cmd) {
+        Some(n) => n,
+        None => {
+            let raw = gh.run(&[
+                "pr", "view", "--json", "number", "-q", ".number", "-R", slug,
+            ]);
+            match raw.and_then(|s| s.parse::<u64>().ok()) {
+                Some(n) => n,
+                None => return,
+            }
+        }
+    };
+
+    clock.sleep_secs(wait_secs);
+
+    // Fetch body + mergeCommit
+    let pr_json = match gh.run(&[
+        "pr",
+        "view",
+        &pr_num.to_string(),
+        "--json",
+        "body,mergeCommit",
+        "-R",
+        slug,
+    ]) {
+        Some(j) => j,
+        None => return,
+    };
+
+    let value: serde_json::Value = match serde_json::from_str(&pr_json) {
+        Ok(v) => v,
+        Err(_) => return,
+    };
+
+    let body = value
+        .get("body")
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("")
+        .to_string();
+
+    let merge_sha = value
+        .get("mergeCommit")
+        .and_then(|mc: &serde_json::Value| mc.get("oid"))
+        .and_then(serde_json::Value::as_str)
+        .unwrap_or("");
+
+    let refs = extract_refs(&body);
+    if refs.is_empty() {
+        return;
+    }
+
+    let short_sha = if merge_sha.len() >= 7 {
+        &merge_sha[..7]
+    } else {
+        merge_sha
+    };
+
+    let mut closed: Vec<String> = Vec::new();
+
+    for issue in &refs {
+        if fetch_issue_state(gh, *issue, slug) != IssueState::Open {
+            continue;
+        }
+
+        let comment =
+            format!("Closed via PR #{pr_num} (commit {short_sha}) — auto-close didn't fire.");
+
+        let ok = gh
+            .run(&[
+                "issue",
+                "close",
+                &issue.to_string(),
+                "-R",
+                slug,
+                "--comment",
+                &comment,
+            ])
+            .is_some();
+
+        if ok {
+            closed.push(format!("#{issue}"));
+        }
+    }
+
+    if !closed.is_empty() {
+        eprintln!(
+            "verify-pr-autoclose: closed {} straggler issue(s) for PR #{pr_num}: {}",
+            closed.len(),
+            closed.join(", ")
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Check implementation
+// ---------------------------------------------------------------------------
+
+/// Advisory check for PR auto-close behaviour.
+///
+/// On `gh pr create`: warns about broken/already-closed issue refs in the PR body.
+/// On `gh pr merge`: waits briefly, then closes any straggler issues that GitHub
+/// missed, citing the merge commit.
+///
+/// Always exits 0 — never blocks.
+pub struct VerifyPrAutoclose;
+
+impl Check for VerifyPrAutoclose {
+    fn name(&self) -> &str {
+        "verify-pr-autoclose"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(cmd) = input.command() else {
+            return CheckResult::allow();
+        };
+
+        // Resolve working directory
+        let cwd_fallback = std::env::current_dir()
+            .ok()
+            .and_then(|p| p.to_str().map(String::from))
+            .unwrap_or_else(|| ".".to_string());
+        let cwd = input.cwd.as_deref().unwrap_or(&cwd_fallback);
+
+        // Get remote URL and parse it
+        let Some(remote_url) = git_command(cwd, &["remote", "get-url", "origin"]) else {
+            return CheckResult::allow();
+        };
+
+        let Some((host, slug)) = parse_remote(&remote_url) else {
+            return CheckResult::allow();
+        };
+
+        // Set GH_HOST for enterprise GitHub
+        if let Some(ref h) = host {
+            // SAFETY: This hook process is single-threaded (one hook fires one check).
+            // No other threads read or write env vars concurrently here.
+            unsafe {
+                std::env::set_var("GH_HOST", h);
+            }
+        }
+
+        let gh = RealGhRunner;
+        let clock = RealClock;
+        let wait_secs: u64 = std::env::var("GH_AUTOCLOSE_WAIT_SECONDS")
+            .ok()
+            .and_then(|s| s.parse().ok())
+            .unwrap_or(10);
+
+        if cmd.contains("gh pr create") {
+            let stdout = input.tool_response_stdout().unwrap_or("");
+            handle_create(&slug, stdout, &gh);
+        } else if cmd.contains("gh pr merge") {
+            handle_merge(&slug, cmd, &gh, &clock, wait_secs);
+        }
+        // else: not a create or merge command — exit 0, no handler invoked
+
+        CheckResult::allow()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::{make_bash, make_bash_post_tool_use};
+    use std::cell::RefCell;
+    use std::collections::HashMap;
+
+    // -----------------------------------------------------------------------
+    // Pure layer tests (cases 1–10)
+    // -----------------------------------------------------------------------
+
+    // Case 1: extract_refs — deduped, sorted, multiple keywords
+    #[test]
+    fn extract_refs_multiple_keywords_deduped_sorted() {
+        let refs = extract_refs("Closes #12 and fixes #3, resolves #12");
+        assert_eq!(refs, vec![3, 12]);
+    }
+
+    // Case 2: extract_refs — no closing keyword → empty
+    #[test]
+    fn extract_refs_no_closing_keyword_is_empty() {
+        let refs = extract_refs("see #9 for context");
+        assert_eq!(refs, Vec::<u64>::new());
+    }
+
+    // Case 3: extract_refs — case-insensitive, deduped
+    #[test]
+    fn extract_refs_case_insensitive_deduped() {
+        let refs = extract_refs("FIXED #7\nCloses #7");
+        assert_eq!(refs, vec![7]);
+    }
+
+    // Case 4: parse_remote — github.com SSH SCP style → host None
+    #[test]
+    fn parse_remote_github_ssh_public() {
+        let result = parse_remote("git@github.com:cameronsjo/cadence-hooks.git");
+        assert_eq!(result, Some((None, "cameronsjo/cadence-hooks".to_string())));
+    }
+
+    // Case 5: parse_remote — enterprise GitHub HTTPS → host Some
+    #[test]
+    fn parse_remote_enterprise_https() {
+        let result = parse_remote("https://gecgithub01.walmart.com/c0s013l/foo.git");
+        assert_eq!(
+            result,
+            Some((
+                Some("gecgithub01.walmart.com".to_string()),
+                "c0s013l/foo".to_string()
+            ))
+        );
+    }
+
+    // Case 6: parse_remote — dots in repo name must be preserved
+    #[test]
+    fn parse_remote_dots_in_repo_name() {
+        let result = parse_remote("git@github.com:owner/repo.with.dots.git");
+        // host_and_repo_from_url strips .git, then takes first two path segments
+        // For SCP: path = "owner/repo.with.dots.git", after strip: "owner/repo.with.dots"
+        // splitn(3, '/') → ["owner", "repo.with.dots"] — dots preserved ✓
+        assert_eq!(result, Some((None, "owner/repo.with.dots".to_string())));
+    }
+
+    // Case 7: parse_remote — local path → None
+    #[test]
+    fn parse_remote_local_path_is_none() {
+        let result = parse_remote("/local/path");
+        assert_eq!(result, None);
+    }
+
+    // Case 8: pr_number_from_create_stdout — extracts from URL
+    #[test]
+    fn pr_number_from_create_stdout_extracts_number() {
+        let stdout = "https://github.com/o/r/pull/42";
+        assert_eq!(pr_number_from_create_stdout(stdout), Some(42));
+    }
+
+    // Case 9: pr_number_from_merge_cmd — number present
+    #[test]
+    fn pr_number_from_merge_cmd_with_number() {
+        assert_eq!(
+            pr_number_from_merge_cmd("gh pr merge 17 --squash"),
+            Some(17)
+        );
+    }
+
+    // Case 10: pr_number_from_merge_cmd — no number → None
+    #[test]
+    fn pr_number_from_merge_cmd_no_number_is_none() {
+        assert_eq!(pr_number_from_merge_cmd("gh pr merge --squash"), None);
+    }
+
+    // -----------------------------------------------------------------------
+    // Fake I/O implementations for shell-flow tests
+    // -----------------------------------------------------------------------
+
+    /// In-memory `gh` runner for tests.
+    ///
+    /// Stores issue states and records calls made to `gh issue close`.
+    struct FakeGh {
+        /// Maps issue number → state string ("OPEN" | "CLOSED")
+        issue_states: HashMap<u64, String>,
+        /// PR body to return for `gh pr view <n> --json body,mergeCommit`
+        pr_body: String,
+        /// PR number to return for bare `gh pr view --json number`
+        pr_number: Option<u64>,
+        /// merge commit OID
+        merge_commit_oid: String,
+        /// Captures `gh issue close` calls: (issue_number, comment)
+        close_calls: RefCell<Vec<(u64, String)>>,
+        /// Captures `gh pr view <n> --json body` calls
+        body_calls: RefCell<Vec<u64>>,
+    }
+
+    impl FakeGh {
+        fn new() -> Self {
+            Self {
+                issue_states: HashMap::new(),
+                pr_body: String::new(),
+                pr_number: None,
+                merge_commit_oid: "abc1234def".to_string(),
+                close_calls: RefCell::new(Vec::new()),
+                body_calls: RefCell::new(Vec::new()),
+            }
+        }
+
+        fn with_issue(mut self, num: u64, state: &str) -> Self {
+            self.issue_states.insert(num, state.to_string());
+            self
+        }
+
+        fn with_pr_body(mut self, body: &str) -> Self {
+            self.pr_body = body.to_string();
+            self
+        }
+
+        fn with_merge_commit(mut self, oid: &str) -> Self {
+            self.merge_commit_oid = oid.to_string();
+            self
+        }
+    }
+
+    impl GhRunner for FakeGh {
+        fn run(&self, args: &[&str]) -> Option<String> {
+            // Match: gh issue view <N> --json state -q .state -R <slug>
+            if args.len() >= 4
+                && args[0] == "issue"
+                && args[1] == "view"
+                && let Ok(num) = args[2].parse::<u64>()
+            {
+                // Check for state vs close subcommand
+                if args.contains(&"state") {
+                    return self.issue_states.get(&num).cloned();
+                }
+            }
+
+            // Match: gh issue close <N> -R <slug> --comment <text>
+            if args.len() >= 2
+                && args[0] == "issue"
+                && args[1] == "close"
+                && let Ok(num) = args[2].parse::<u64>()
+            {
+                // Find comment after --comment flag
+                let comment = args
+                    .windows(2)
+                    .find(|w| w[0] == "--comment")
+                    .map(|w| w[1].to_string())
+                    .unwrap_or_default();
+                self.close_calls.borrow_mut().push((num, comment));
+                return Some("closed".to_string());
+            }
+
+            // Match: gh pr view ... (handle_create, handle_merge, or bare current-branch lookup)
+            if args.len() >= 4 && args[0] == "pr" && args[1] == "view" {
+                match args[2].parse::<u64>() {
+                    Ok(num) => {
+                        // Determine which --json field set was requested
+                        let json_fields = args.windows(2).find(|w| w[0] == "--json").map(|w| w[1]);
+
+                        match json_fields {
+                            Some("body") => {
+                                // body-only fetch (handle_create)
+                                self.body_calls.borrow_mut().push(num);
+                                let json = serde_json::json!({"body": self.pr_body});
+                                return Some(json.to_string());
+                            }
+                            Some("body,mergeCommit") => {
+                                // body + mergeCommit fetch (handle_merge)
+                                let json = serde_json::json!({
+                                    "body": self.pr_body,
+                                    "mergeCommit": {"oid": self.merge_commit_oid}
+                                });
+                                return Some(json.to_string());
+                            }
+                            _ => {}
+                        }
+                    }
+                    Err(_) => {
+                        // Bare `gh pr view --json number -q .number` (no PR number in args)
+                        if args.contains(&"number") {
+                            return self.pr_number.map(|n| n.to_string());
+                        }
+                    }
+                }
+            }
+
+            None
+        }
+    }
+
+    /// No-op clock for tests — records sleep calls.
+    struct FakeClock {
+        sleep_calls: RefCell<Vec<u64>>,
+    }
+
+    impl FakeClock {
+        fn new() -> Self {
+            Self {
+                sleep_calls: RefCell::new(Vec::new()),
+            }
+        }
+    }
+
+    impl Clock for FakeClock {
+        fn sleep_secs(&self, secs: u64) {
+            self.sleep_calls.borrow_mut().push(secs);
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Shell-flow tests (cases 11–18)
+    // -----------------------------------------------------------------------
+
+    // Case 11: create, body refs #5 (OPEN) → no stderr (test indirectly via no close calls)
+    #[test]
+    fn create_body_refs_open_issue_no_warnings() {
+        let gh = FakeGh::new()
+            .with_issue(5, "OPEN")
+            .with_pr_body("Closes #5");
+
+        // handle_create should silently succeed with no close calls and no panic
+        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+
+        // No warnings means no close calls; body was fetched once
+        assert!(gh.close_calls.borrow().is_empty());
+        assert_eq!(*gh.body_calls.borrow(), vec![1u64]);
+    }
+
+    // Case 12: create, body refs #5 (CLOSED) → warnings logged
+    // (We test via stderr capture indirectly — we verify the function doesn't panic
+    //  and runs the warning path; stderr capture is an integration concern)
+    #[test]
+    fn create_body_refs_closed_issue_emits_warning() {
+        let gh = FakeGh::new()
+            .with_issue(5, "CLOSED")
+            .with_pr_body("Closes #5");
+
+        // Should not panic; state is verified by checking that parse_issue_state(CLOSED)
+        // correctly maps to IssueState::Closed
+        assert_eq!(
+            parse_issue_state(Some("CLOSED".to_string())),
+            IssueState::Closed
+        );
+
+        // handle_create runs the warning path — we verify it completes without panic
+        // and that no close calls are made (warnings only, no mutation)
+        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+        assert!(gh.close_calls.borrow().is_empty());
+    }
+
+    // Case 13: create, body refs #99 (missing) → warns "not found"
+    #[test]
+    fn create_body_refs_missing_issue_emits_warning() {
+        let gh = FakeGh::new()
+            // issue 99 not in map → gh returns None → Missing state
+            .with_pr_body("Closes #99");
+
+        assert_eq!(parse_issue_state(None), IssueState::Missing);
+
+        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+        assert!(gh.close_calls.borrow().is_empty());
+    }
+
+    // Case 14: create, body has no refs → no body fetch calls after the initial one
+    #[test]
+    fn create_body_no_refs_returns_early() {
+        let gh = FakeGh::new().with_pr_body("This PR is purely cosmetic.");
+
+        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+
+        // Body was fetched but no issue state calls and no close calls
+        assert!(gh.close_calls.borrow().is_empty());
+        // No issue state calls because refs list is empty
+        assert_eq!(*gh.body_calls.borrow(), vec![1u64]);
+    }
+
+    // Case 15: merge #8, body refs #5 OPEN → closes #5 with correct comment
+    #[test]
+    fn merge_open_issue_gets_closed_with_commit_citation() {
+        let gh = FakeGh::new()
+            .with_issue(5, "OPEN")
+            .with_pr_body("Closes #5")
+            .with_merge_commit("abc1234def456");
+
+        let clock = FakeClock::new();
+        handle_merge("owner/repo", "gh pr merge 8 --squash", &gh, &clock, 0);
+
+        let calls = gh.close_calls.borrow();
+        assert_eq!(calls.len(), 1, "should close issue #5");
+        let (num, comment) = &calls[0];
+        assert_eq!(*num, 5);
+        assert!(
+            comment.contains("PR #8"),
+            "comment should cite PR number: {comment}"
+        );
+        assert!(
+            comment.contains("abc1234"),
+            "comment should cite short commit SHA: {comment}"
+        );
+    }
+
+    // Case 16: merge #8, body refs #5 already CLOSED → no close call
+    #[test]
+    fn merge_already_closed_issue_skipped() {
+        let gh = FakeGh::new()
+            .with_issue(5, "CLOSED")
+            .with_pr_body("Closes #5")
+            .with_merge_commit("abc1234def456");
+
+        let clock = FakeClock::new();
+        handle_merge("owner/repo", "gh pr merge 8 --squash", &gh, &clock, 0);
+
+        assert!(
+            gh.close_calls.borrow().is_empty(),
+            "should not close already-closed issue"
+        );
+    }
+
+    // Case 17: merge, no PR number resolvable → return early, no sleep
+    #[test]
+    fn merge_no_pr_number_returns_early_no_sleep() {
+        let gh = FakeGh::new(); // pr_number is None by default
+
+        let clock = FakeClock::new();
+        handle_merge(
+            "owner/repo",
+            "gh pr merge --squash", // no number in cmd
+            &gh,
+            &clock,
+            10,
+        );
+
+        // No sleep should have been called because we return before sleeping
+        assert!(
+            clock.sleep_calls.borrow().is_empty(),
+            "should not sleep when PR number unresolvable"
+        );
+        assert!(gh.close_calls.borrow().is_empty());
+    }
+
+    // Case 18: cmd is neither create nor merge → Check::run allows, no handler invoked
+    // (Tested via the Check trait — we verify allow() is returned for unrelated commands)
+    #[test]
+    fn unrelated_command_returns_allow() {
+        let input = make_bash("git status");
+        // We can't call VerifyPrAutoclose::run here because it hits git remote.
+        // Instead test the logic path: if cmd doesn't contain "gh pr create" or "gh pr merge",
+        // neither handler is invoked. We verify this via pr_number_from_create_stdout
+        // and pr_number_from_merge_cmd returning None for unrelated commands.
+        assert_eq!(pr_number_from_create_stdout("git status output"), None);
+        assert_eq!(pr_number_from_merge_cmd("git status"), None);
+
+        // Additionally verify the Check returns allow (the guard is the top-level command check)
+        // This will attempt git remote; if not in a git repo → allow
+        let result = VerifyPrAutoclose.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // -----------------------------------------------------------------------
+    // Additional pure-helper edge cases
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn extract_refs_all_variants() {
+        let text = "close #1 closed #2 closes #3 fix #4 fixed #5 fixes #6 resolve #7 resolved #8 resolves #9";
+        let refs = extract_refs(text);
+        assert_eq!(refs, vec![1, 2, 3, 4, 5, 6, 7, 8, 9]);
+    }
+
+    #[test]
+    fn extract_refs_empty_string() {
+        assert_eq!(extract_refs(""), Vec::<u64>::new());
+    }
+
+    #[test]
+    fn pr_number_from_create_stdout_no_url_is_none() {
+        assert_eq!(pr_number_from_create_stdout("Created pull request"), None);
+    }
+
+    #[test]
+    fn pr_number_from_merge_cmd_flags_only() {
+        // --squash and --delete-branch are flags, not a number
+        assert_eq!(
+            pr_number_from_merge_cmd("gh pr merge --squash --delete-branch"),
+            None
+        );
+    }
+
+    #[test]
+    fn parse_remote_github_https() {
+        let result = parse_remote("https://github.com/cameronsjo/cadence-hooks.git");
+        assert_eq!(result, Some((None, "cameronsjo/cadence-hooks".to_string())));
+    }
+
+    #[test]
+    fn parse_issue_state_open() {
+        assert_eq!(
+            parse_issue_state(Some("OPEN".to_string())),
+            IssueState::Open
+        );
+    }
+
+    #[test]
+    fn parse_issue_state_closed() {
+        assert_eq!(
+            parse_issue_state(Some("CLOSED".to_string())),
+            IssueState::Closed
+        );
+    }
+
+    #[test]
+    fn parse_issue_state_none_is_missing() {
+        assert_eq!(parse_issue_state(None), IssueState::Missing);
+    }
+
+    #[test]
+    fn parse_issue_state_unknown_is_missing() {
+        assert_eq!(
+            parse_issue_state(Some("DELETED".to_string())),
+            IssueState::Missing
+        );
+    }
+
+    // Verify make_bash_post_tool_use builder works
+    #[test]
+    fn post_tool_use_builder_carries_stdout() {
+        let input =
+            make_bash_post_tool_use("gh pr create ...", "https://github.com/owner/repo/pull/42");
+        assert_eq!(input.command(), Some("gh pr create ..."));
+        assert_eq!(
+            input.tool_response_stdout(),
+            Some("https://github.com/owner/repo/pull/42")
+        );
+    }
+}

--- a/crates/guardrails/src/verify_pr_autoclose.rs
+++ b/crates/guardrails/src/verify_pr_autoclose.rs
@@ -105,11 +105,21 @@ pub trait Clock {
 // ---------------------------------------------------------------------------
 
 /// Production `gh` runner: shells out to the system `gh` binary.
-pub struct RealGhRunner;
+///
+/// Carries the enterprise host (if any) and scopes `GH_HOST` to each spawned
+/// command — no process-global env mutation.
+pub struct RealGhRunner {
+    /// `GH_HOST` value for enterprise GitHub remotes; `None` targets github.com.
+    pub gh_host: Option<String>,
+}
 
 impl GhRunner for RealGhRunner {
     fn run(&self, args: &[&str]) -> Option<String> {
-        let output = std::process::Command::new("gh").args(args).output().ok()?;
+        let mut cmd = std::process::Command::new("gh");
+        if let Some(h) = &self.gh_host {
+            cmd.env("GH_HOST", h);
+        }
+        let output = cmd.args(args).output().ok()?;
         if output.status.success() {
             let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
             if s.is_empty() { None } else { Some(s) }
@@ -167,16 +177,15 @@ fn fetch_issue_state(gh: &dyn GhRunner, issue: u64, slug: &str) -> IssueState {
 
 /// Warn about broken issue references in a newly-created PR.
 ///
-/// Fetches the PR body, extracts closing-keyword refs, and warns to stderr
-/// for any ref that is CLOSED (auto-close can't re-fire) or MISSING (not found).
-/// Silent on the happy path (all refs OPEN, or no refs at all).
-pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) {
-    let Some(pr_num) = pr_number_from_create_stdout(stdout) else {
-        return;
-    };
+/// Fetches the PR body, extracts closing-keyword refs, and returns a warning
+/// message for any ref that is CLOSED (auto-close can't re-fire) or MISSING
+/// (not found). Returns `None` on the happy path (all refs OPEN, or no refs).
+/// The caller routes the message through `CheckResult::nudge` so Claude sees it.
+pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) -> Option<String> {
+    let pr_num = pr_number_from_create_stdout(stdout)?;
 
     // Fetch the PR body as JSON then extract the body field
-    let body_json = match gh.run(&[
+    let body_json = gh.run(&[
         "pr",
         "view",
         &pr_num.to_string(),
@@ -184,10 +193,7 @@ pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) {
         "body",
         "-R",
         slug,
-    ]) {
-        Some(j) => j,
-        None => return,
-    };
+    ])?;
 
     // Parse body from JSON: {"body":"..."} — use serde_json for correctness
     let body: String = match serde_json::from_str::<serde_json::Value>(&body_json) {
@@ -201,7 +207,7 @@ pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) {
 
     let refs = extract_refs(&body);
     if refs.is_empty() {
-        return;
+        return None;
     }
 
     let mut warnings: Vec<String> = Vec::new();
@@ -219,11 +225,13 @@ pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) {
         }
     }
 
-    if !warnings.is_empty() {
-        eprintln!(
+    if warnings.is_empty() {
+        None
+    } else {
+        Some(format!(
             "verify-pr-autoclose: PR #{pr_num} has broken references:\n{}",
             warnings.join("\n")
-        );
+        ))
     }
 }
 
@@ -235,8 +243,16 @@ pub fn handle_create(slug: &str, stdout: &str, gh: &dyn GhRunner) {
 ///
 /// Waits `wait_secs` (injected via `clock`) to give GitHub time to auto-close,
 /// then checks each referenced issue. If still OPEN, closes it via `gh issue close`
-/// with a commit-citing comment. Reports closed issues to stderr.
-pub fn handle_merge(slug: &str, cmd: &str, gh: &dyn GhRunner, clock: &dyn Clock, wait_secs: u64) {
+/// with a commit-citing comment. Returns a summary message naming the closed
+/// issues, or `None` when there was nothing to do. The caller routes the
+/// message through `CheckResult::nudge` so Claude sees it.
+pub fn handle_merge(
+    slug: &str,
+    cmd: &str,
+    gh: &dyn GhRunner,
+    clock: &dyn Clock,
+    wait_secs: u64,
+) -> Option<String> {
     // Resolve PR number: from command or from `gh pr view`
     let pr_num = match pr_number_from_merge_cmd(cmd) {
         Some(n) => n,
@@ -244,17 +260,14 @@ pub fn handle_merge(slug: &str, cmd: &str, gh: &dyn GhRunner, clock: &dyn Clock,
             let raw = gh.run(&[
                 "pr", "view", "--json", "number", "-q", ".number", "-R", slug,
             ]);
-            match raw.and_then(|s| s.parse::<u64>().ok()) {
-                Some(n) => n,
-                None => return,
-            }
+            raw.and_then(|s| s.parse::<u64>().ok())?
         }
     };
 
     clock.sleep_secs(wait_secs);
 
     // Fetch body + mergeCommit
-    let pr_json = match gh.run(&[
+    let pr_json = gh.run(&[
         "pr",
         "view",
         &pr_num.to_string(),
@@ -262,15 +275,9 @@ pub fn handle_merge(slug: &str, cmd: &str, gh: &dyn GhRunner, clock: &dyn Clock,
         "body,mergeCommit",
         "-R",
         slug,
-    ]) {
-        Some(j) => j,
-        None => return,
-    };
+    ])?;
 
-    let value: serde_json::Value = match serde_json::from_str(&pr_json) {
-        Ok(v) => v,
-        Err(_) => return,
-    };
+    let value: serde_json::Value = serde_json::from_str(&pr_json).ok()?;
 
     let body = value
         .get("body")
@@ -286,7 +293,7 @@ pub fn handle_merge(slug: &str, cmd: &str, gh: &dyn GhRunner, clock: &dyn Clock,
 
     let refs = extract_refs(&body);
     if refs.is_empty() {
-        return;
+        return None;
     }
 
     let short_sha = if merge_sha.len() >= 7 {
@@ -322,12 +329,14 @@ pub fn handle_merge(slug: &str, cmd: &str, gh: &dyn GhRunner, clock: &dyn Clock,
         }
     }
 
-    if !closed.is_empty() {
-        eprintln!(
+    if closed.is_empty() {
+        None
+    } else {
+        Some(format!(
             "verify-pr-autoclose: closed {} straggler issue(s) for PR #{pr_num}: {}",
             closed.len(),
             closed.join(", ")
-        );
+        ))
     }
 }
 
@@ -370,31 +379,29 @@ impl Check for VerifyPrAutoclose {
             return CheckResult::allow();
         };
 
-        // Set GH_HOST for enterprise GitHub
-        if let Some(ref h) = host {
-            // SAFETY: This hook process is single-threaded (one hook fires one check).
-            // No other threads read or write env vars concurrently here.
-            unsafe {
-                std::env::set_var("GH_HOST", h);
-            }
-        }
-
-        let gh = RealGhRunner;
+        // Enterprise GitHub: scope GH_HOST to the runner's spawned commands
+        // rather than mutating this process's environment.
+        let gh = RealGhRunner { gh_host: host };
         let clock = RealClock;
         let wait_secs: u64 = std::env::var("GH_AUTOCLOSE_WAIT_SECONDS")
             .ok()
             .and_then(|s| s.parse().ok())
             .unwrap_or(10);
 
-        if cmd.contains("gh pr create") {
+        let message = if cmd.contains("gh pr create") {
             let stdout = input.tool_response_stdout().unwrap_or("");
-            handle_create(&slug, stdout, &gh);
+            handle_create(&slug, stdout, &gh)
         } else if cmd.contains("gh pr merge") {
-            handle_merge(&slug, cmd, &gh, &clock, wait_secs);
-        }
-        // else: not a create or merge command — exit 0, no handler invoked
+            handle_merge(&slug, cmd, &gh, &clock, wait_secs)
+        } else {
+            // Not a create or merge command — no handler invoked
+            None
+        };
 
-        CheckResult::allow()
+        match message {
+            Some(msg) => CheckResult::nudge(msg),
+            None => CheckResult::allow(),
+        }
     }
 }
 
@@ -635,40 +642,40 @@ mod tests {
     // Shell-flow tests (cases 11–18)
     // -----------------------------------------------------------------------
 
-    // Case 11: create, body refs #5 (OPEN) → no stderr (test indirectly via no close calls)
+    // Case 11: create, body refs #5 (OPEN) → no warning message
     #[test]
     fn create_body_refs_open_issue_no_warnings() {
         let gh = FakeGh::new()
             .with_issue(5, "OPEN")
             .with_pr_body("Closes #5");
 
-        // handle_create should silently succeed with no close calls and no panic
-        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+        let msg = handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
 
-        // No warnings means no close calls; body was fetched once
+        assert_eq!(msg, None, "happy path should produce no warning");
         assert!(gh.close_calls.borrow().is_empty());
         assert_eq!(*gh.body_calls.borrow(), vec![1u64]);
     }
 
-    // Case 12: create, body refs #5 (CLOSED) → warnings logged
-    // (We test via stderr capture indirectly — we verify the function doesn't panic
-    //  and runs the warning path; stderr capture is an integration concern)
+    // Case 12: create, body refs #5 (CLOSED) → warning names the issue and reason
     #[test]
     fn create_body_refs_closed_issue_emits_warning() {
         let gh = FakeGh::new()
             .with_issue(5, "CLOSED")
             .with_pr_body("Closes #5");
 
-        // Should not panic; state is verified by checking that parse_issue_state(CLOSED)
-        // correctly maps to IssueState::Closed
-        assert_eq!(
-            parse_issue_state(Some("CLOSED".to_string())),
-            IssueState::Closed
-        );
+        let msg = handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh)
+            .expect("closed ref should produce a warning");
 
-        // handle_create runs the warning path — we verify it completes without panic
-        // and that no close calls are made (warnings only, no mutation)
-        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+        assert!(msg.contains("#5"), "warning should name the issue: {msg}");
+        assert!(
+            msg.contains("already CLOSED"),
+            "warning should explain auto-close cannot re-fire: {msg}"
+        );
+        assert!(
+            msg.contains("PR #1"),
+            "warning should cite the PR number: {msg}"
+        );
+        // Warnings only, no mutation
         assert!(gh.close_calls.borrow().is_empty());
     }
 
@@ -679,20 +686,24 @@ mod tests {
             // issue 99 not in map → gh returns None → Missing state
             .with_pr_body("Closes #99");
 
-        assert_eq!(parse_issue_state(None), IssueState::Missing);
+        let msg = handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh)
+            .expect("missing ref should produce a warning");
 
-        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+        assert!(
+            msg.contains("#99") && msg.contains("not found"),
+            "warning should name the missing issue: {msg}"
+        );
         assert!(gh.close_calls.borrow().is_empty());
     }
 
-    // Case 14: create, body has no refs → no body fetch calls after the initial one
+    // Case 14: create, body has no refs → no warning, no issue-state calls
     #[test]
     fn create_body_no_refs_returns_early() {
         let gh = FakeGh::new().with_pr_body("This PR is purely cosmetic.");
 
-        handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
+        let msg = handle_create("owner/repo", "https://github.com/owner/repo/pull/1", &gh);
 
-        // Body was fetched but no issue state calls and no close calls
+        assert_eq!(msg, None);
         assert!(gh.close_calls.borrow().is_empty());
         // No issue state calls because refs list is empty
         assert_eq!(*gh.body_calls.borrow(), vec![1u64]);
@@ -707,7 +718,13 @@ mod tests {
             .with_merge_commit("abc1234def456");
 
         let clock = FakeClock::new();
-        handle_merge("owner/repo", "gh pr merge 8 --squash", &gh, &clock, 0);
+        let msg = handle_merge("owner/repo", "gh pr merge 8 --squash", &gh, &clock, 0)
+            .expect("closing a straggler should produce a summary");
+
+        assert!(
+            msg.contains("closed 1 straggler") && msg.contains("#5"),
+            "summary should count and name closed issues: {msg}"
+        );
 
         let calls = gh.close_calls.borrow();
         assert_eq!(calls.len(), 1, "should close issue #5");
@@ -732,8 +749,9 @@ mod tests {
             .with_merge_commit("abc1234def456");
 
         let clock = FakeClock::new();
-        handle_merge("owner/repo", "gh pr merge 8 --squash", &gh, &clock, 0);
+        let msg = handle_merge("owner/repo", "gh pr merge 8 --squash", &gh, &clock, 0);
 
+        assert_eq!(msg, None, "nothing closed → no summary message");
         assert!(
             gh.close_calls.borrow().is_empty(),
             "should not close already-closed issue"
@@ -746,7 +764,7 @@ mod tests {
         let gh = FakeGh::new(); // pr_number is None by default
 
         let clock = FakeClock::new();
-        handle_merge(
+        let msg = handle_merge(
             "owner/repo",
             "gh pr merge --squash", // no number in cmd
             &gh,
@@ -754,6 +772,7 @@ mod tests {
             10,
         );
 
+        assert_eq!(msg, None);
         // No sleep should have been called because we return before sleeping
         assert!(
             clock.sleep_calls.borrow().is_empty(),

--- a/crates/guardrails/src/verify_pr_autoclose.rs
+++ b/crates/guardrails/src/verify_pr_autoclose.rs
@@ -15,28 +15,8 @@ use std::sync::LazyLock;
 // Pure helpers
 // ---------------------------------------------------------------------------
 
-/// Regex for issue-closing keywords followed by a `#<number>` ref.
-///
-/// Matches: closes, closed, close, fixes, fixed, fix, resolves, resolved, resolve
-/// Case-insensitive; captures the digit string after `#`.
-static CLOSING_KW_RE: LazyLock<Regex> = LazyLock::new(|| {
-    Regex::new(r"(?i)(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+#([0-9]+)")
-        .expect("pattern should compile")
-});
-
-/// Extract sorted, deduplicated issue numbers from closing-keyword references.
-///
-/// Finds all `closes #N`, `fixes #N`, `resolves #N` (and inflected variants),
-/// case-insensitively. Returns issue numbers sorted ascending with duplicates removed.
-pub fn extract_refs(text: &str) -> Vec<u64> {
-    let mut nums: Vec<u64> = CLOSING_KW_RE
-        .captures_iter(text)
-        .filter_map(|cap| cap.get(1)?.as_str().parse::<u64>().ok())
-        .collect();
-    nums.sort_unstable();
-    nums.dedup();
-    nums
-}
+// Closing-keyword detection is shared with guard_pr_issue_link via issue_refs.
+pub use crate::issue_refs::extract_refs;
 
 /// Parse a git remote URL into `(host, "owner/repo")`.
 ///
@@ -120,12 +100,11 @@ impl GhRunner for RealGhRunner {
             cmd.env("GH_HOST", h);
         }
         let output = cmd.args(args).output().ok()?;
-        if output.status.success() {
-            let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if s.is_empty() { None } else { Some(s) }
-        } else {
-            None
+        if !output.status.success() {
+            return None;
         }
+        let s = String::from_utf8_lossy(&output.stdout).trim().to_string();
+        (!s.is_empty()).then_some(s)
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -118,6 +118,12 @@ enum GuardrailsCommands {
     NudgeUpgradeAfterPush,
     /// Warn about untracked files during git commit operations
     WarnUntracked,
+    /// Block direct edits to production dotfiles (opt-in via CADENCE_GUARD_DOTFILES=1)
+    GuardDotfiles,
+    /// Block `gh pr create` without a closing issue keyword in the body
+    GuardPrIssueLink,
+    /// Verify issue auto-close after PR create/merge; close stragglers
+    VerifyPrAutoclose,
     /// Snooze warn-main-branch for this repo for the given duration
     DismissMainBranchWarn {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
@@ -280,6 +286,21 @@ const HOOKS: &[HookEntry] = &[
         description: "Warn about untracked files during git commit operations",
         plugin: "guardrails",
     },
+    HookEntry {
+        name: "guard-dotfiles",
+        description: "Block direct edits to production dotfiles (opt-in)",
+        plugin: "guardrails",
+    },
+    HookEntry {
+        name: "guard-pr-issue-link",
+        description: "Block gh pr create without a closing issue keyword",
+        plugin: "guardrails",
+    },
+    HookEntry {
+        name: "verify-pr-autoclose",
+        description: "Verify and repair issue auto-close after PR create/merge",
+        plugin: "guardrails",
+    },
     // rules
     HookEntry {
         name: "validate-frontmatter",
@@ -354,6 +375,9 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::WarnCronDatetime => "warn-cron-datetime",
             GuardrailsCommands::NudgeUpgradeAfterPush => "nudge-upgrade-after-push",
             GuardrailsCommands::WarnUntracked => "warn-untracked",
+            GuardrailsCommands::GuardDotfiles => "guard-dotfiles",
+            GuardrailsCommands::GuardPrIssueLink => "guard-pr-issue-link",
+            GuardrailsCommands::VerifyPrAutoclose => "verify-pr-autoclose",
             // dismiss-main-branch-warn is a CLI action, not a hook —
             // it has no PreToolUse/PostToolUse wiring and isn't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
@@ -621,6 +645,18 @@ fn main() {
             GuardrailsCommands::WarnUntracked => run_check_from_stdin(
                 &cadence_hooks_guardrails::warn_untracked::WarnUntrackedFiles,
                 pre,
+            ),
+            GuardrailsCommands::GuardDotfiles => run_check_from_stdin(
+                &cadence_hooks_guardrails::guard_dotfiles::GuardDotfiles,
+                pre,
+            ),
+            GuardrailsCommands::GuardPrIssueLink => run_check_from_stdin(
+                &cadence_hooks_guardrails::guard_pr_issue_link::PrIssueLinkGuard,
+                pre,
+            ),
+            GuardrailsCommands::VerifyPrAutoclose => run_check_from_stdin(
+                &cadence_hooks_guardrails::verify_pr_autoclose::VerifyPrAutoclose,
+                post,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {
                 cadence_hooks_guardrails::dismiss_main_branch_warn::run_dismiss(&for_);


### PR DESCRIPTION
## Summary

Ships three of the four checks from #43 as first-class guardrails. The fourth (`warn-security-patterns`) already exists as `cadence-hooks rules security-patterns` — all 20 spec patterns, exemption paths, and tests are present (see [issue comment](https://github.com/cameronsjo/cadence-hooks/issues/43#issuecomment-4595733145)).

Closes #43

## New checks

| Check | Event | Severity | Key behavior |
|---|---|---|---|
| `guard-dotfiles` | PreToolUse Edit\|Write | Blocking | Exact-match block on production dotfiles; opt-in via `CADENCE_GUARD_DOTFILES=1`, clean no-op otherwise |
| `guard-pr-issue-link` | PreToolUse Bash | Blocking | `gh pr create` must have a closing keyword (`Closes/Fixes/Resolves #N`); **port improvement**: `--body-file`/`-F` contents are scanned before denying (the Bash version false-blocked this) |
| `verify-pr-autoclose` | PostToolUse Bash | Advisory + side-effect | On create: nudge about broken/closed issue refs. On merge: wait `GH_AUTOCLOSE_WAIT_SECONDS`, close stragglers with commit-citing comments |

## Architecture

- **Functional core / I/O shell**: every check's decision logic is a pure function (`judge_dotfile`, `judge_pr_create`, `extract_refs`/`parse_remote`/PR-number parsers) with table-driven tests — zero mocks
- **Injected I/O**: `verify-pr-autoclose` takes `GhRunner` + `Clock` traits; tests use fakes (no network, no sleeps). `RealGhRunner` scopes `GH_HOST` per spawned command — no process-env mutation, no `unsafe`
- **Advisories route through `CheckResult::nudge`** (additionalContext), not bare stderr — so Claude actually sees broken-ref warnings and straggler-close summaries
- **Core extension**: `HookInput` gains `tool_response: Option<ToolResponse>` (backward-compatible; needed to read the PR URL from `gh pr create` output)

## Coordination

The sibling wiring PR (cadence-guardrails: hooks.json entries with `if:` filters) is opened alongside this one but must NOT merge until the 0.12.0 release lands — the audit test (`all_binary_subcommands_are_registered`) ties the two together.

## Verification

- `make ci` exit 0 — fmt + clippy (workspace, `-D warnings`) + all 20 test suites including the registration audit
- Guardrails crate: 354 tests (290 → 354, +64 across the three checks)
- 10/10 acceptance smoke tests against the built binary per the issue's criteria: pr-create-without-Closes blocked, dotfile blocked when enabled / no-op when disabled / `.local` override allowed, autoclose never blocks
- Implemented by three parallel implementer subagents (one per check), each independently verified; integration review fixed two idiom deviations (stderr→nudge, unsafe env mutation→runner-scoped host)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three guardrails: opt-in dotfile protection (blocks direct edits to protected dotfiles), PR issue-link enforcement (blocks `gh pr create` without a closing-keyword+issue), and PR auto-close verification (non-blocking warnings on broken refs and optional post-merge auto-close). CLI exposes these guardrails.

* **Documentation**
  * README updated to document the new guardrails and added CADENCE_GUARD_DOTFILES and GH_AUTOCLOSE_WAIT_SECONDS env vars.

* **Chores**
  * Added a local review file to .gitignore.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->