### PR TITLE
fix: mid-line security-pattern line numbers + audit enforcement for cadence-rules migration

### DIFF
--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -44,6 +44,12 @@ static REPO_SUBCOMMAND: LazyLock<Regex> = LazyLock::new(|| {
 static API_REPOS: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r"/?repos/([^/]+/[^/ ]+)").expect("pattern should compile"));
 
+static GIST_COMMAND: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"gh\s+gist\s").expect("pattern should compile"));
+
+static REPO_FORK_COMMAND: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"gh\s+repo\s+fork\b").expect("pattern should compile"));
+
 fn is_write_command(command: &str) -> bool {
     WRITE_ACTIONS.is_match(command)
         || API_WRITE_METHOD.is_match(command)
@@ -481,12 +487,12 @@ impl Check for GhWriteGuard {
         }
 
         // Gists are user-scoped
-        if Regex::new(r"gh\s+gist\s").unwrap().is_match(command) {
+        if GIST_COMMAND.is_match(command) {
             return CheckResult::allow();
         }
 
         // Fork creates under your account
-        if Regex::new(r"gh\s+repo\s+fork\b").unwrap().is_match(command) {
+        if REPO_FORK_COMMAND.is_match(command) {
             return CheckResult::allow();
         }
 

--- a/crates/rules/src/check_security_patterns.rs
+++ b/crates/rules/src/check_security_patterns.rs
@@ -130,7 +130,9 @@ pub fn scan_content(content: &str, ext: &str) -> Vec<(usize, &'static str)> {
 
         if let Ok(re) = Regex::new(sp.pattern) {
             for m in re.find_iter(content) {
-                let line_num = content[..m.start()].lines().count() + 1;
+                // Count newlines, not lines: a partial line before the match
+                // ("data = " before "pickle.loads") must not add a line.
+                let line_num = content[..m.start()].matches('\n').count() + 1;
                 warnings.push((line_num, sp.message));
             }
         }
@@ -387,6 +389,20 @@ mod tests {
         let results = scan_content(content, "py");
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].0, 5);
+    }
+
+    #[test]
+    fn line_number_accuracy_for_mid_line_match() {
+        // Match that does NOT start at column 0: the partial line before the
+        // pattern must not inflate the line count.
+        let content = "import pickle\ndata = pickle.loads(blob)";
+        let results = scan_content(content, "py");
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].0, 2,
+            "pickle.loads is on line 2, got line {}",
+            results[0].0
+        );
     }
 
     #[test]

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -87,11 +87,12 @@ const BINARY_PLUGIN_DIRS: &[(&str, &str)] = &[
     ("cadence-guardrails", "guardrails"),
     ("cadence-lab", "lab"),
     ("cadence-metrics", "metrics"),
+    ("cadence-rules", "rules"),
 ];
 
 /// Plugin directories that still use shell script wrappers (not yet migrated to binary).
 /// These are tracked so the "all subcommands registered" test knows they exist.
-const SHELL_PLUGIN_DIRS: &[(&str, &str)] = &[("rules", "rules"), ("cadence-obsidian", "obsidian")];
+const SHELL_PLUGIN_DIRS: &[(&str, &str)] = &[("cadence-obsidian", "obsidian")];
 
 /// Bash-matcher hooks that intentionally inspect every command (no `if` filter).
 /// These run broad pattern matching internally and can't be narrowed to a single glob.


### PR DESCRIPTION
## Summary

The cadence-hooks side of the cadence-rules binary migration ([cadence-rules#8](https://github.com/cameronsjo/cadence-rules/pull/8)), plus a line-number bug fix surfaced while verifying that migration.

> **Stacked on #48** (`feat/issue-39-doctor`) — the bottom of the stack is #47 → #48 → this. Based here so local `make ci` passes (the cadence-guardrails sibling's hooks.json references subcommands that only exist on the stack).

## Changes

### 1. `fix`: security-patterns line numbers off by one for mid-line matches

`scan_content` counted `lines()` of the prefix before a match — a partial line ("`data = `" before "`pickle.loads`") counted as a full line, so a line-2 match reported as L3. Found during the cadence-rules migration smoke test. Counts newlines now.

The pre-existing `line_number_accuracy` test masked this by only matching at column 0; the new `line_number_accuracy_for_mid_line_match` test covers the general case (classic tests-codify-bugs).

### 2. `test`: enforce cadence-rules as a binary-dispatch plugin in the audit

Moves `cadence-rules` from `SHELL_PLUGIN_DIRS` (exempt) to `BINARY_PLUGIN_DIRS`, so the registration audit starts checking its hooks.json — `rules validate-frontmatter` and `rules security-patterns` must stay registered there, and the cross-plugin / if-filter checks now apply.

## Coordination

This PR and **cadence-rules#8 must merge together**: with this change, local `make ci` fails if the cadence-rules sibling checkout still has the shell-script hooks.json. (CI is unaffected — the audit skips when sibling plugin dirs are absent.)

## Verification

- `make ci` exit 0 — **1256 tests passed, 0 failed** (run with the cadence-rules sibling on its migration branch)
- TDD on the line fix: new test failed with `left: 3, right: 2` against the old code, passes after
- All 7 registration-audit tests pass with cadence-rules enforced
