### PR TITLE
feat: five guardrails checks from CLAUDE.md prose rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- Five guardrails checks converting machine-enforceable prose rules from a personal CLAUDE.md into deterministic hooks (#52, #53):
+  - `guard-op-vault-scan` (**block**) — `op item list` / `op vault list` enumeration, including inside exec wrappers. Single-item reads (`op read`, `op item get`) stay allowed; the guard targets enumeration, not access.
+  - `warn-curl-alias` (nudge) — bare `curl` with `-H`/`--header` flags, for machines where curl is aliased to curlie (which infers POST from JSON-like headers, causing silent 400s). Per-segment analysis keeps `grep -H` and other piped tools from false-positiving.
+  - `warn-gh-merge-preflight` (nudge) — pre-flight checklist on `gh pr merge`: draft PRs report MERGEABLE/CLEAN but fail with a GraphQL error (check `isDraft`); worktree checkouts break `--delete-branch` local cleanup; failed merges may have landed server-side (verify `mergedAt` before retrying).
+  - `warn-coderabbit-retrigger` (nudge) — `@coderabbitai review` comments are no-ops on already-reviewed content (CodeRabbit's incremental review is content-cached, not SHA-cached); push a new commit instead.
+  - `warn-alias-parsing` (nudge) — piping aliased-tool output (`cat`/`find`/`ls`/`du`/`df`/`top` → bat/fd/eza/dust/duf/btm) into parsers. Fires only when the aliased tool is a pipeline *producer*; consumer position (`git diff | cat`) and interactive use stay silent.
+- `KNOWN_DISTINCT_SETTINGS_SCRIPTS` allowlist in the registration audit test, for settings.json scripts that trip the keyword-overlap heuristic without duplicating any plugin hook (first entry: `block-vault-git-writes.sh`, an Obsidian-vault guard unrelated to the 1Password `guard-op-vault-scan`).
+
 ## [0.11.0] - 2026-05-30
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -43,6 +43,11 @@ Hooks are organized by the plugin they serve:
 | `guard-dotfiles` | PreToolUse (Edit, Write) | Block direct edits to production dotfiles (opt-in via `CADENCE_GUARD_DOTFILES=1`) |
 | `guard-pr-issue-link` | PreToolUse (Bash) | Block `gh pr create` without a closing issue keyword (`Closes #N`) in the body |
 | `verify-pr-autoclose` | PostToolUse (Bash) | Verify issue auto-close refs after PR create; close stragglers after merge |
+| `guard-op-vault-scan` | PreToolUse (Bash) | Block 1Password vault enumeration (`op item list`); single-item reads stay allowed |
+| `warn-curl-alias` | PreToolUse (Bash) | Warn when bare `curl` (aliased to curlie) is used with custom headers |
+| `warn-gh-merge-preflight` | PreToolUse (Bash) | Pre-flight checklist before `gh pr merge` (isDraft, worktree, mergedAt verification) |
+| `warn-coderabbit-retrigger` | PreToolUse (Bash) | Warn that `@coderabbitai review` comments are no-ops on already-reviewed content |
+| `warn-alias-parsing` | PreToolUse (Bash) | Warn when piping aliased-tool output (cat/find/ls/du/df/top) into parsers |
 
 ### rules
 

--- a/crates/guardrails/src/guard_op_vault_scan.rs
+++ b/crates/guardrails/src/guard_op_vault_scan.rs
@@ -1,0 +1,202 @@
+//! Block uninvited 1Password vault enumeration.
+//!
+//! `op item list` (especially piped to grep/awk) scans the whole vault. In
+//! background/auto-mode sessions this trips the auto-mode classifier, and in
+//! any session it reads far more secret metadata than a task needs. Single-item
+//! reads (`op read op://...`, `op item get <name>`) stay allowed — the guard
+//! targets enumeration, not access.
+
+use cadence_hooks_core::shell::strip_quotes;
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Matches `op item list` / `op vault list` enumeration commands.
+static OP_VAULT_SCAN: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\bop\s+(item|vault)\s+list\b").expect("pattern should compile"));
+
+/// Matches shell exec wrappers that can hide a scan inside quotes.
+static EXEC_WRAPPER: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\b(bash|sh|zsh)\s+-c\b").expect("pattern should compile"));
+
+/// Blocks `op item list` vault enumeration; single-item reads are allowed.
+pub struct OpVaultScanGuard;
+
+fn block_message(found: &str) -> String {
+    format!(
+        "🚫 guard-op-vault-scan: 1Password vault enumeration blocked\n   \
+         Found: `{found}`\n   \
+         Fix: ask the user how to supply the secret (op:// URI, item name, or env var) — \
+         vault scans read every item's metadata and trip the auto-mode classifier.\n   \
+         Allowed: single-item reads like `op read op://vault/item/field` or `op item get <name>`"
+    )
+}
+
+impl Check for OpVaultScanGuard {
+    fn name(&self) -> &str {
+        "guard-op-vault-scan"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(command) = input.command() else {
+            return CheckResult::allow();
+        };
+
+        if !command.contains("op") {
+            return CheckResult::allow();
+        }
+
+        // Strip quoted strings so prose mentioning the command doesn't fire.
+        let stripped = strip_quotes(command);
+
+        // Pass 1: direct invocation (after stripping quotes)
+        if let Some(m) = OP_VAULT_SCAN.find(&stripped) {
+            return CheckResult::block(block_message(m.as_str().trim()));
+        }
+
+        // Pass 2: inside exec wrappers (bash -c 'op item list')
+        if EXEC_WRAPPER.is_match(&stripped)
+            && let Some(m) = OP_VAULT_SCAN.find(command)
+        {
+            return CheckResult::block(block_message(m.as_str().trim()));
+        }
+
+        CheckResult::allow()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::make_bash;
+
+    // --- guard clause: non-matching commands stay allowed ---
+
+    #[test]
+    fn no_command_allowed() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: None,
+            cwd: None,
+            ..Default::default()
+        };
+        let result = OpVaultScanGuard.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn unrelated_command_allowed() {
+        let result = OpVaultScanGuard.run(&make_bash("ls -la"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn op_read_single_item_allowed() {
+        let result =
+            OpVaultScanGuard.run(&make_bash("op read op://Private/GitHub Token/credential"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn op_item_get_allowed() {
+        let result = OpVaultScanGuard.run(&make_bash(
+            "op item get \"GitHub Token\" --fields label=token",
+        ));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn op_whoami_allowed() {
+        let result = OpVaultScanGuard.run(&make_bash("op whoami"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- happy path: vault enumeration blocked ---
+
+    #[test]
+    fn op_item_list_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op item list"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_item_list_piped_to_grep_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op item list | grep -i token"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_item_list_with_vault_flag_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op item list --vault Private | grep api"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_item_list_in_exec_wrapper_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("bash -c 'op item list'"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_item_list_in_chain_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("echo start && op item list | head -5"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_vault_list_blocked() {
+        // `op vault list` enumerates vaults — same scan class
+        let result = OpVaultScanGuard.run(&make_bash("op vault list"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    // --- block message quality ---
+
+    #[test]
+    fn block_message_tells_claude_to_ask_user() {
+        let result = OpVaultScanGuard.run(&make_bash("op item list | grep token"));
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("ask the user"),
+            "block message should redirect to asking the user: {msg}"
+        );
+    }
+
+    // --- edge cases ---
+
+    #[test]
+    fn quoted_prose_mentioning_op_item_list_allowed() {
+        let result = OpVaultScanGuard.run(&make_bash("echo 'never run op item list uninvited'"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn extra_whitespace_between_tokens_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op  item   list"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn empty_command_allowed() {
+        let result = OpVaultScanGuard.run(&make_bash(""));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn hyphenated_lookalike_allowed() {
+        // "op-item-list" is a different word, not the op CLI
+        let result = OpVaultScanGuard.run(&make_bash("op-item-list --help"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- evasion (documented limitations) ---
+
+    #[test]
+    fn variable_expansion_not_caught() {
+        // Variable indirection can't be resolved statically — documented gap.
+        // The auto-mode classifier remains the backstop for this.
+        let result = OpVaultScanGuard.run(&make_bash("$OP_CMD item list"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+}

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -29,6 +29,8 @@ pub mod nudge_upgrade_after_push;
 pub mod verify_pr_autoclose;
 /// Warn when creating a branch from a non-main base.
 pub mod warn_branch_base;
+/// Warn that CodeRabbit re-trigger comments are no-ops on already-reviewed content.
+pub mod warn_coderabbit_retrigger;
 /// Remind to check datetime before scheduling cron jobs.
 pub mod warn_cron_datetime;
 /// Warn when bare `curl` (aliased to curlie) is used with custom headers.

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -27,6 +27,8 @@ pub mod issue_refs;
 pub mod nudge_upgrade_after_push;
 /// Warn about broken issue refs on PR create; close straggler issues on PR merge.
 pub mod verify_pr_autoclose;
+/// Warn when piping aliased-tool output (ls/find/cat/du/df/top) into parsers.
+pub mod warn_alias_parsing;
 /// Warn when creating a branch from a non-main base.
 pub mod warn_branch_base;
 /// Warn that CodeRabbit re-trigger comments are no-ops on already-reviewed content.

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -15,6 +15,8 @@ pub mod guard_gh_dangerous;
 pub mod guard_gh_write;
 /// Nudge to scaffold project standards after `git init`.
 pub mod guard_git_init;
+/// Block uninvited 1Password vault enumeration (`op item list`).
+pub mod guard_op_vault_scan;
 /// Block `gh pr create` when the PR body has no closing keyword linking to an issue.
 pub mod guard_pr_issue_link;
 /// Block `git push` to remotes owned by others.

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -31,6 +31,8 @@ pub mod verify_pr_autoclose;
 pub mod warn_branch_base;
 /// Remind to check datetime before scheduling cron jobs.
 pub mod warn_cron_datetime;
+/// Warn when bare `curl` (aliased to curlie) is used with custom headers.
+pub mod warn_curl_alias;
 /// Warn when editing files directly on main/master branch.
 pub mod warn_main_branch;
 /// Warn about untracked files during git commit operations.

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -33,6 +33,8 @@ pub mod warn_branch_base;
 pub mod warn_cron_datetime;
 /// Warn when bare `curl` (aliased to curlie) is used with custom headers.
 pub mod warn_curl_alias;
+/// Pre-flight checklist nudge before `gh pr merge` (draft, worktree, verify).
+pub mod warn_gh_merge_preflight;
 /// Warn when editing files directly on main/master branch.
 pub mod warn_main_branch;
 /// Warn about untracked files during git commit operations.

--- a/crates/guardrails/src/warn_alias_parsing.rs
+++ b/crates/guardrails/src/warn_alias_parsing.rs
@@ -1,0 +1,259 @@
+//! Warn when piping output from shell-aliased tools into parsers.
+//!
+//! Modern CLI replacements (`cat`→`bat`, `find`→`fd`, `ls`→`eza`, `du`→`dust`,
+//! `df`→`duf`, `top`→`btm`) change output format — and `find`→`fd` changes
+//! syntax entirely. Piping their output into grep/awk/xargs parses the
+//! replacement's format, not the original's. The fix is `command <tool>` or an
+//! absolute path.
+//!
+//! Scope is deliberately narrow to avoid false positives: the nudge fires only
+//! when an aliased tool is a *producer* in a pipeline (a non-final pipe stage).
+//! Interactive use (`ls -la`) and consumer position (`git diff | cat`) stay
+//! silent.
+
+use cadence_hooks_core::shell::strip_quotes;
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Tools that are commonly aliased to modern replacements with different output.
+const ALIASED_TOOLS: &[(&str, &str)] = &[
+    ("cat", "bat"),
+    ("find", "fd"),
+    ("ls", "eza"),
+    ("du", "dust"),
+    ("df", "duf"),
+    ("top", "btm"),
+];
+
+/// Command wrappers whose next argument is the real tool being run.
+const WRAPPERS: &[&str] = &["xargs", "sudo", "env", "nice", "timeout"];
+
+/// Splits a command into chain segments (`&&`, `||`, `;`) — NOT single pipes.
+static CHAIN_SPLIT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"\|\||&&|;").expect("pattern should compile"));
+
+/// Nudges to use `command <tool>` when piping aliased tool output to parsers.
+pub struct WarnAliasParsing;
+
+/// If this pipe stage's producing command is a bare aliased tool, return the
+/// (tool, replacement) pair.
+fn stage_aliased_tool(stage: &str) -> Option<(&'static str, &'static str)> {
+    let tokens: Vec<&str> = stage.split_whitespace().collect();
+
+    // Skip through wrappers (`xargs ls`, `sudo du`) and env assignments
+    // (`LC_ALL=C find`) to reach the real tool.
+    let mut idx = 0;
+    while idx < tokens.len() && (WRAPPERS.contains(&tokens[idx]) || tokens[idx].contains('=')) {
+        idx += 1;
+    }
+
+    let first = tokens.get(idx)?;
+
+    // `command <tool>` is the fix — never flag it. Absolute paths are
+    // different tokens and never match the bare names below.
+    if *first == "command" {
+        return None;
+    }
+
+    ALIASED_TOOLS
+        .iter()
+        .find(|(tool, _)| tool == first)
+        .copied()
+}
+
+impl Check for WarnAliasParsing {
+    fn name(&self) -> &str {
+        "warn-alias-parsing"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(command) = input.command() else {
+            return CheckResult::allow();
+        };
+
+        // Pipes are the only scope of this check.
+        if !command.contains('|') {
+            return CheckResult::allow();
+        }
+
+        // Strip quoted strings so prose and quoted examples don't fire.
+        let stripped = strip_quotes(command);
+
+        // Chain segments first (&&, ||, ;), then pipe stages within each.
+        for chain in CHAIN_SPLIT.split(&stripped) {
+            let stages: Vec<&str> = chain.split('|').collect();
+            if stages.len() < 2 {
+                continue;
+            }
+
+            // Every stage except the last produces output that gets parsed.
+            for stage in &stages[..stages.len() - 1] {
+                if let Some((tool, replacement)) = stage_aliased_tool(stage) {
+                    return CheckResult::nudge(format!(
+                        "`{tool}` is aliased to `{replacement}` on this machine — piped output \
+                         is {replacement}'s format, not {tool}'s, and may not parse as expected. \
+                         Use `command {tool}` (or an absolute path) when parsing output \
+                         programmatically."
+                    ));
+                }
+            }
+        }
+
+        CheckResult::allow()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::make_bash;
+
+    // --- guard clause: non-matching commands stay allowed ---
+
+    #[test]
+    fn no_command_allowed() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: None,
+            cwd: None,
+            ..Default::default()
+        };
+        let result = WarnAliasParsing.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn unrelated_command_allowed() {
+        let result = WarnAliasParsing.run(&make_bash("git status"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn command_prefixed_ls_pipe_allowed() {
+        let result = WarnAliasParsing.run(&make_bash("command ls -1 | grep config"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn absolute_path_find_pipe_allowed() {
+        let result = WarnAliasParsing.run(&make_bash("/usr/bin/find . -name '*.rs' | xargs wc -l"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn ls_without_pipe_allowed() {
+        // Interactive listing — output format doesn't matter
+        let result = WarnAliasParsing.run(&make_bash("ls -la"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn pipe_without_aliased_tools_allowed() {
+        let result = WarnAliasParsing.run(&make_bash("grep -r TODO src/ | sort | uniq"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn aliased_tool_as_consumer_allowed() {
+        // `| cat` as a pager-disable trick — cat is the last stage, its output
+        // goes to the terminal, nothing parses it
+        let result = WarnAliasParsing.run(&make_bash("git diff | cat"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn similar_name_subcommand_allowed() {
+        // "ls-files" is a git subcommand, "ls" is not the first token
+        let result = WarnAliasParsing.run(&make_bash("git ls-files | grep test"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- happy path: aliased producer piped to parser nudges ---
+
+    #[test]
+    fn ls_piped_to_grep_nudges() {
+        let result = WarnAliasParsing.run(&make_bash("ls -1 | grep config"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn find_piped_to_xargs_nudges() {
+        let result = WarnAliasParsing.run(&make_bash("find . -name '*.rs' | xargs wc -l"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn cat_piped_to_jq_nudges() {
+        let result = WarnAliasParsing.run(&make_bash("cat data.json | jq '.items'"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn du_piped_to_sort_nudges() {
+        let result = WarnAliasParsing.run(&make_bash("du -sh * | sort -h"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn df_piped_to_awk_nudges() {
+        let result = WarnAliasParsing.run(&make_bash("df -h | awk '{print $5}'"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn aliased_producer_in_chain_nudges() {
+        let result = WarnAliasParsing.run(&make_bash("cd /tmp && ls | grep log"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    // --- nudge message quality ---
+
+    #[test]
+    fn nudge_message_names_tool_and_alias() {
+        let result = WarnAliasParsing.run(&make_bash("ls -1 | grep config"));
+        let msg = result.message.unwrap_or_default();
+        assert!(msg.contains("ls"), "nudge should name the tool: {msg}");
+        assert!(msg.contains("eza"), "nudge should name the alias: {msg}");
+        assert!(
+            msg.contains("command ls"),
+            "nudge should give the fix: {msg}"
+        );
+    }
+
+    #[test]
+    fn nudge_message_names_find_fd() {
+        let result = WarnAliasParsing.run(&make_bash("find . -type f | head -5"));
+        let msg = result.message.unwrap_or_default();
+        assert!(msg.contains("fd"), "nudge should name the fd alias: {msg}");
+    }
+
+    // --- edge cases ---
+
+    #[test]
+    fn quoted_prose_with_pipe_allowed() {
+        let result = WarnAliasParsing.run(&make_bash("echo 'try: ls | grep foo'"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn empty_command_allowed() {
+        let result = WarnAliasParsing.run(&make_bash(""));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn logical_or_not_treated_as_pipe() {
+        // `||` is logical-or, not a pipe — `ls` output goes nowhere
+        let result = WarnAliasParsing.run(&make_bash("ls /missing || echo 'not found'"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn middle_pipe_stage_producer_nudges() {
+        // Aliased tool in the middle of a pipeline still produces parsed output
+        let result = WarnAliasParsing.run(&make_bash("echo /tmp | xargs ls | grep log"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+}

--- a/crates/guardrails/src/warn_coderabbit_retrigger.rs
+++ b/crates/guardrails/src/warn_coderabbit_retrigger.rs
@@ -1,0 +1,180 @@
+//! Warn that `@coderabbitai review` comments don't force a fresh review.
+//!
+//! CodeRabbit's incremental review is content-cached, not SHA-cached. A
+//! re-trigger comment posts "Review triggered" but submits nothing when the
+//! head's content was already reviewed. The reliable way to force a fresh
+//! pass is pushing a new commit (including force-push after a rebase).
+
+use cadence_hooks_core::shell::strip_quotes;
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+
+/// Nudges that CodeRabbit re-trigger comments are no-ops on reviewed content.
+pub struct WarnCoderabbitRetrigger;
+
+/// Does the (quote-stripped) command invoke a gh comment subcommand?
+///
+/// Requires both `gh` and `comment` as standalone tokens, so commit messages
+/// and other commands that merely *mention* CodeRabbit never match.
+fn is_gh_comment(stripped: &str) -> bool {
+    let tokens: Vec<&str> = stripped.split_whitespace().collect();
+    tokens.contains(&"gh") && tokens.contains(&"comment")
+}
+
+/// Is the comment body a CodeRabbit re-review trigger?
+///
+/// Checked against the *raw* command because the trigger phrase lives inside
+/// the quoted `--body` value. `@coderabbitai resolve` and other commands are
+/// not review triggers.
+fn is_review_trigger(raw: &str) -> bool {
+    raw.contains("@coderabbitai")
+        && (raw.contains("@coderabbitai review") || raw.contains("full review"))
+}
+
+impl Check for WarnCoderabbitRetrigger {
+    fn name(&self) -> &str {
+        "warn-coderabbit-retrigger"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(command) = input.command() else {
+            return CheckResult::allow();
+        };
+
+        if !command.contains("coderabbitai") {
+            return CheckResult::allow();
+        }
+
+        let stripped = strip_quotes(command);
+
+        if !is_gh_comment(&stripped) || !is_review_trigger(command) {
+            return CheckResult::allow();
+        }
+
+        CheckResult::nudge(
+            "CodeRabbit's incremental review is content-cached, not SHA-cached — \
+             '@coderabbitai review' posts \"Review triggered\" but submits nothing when this \
+             content was already reviewed. To force a fresh pass, push a new commit (including \
+             a force-push after a rebase); expect the review ~30 seconds after a real push.",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::make_bash;
+
+    // --- guard clause: non-matching commands stay allowed ---
+
+    #[test]
+    fn no_command_allowed() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: None,
+            cwd: None,
+            ..Default::default()
+        };
+        let result = WarnCoderabbitRetrigger.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn unrelated_command_allowed() {
+        let result = WarnCoderabbitRetrigger.run(&make_bash("git status"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn plain_pr_comment_allowed() {
+        let result =
+            WarnCoderabbitRetrigger.run(&make_bash("gh pr comment 5 --body \"LGTM, merging\""));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn coderabbit_resolve_command_allowed() {
+        // @coderabbitai resolve is not a re-review trigger
+        let result = WarnCoderabbitRetrigger.run(&make_bash(
+            "gh pr comment 5 --body \"@coderabbitai resolve\"",
+        ));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn commit_message_mentioning_coderabbit_review_allowed() {
+        // Commit messages routinely reference CodeRabbit review feedback —
+        // not a re-trigger attempt.
+        let result = WarnCoderabbitRetrigger.run(&make_bash(
+            "git commit -m \"fix: address @coderabbitai review findings\"",
+        ));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- happy path: re-trigger comments nudge ---
+
+    #[test]
+    fn coderabbit_review_comment_nudges() {
+        let result = WarnCoderabbitRetrigger.run(&make_bash(
+            "gh pr comment 5 --body \"@coderabbitai review\"",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn coderabbit_full_review_comment_nudges() {
+        let result = WarnCoderabbitRetrigger.run(&make_bash(
+            "gh pr comment 5 --body '@coderabbitai full review'",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn coderabbit_review_with_repo_flag_nudges() {
+        let result = WarnCoderabbitRetrigger.run(&make_bash(
+            "gh pr comment 12 -R cameronsjo/cadence --body \"@coderabbitai review\"",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn coderabbit_review_in_chain_nudges() {
+        let result = WarnCoderabbitRetrigger.run(&make_bash(
+            "cd /repo && gh pr comment 5 --body \"@coderabbitai review\"",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    // --- nudge message quality ---
+
+    #[test]
+    fn nudge_message_explains_content_caching() {
+        let result = WarnCoderabbitRetrigger.run(&make_bash(
+            "gh pr comment 5 --body \"@coderabbitai review\"",
+        ));
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("content-cached"),
+            "nudge should explain the caching behavior: {msg}"
+        );
+        assert!(
+            msg.contains("push a new commit") || msg.contains("Push a new commit"),
+            "nudge should give the fix: {msg}"
+        );
+    }
+
+    // --- edge cases ---
+
+    #[test]
+    fn empty_command_allowed() {
+        let result = WarnCoderabbitRetrigger.run(&make_bash(""));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn gh_pr_view_comments_allowed() {
+        // Reading comments that happen to mention CodeRabbit is not a trigger
+        let result = WarnCoderabbitRetrigger.run(&make_bash("gh pr view 5 --comments"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+}

--- a/crates/guardrails/src/warn_curl_alias.rs
+++ b/crates/guardrails/src/warn_curl_alias.rs
@@ -1,0 +1,228 @@
+//! Warn when bare `curl` is used for API calls with custom headers.
+//!
+//! On machines where `curl` is aliased to `curlie`, JSON-like headers
+//! (`Accept: application/json`) make curlie infer POST — producing silent
+//! 400s from endpoints expecting GET. The fix is `command curl` (bypasses
+//! the alias) or an absolute path. This nudge fires only when custom headers
+//! are present; plain downloads behave identically under both tools.
+
+use cadence_hooks_core::shell::strip_quotes;
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use regex::Regex;
+use std::sync::LazyLock;
+
+/// Splits a command into pipeline/chain segments (`|`, `&&`, `||`, `;`).
+static SEGMENT_SPLIT: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"[|;&]+").expect("pattern should compile"));
+
+/// Nudges to use `command curl` when custom headers are present.
+pub struct WarnCurlAlias;
+
+/// Does this segment invoke bare `curl` (unprefixed, non-absolute) with a
+/// custom header flag?
+fn segment_has_bare_curl_with_headers(segment: &str) -> bool {
+    let tokens: Vec<&str> = segment.split_whitespace().collect();
+
+    // Find the first `curl` token that is not preceded by `command`.
+    // Absolute paths (/usr/bin/curl) are different tokens and never match.
+    let curl_idx = tokens.iter().enumerate().find_map(|(i, tok)| {
+        if *tok == "curl" && (i == 0 || tokens[i - 1] != "command") {
+            Some(i)
+        } else {
+            None
+        }
+    });
+
+    let Some(idx) = curl_idx else {
+        return false;
+    };
+
+    // Custom header flag anywhere after the curl invocation in this segment.
+    tokens[idx + 1..]
+        .iter()
+        .any(|t| t.starts_with("-H") || *t == "--header" || t.starts_with("--header="))
+}
+
+impl Check for WarnCurlAlias {
+    fn name(&self) -> &str {
+        "warn-curl-alias"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(command) = input.command() else {
+            return CheckResult::allow();
+        };
+
+        if !command.contains("curl") {
+            return CheckResult::allow();
+        }
+
+        // Strip quoted strings: prose mentioning curl won't fire, and quoted
+        // header *values* disappear while the flags themselves survive.
+        let stripped = strip_quotes(command);
+
+        // Check each pipeline/chain segment independently so header flags from
+        // other tools (e.g. `grep -H`) never attach to a curl invocation.
+        for segment in SEGMENT_SPLIT.split(&stripped) {
+            if segment_has_bare_curl_with_headers(segment) {
+                return CheckResult::nudge(
+                    "This machine aliases `curl` to `curlie`, which infers POST from JSON-like \
+                     headers — API calls with custom headers can fail with silent 400s from \
+                     endpoints expecting GET. Use `command curl` (or /usr/bin/curl) to bypass \
+                     the alias.",
+                );
+            }
+        }
+
+        CheckResult::allow()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::make_bash;
+
+    // --- guard clause: non-matching commands stay allowed ---
+
+    #[test]
+    fn no_command_allowed() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: None,
+            cwd: None,
+            ..Default::default()
+        };
+        let result = WarnCurlAlias.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn unrelated_command_allowed() {
+        let result = WarnCurlAlias.run(&make_bash("git status"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn command_prefixed_curl_with_headers_allowed() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "command curl -H 'Accept: application/json' https://api.example.com",
+        ));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn absolute_path_curl_with_headers_allowed() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "/usr/bin/curl -H 'Accept: application/json' https://api.example.com",
+        ));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn bare_curl_without_headers_allowed() {
+        // Plain downloads behave identically under curl and curlie
+        let result = WarnCurlAlias.run(&make_bash("curl -fsSL https://example.com/install.sh"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn bare_curl_output_flag_allowed() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "curl -o archive.tar.gz https://example.com/a.tar.gz",
+        ));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- happy path: bare curl + custom headers nudges ---
+
+    #[test]
+    fn bare_curl_with_h_flag_nudges() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "curl -H 'Accept: application/json' https://api.example.com/items",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn bare_curl_with_header_flag_nudges() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "curl --header 'Content-Type: application/json' https://api.example.com",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn bare_curl_with_headers_in_pipe_nudges() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "curl -sS -H 'Authorization: Bearer tok' https://api.example.com | jq '.items'",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn bare_curl_in_chain_nudges() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "cd /tmp && curl -H 'Accept: application/json' https://api.example.com",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn attached_h_flag_nudges() {
+        // -H with the value attached (no space)
+        let result = WarnCurlAlias.run(&make_bash(
+            "curl -H'Accept: application/json' https://api.example.com",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    // --- nudge message quality ---
+
+    #[test]
+    fn nudge_message_mentions_command_curl() {
+        let result = WarnCurlAlias.run(&make_bash(
+            "curl -H 'Accept: application/json' https://api.example.com",
+        ));
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("command curl"),
+            "nudge should give the fix: {msg}"
+        );
+        assert!(
+            msg.contains("curlie"),
+            "nudge should explain the alias cause: {msg}"
+        );
+    }
+
+    // --- edge cases ---
+
+    #[test]
+    fn quoted_prose_mentioning_curl_allowed() {
+        let result = WarnCurlAlias.run(&make_bash("echo 'use curl -H for custom headers'"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn empty_command_allowed() {
+        let result = WarnCurlAlias.run(&make_bash(""));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn curl_substring_in_word_allowed() {
+        // "curling" contains "curl" but is not the curl command
+        let result = WarnCurlAlias.run(&make_bash("echo curling -H is a sport"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn command_prefix_in_chain_allowed() {
+        // command-prefixed in second segment of a chain
+        let result = WarnCurlAlias.run(&make_bash(
+            "cd /tmp && command curl -H 'Accept: application/json' https://api.example.com",
+        ));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+}

--- a/crates/guardrails/src/warn_gh_merge_preflight.rs
+++ b/crates/guardrails/src/warn_gh_merge_preflight.rs
@@ -1,0 +1,195 @@
+//! Pre-flight checklist nudge before `gh pr merge`.
+//!
+//! Three gotchas bite repeatedly when merging PRs from the CLI:
+//!
+//! 1. **Draft PRs silently block merge** — `gh pr view --json mergeable,mergeStateStatus`
+//!    reports `MERGEABLE`/`CLEAN` on drafts, then the merge fails with
+//!    `GraphQL: Pull Request is still a draft`. Only `isDraft` reveals it.
+//! 2. **Worktree checkouts break `--delete-branch`** — the server-side merge
+//!    succeeds, but gh's local checkout/branch-delete step fails when the
+//!    branch (or main) is checked out in another worktree, leaving the remote
+//!    branch undeleted.
+//! 3. **A failed `gh pr merge` may have merged anyway** — always verify with
+//!    `gh pr view <n> --json mergedAt,mergeCommit` before retrying or assuming
+//!    failure.
+
+use cadence_hooks_core::shell::strip_quotes;
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+
+/// Nudges a pre-flight checklist on `gh pr merge`.
+pub struct WarnGhMergePreflight;
+
+/// Returns true if `command` contains a `gh pr merge` token sequence.
+///
+/// Token-based to avoid substring false positives (hyphenated script names,
+/// prose). Caller is expected to strip quotes first.
+fn is_gh_pr_merge(command: &str) -> bool {
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    tokens
+        .windows(3)
+        .any(|w| w[0] == "gh" && w[1] == "pr" && w[2] == "merge")
+}
+
+impl Check for WarnGhMergePreflight {
+    fn name(&self) -> &str {
+        "warn-gh-merge-preflight"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(command) = input.command() else {
+            return CheckResult::allow();
+        };
+
+        if !command.contains("gh") {
+            return CheckResult::allow();
+        }
+
+        // Strip quoted strings so prose mentioning the command doesn't fire.
+        let stripped = strip_quotes(command);
+
+        if !is_gh_pr_merge(&stripped) {
+            return CheckResult::allow();
+        }
+
+        CheckResult::nudge(
+            "gh pr merge pre-flight checklist:\n\
+             1. Draft check: `gh pr view <n> --json isDraft` — drafts report MERGEABLE/CLEAN \
+             but fail to merge with a GraphQL error. Run `gh pr ready <n>` first if needed.\n\
+             2. Worktree check: if the PR branch (or main) is checked out in another worktree, \
+             `--delete-branch` fails locally after the server-side merge succeeds — expect to \
+             delete the remote branch manually with `git push origin --delete <branch>`.\n\
+             3. On any merge error: verify with `gh pr view <n> --json mergedAt,mergeCommit` \
+             before retrying — the merge may have landed server-side despite the error.",
+        )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::make_bash;
+
+    // --- guard clause: non-matching commands stay allowed ---
+
+    #[test]
+    fn no_command_allowed() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: None,
+            cwd: None,
+            ..Default::default()
+        };
+        let result = WarnGhMergePreflight.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn unrelated_command_allowed() {
+        let result = WarnGhMergePreflight.run(&make_bash("git status"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn gh_pr_view_allowed() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr view 5 --json mergedAt"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn gh_pr_create_allowed() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr create --title test"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn git_merge_allowed() {
+        // git merge is not gh pr merge
+        let result = WarnGhMergePreflight.run(&make_bash("git merge feature-branch"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- happy path: gh pr merge nudges ---
+
+    #[test]
+    fn gh_pr_merge_nudges() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr merge 5 --squash"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn gh_pr_merge_with_delete_branch_nudges() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr merge 5 --squash --delete-branch"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn gh_pr_merge_auto_nudges() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr merge --auto --squash"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn gh_pr_merge_in_chain_nudges() {
+        let result = WarnGhMergePreflight.run(&make_bash("cd /repo && gh pr merge 12 --merge"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn gh_pr_merge_with_repo_flag_nudges() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr merge 7 -R owner/repo --squash"));
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    // --- nudge message quality: all three gotchas present ---
+
+    #[test]
+    fn nudge_message_covers_draft_check() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr merge 5 --squash"));
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("isDraft"),
+            "nudge should mention the isDraft pre-check: {msg}"
+        );
+    }
+
+    #[test]
+    fn nudge_message_covers_merged_at_verification() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr merge 5 --squash"));
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("mergedAt"),
+            "nudge should mention post-error mergedAt verification: {msg}"
+        );
+    }
+
+    #[test]
+    fn nudge_message_covers_worktree_gotcha() {
+        let result = WarnGhMergePreflight.run(&make_bash("gh pr merge 5 --delete-branch"));
+        let msg = result.message.unwrap_or_default();
+        assert!(
+            msg.contains("worktree"),
+            "nudge should mention the worktree/--delete-branch gotcha: {msg}"
+        );
+    }
+
+    // --- edge cases ---
+
+    #[test]
+    fn quoted_prose_mentioning_merge_allowed() {
+        let result = WarnGhMergePreflight.run(&make_bash("echo 'remember to gh pr merge later'"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn empty_command_allowed() {
+        let result = WarnGhMergePreflight.run(&make_bash(""));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn hyphenated_lookalike_allowed() {
+        let result = WarnGhMergePreflight.run(&make_bash("./gh-pr-merge-helper.sh"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -131,6 +131,8 @@ enum GuardrailsCommands {
     VerifyPrAutoclose,
     /// Block uninvited 1Password vault enumeration (op item list)
     GuardOpVaultScan,
+    /// Warn when bare curl (aliased to curlie) is used with custom headers
+    WarnCurlAlias,
     /// Snooze warn-main-branch for this repo for the given duration
     DismissMainBranchWarn {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
@@ -208,6 +210,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::GuardPrIssueLink => "guard-pr-issue-link",
             GuardrailsCommands::VerifyPrAutoclose => "verify-pr-autoclose",
             GuardrailsCommands::GuardOpVaultScan => "guard-op-vault-scan",
+            GuardrailsCommands::WarnCurlAlias => "warn-curl-alias",
             // dismiss-main-branch-warn is a CLI action, not a hook —
             // it has no PreToolUse/PostToolUse wiring and isn't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
@@ -492,6 +495,10 @@ fn main() {
             ),
             GuardrailsCommands::GuardOpVaultScan => run_check_from_stdin(
                 &cadence_hooks_guardrails::guard_op_vault_scan::OpVaultScanGuard,
+                pre,
+            ),
+            GuardrailsCommands::WarnCurlAlias => run_check_from_stdin(
+                &cadence_hooks_guardrails::warn_curl_alias::WarnCurlAlias,
                 pre,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -129,6 +129,8 @@ enum GuardrailsCommands {
     GuardPrIssueLink,
     /// Verify issue auto-close after PR create/merge; close stragglers
     VerifyPrAutoclose,
+    /// Block uninvited 1Password vault enumeration (op item list)
+    GuardOpVaultScan,
     /// Snooze warn-main-branch for this repo for the given duration
     DismissMainBranchWarn {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
@@ -205,6 +207,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::GuardDotfiles => "guard-dotfiles",
             GuardrailsCommands::GuardPrIssueLink => "guard-pr-issue-link",
             GuardrailsCommands::VerifyPrAutoclose => "verify-pr-autoclose",
+            GuardrailsCommands::GuardOpVaultScan => "guard-op-vault-scan",
             // dismiss-main-branch-warn is a CLI action, not a hook —
             // it has no PreToolUse/PostToolUse wiring and isn't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
@@ -486,6 +489,10 @@ fn main() {
             GuardrailsCommands::VerifyPrAutoclose => run_check_from_stdin(
                 &cadence_hooks_guardrails::verify_pr_autoclose::VerifyPrAutoclose,
                 post,
+            ),
+            GuardrailsCommands::GuardOpVaultScan => run_check_from_stdin(
+                &cadence_hooks_guardrails::guard_op_vault_scan::OpVaultScanGuard,
+                pre,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {
                 cadence_hooks_guardrails::dismiss_main_branch_warn::run_dismiss(&for_);

--- a/src/main.rs
+++ b/src/main.rs
@@ -135,6 +135,8 @@ enum GuardrailsCommands {
     WarnCurlAlias,
     /// Pre-flight checklist nudge before gh pr merge (draft, worktree, verify)
     WarnGhMergePreflight,
+    /// Warn that CodeRabbit re-trigger comments are no-ops on reviewed content
+    WarnCoderabbitRetrigger,
     /// Snooze warn-main-branch for this repo for the given duration
     DismissMainBranchWarn {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
@@ -214,6 +216,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::GuardOpVaultScan => "guard-op-vault-scan",
             GuardrailsCommands::WarnCurlAlias => "warn-curl-alias",
             GuardrailsCommands::WarnGhMergePreflight => "warn-gh-merge-preflight",
+            GuardrailsCommands::WarnCoderabbitRetrigger => "warn-coderabbit-retrigger",
             // dismiss-main-branch-warn is a CLI action, not a hook —
             // it has no PreToolUse/PostToolUse wiring and isn't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
@@ -506,6 +509,10 @@ fn main() {
             ),
             GuardrailsCommands::WarnGhMergePreflight => run_check_from_stdin(
                 &cadence_hooks_guardrails::warn_gh_merge_preflight::WarnGhMergePreflight,
+                pre,
+            ),
+            GuardrailsCommands::WarnCoderabbitRetrigger => run_check_from_stdin(
+                &cadence_hooks_guardrails::warn_coderabbit_retrigger::WarnCoderabbitRetrigger,
                 pre,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -137,6 +137,8 @@ enum GuardrailsCommands {
     WarnGhMergePreflight,
     /// Warn that CodeRabbit re-trigger comments are no-ops on reviewed content
     WarnCoderabbitRetrigger,
+    /// Warn when piping aliased-tool output (ls/find/cat/du/df/top) into parsers
+    WarnAliasParsing,
     /// Snooze warn-main-branch for this repo for the given duration
     DismissMainBranchWarn {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
@@ -217,6 +219,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::WarnCurlAlias => "warn-curl-alias",
             GuardrailsCommands::WarnGhMergePreflight => "warn-gh-merge-preflight",
             GuardrailsCommands::WarnCoderabbitRetrigger => "warn-coderabbit-retrigger",
+            GuardrailsCommands::WarnAliasParsing => "warn-alias-parsing",
             // dismiss-main-branch-warn is a CLI action, not a hook —
             // it has no PreToolUse/PostToolUse wiring and isn't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
@@ -513,6 +516,10 @@ fn main() {
             ),
             GuardrailsCommands::WarnCoderabbitRetrigger => run_check_from_stdin(
                 &cadence_hooks_guardrails::warn_coderabbit_retrigger::WarnCoderabbitRetrigger,
+                pre,
+            ),
+            GuardrailsCommands::WarnAliasParsing => run_check_from_stdin(
+                &cadence_hooks_guardrails::warn_alias_parsing::WarnAliasParsing,
                 pre,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -133,6 +133,8 @@ enum GuardrailsCommands {
     GuardOpVaultScan,
     /// Warn when bare curl (aliased to curlie) is used with custom headers
     WarnCurlAlias,
+    /// Pre-flight checklist nudge before gh pr merge (draft, worktree, verify)
+    WarnGhMergePreflight,
     /// Snooze warn-main-branch for this repo for the given duration
     DismissMainBranchWarn {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
@@ -211,6 +213,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::VerifyPrAutoclose => "verify-pr-autoclose",
             GuardrailsCommands::GuardOpVaultScan => "guard-op-vault-scan",
             GuardrailsCommands::WarnCurlAlias => "warn-curl-alias",
+            GuardrailsCommands::WarnGhMergePreflight => "warn-gh-merge-preflight",
             // dismiss-main-branch-warn is a CLI action, not a hook —
             // it has no PreToolUse/PostToolUse wiring and isn't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
@@ -499,6 +502,10 @@ fn main() {
             ),
             GuardrailsCommands::WarnCurlAlias => run_check_from_stdin(
                 &cadence_hooks_guardrails::warn_curl_alias::WarnCurlAlias,
+                pre,
+            ),
+            GuardrailsCommands::WarnGhMergePreflight => run_check_from_stdin(
+                &cadence_hooks_guardrails::warn_gh_merge_preflight::WarnGhMergePreflight,
                 pre,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -140,6 +140,11 @@ pub const HOOKS: &[HookEntry] = &[
         description: "Block uninvited 1Password vault enumeration (op item list)",
         plugin: "guardrails",
     },
+    HookEntry {
+        name: "warn-curl-alias",
+        description: "Warn when bare curl (aliased to curlie) is used with custom headers",
+        plugin: "guardrails",
+    },
     // rules
     HookEntry {
         name: "validate-frontmatter",

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -145,6 +145,11 @@ pub const HOOKS: &[HookEntry] = &[
         description: "Warn when bare curl (aliased to curlie) is used with custom headers",
         plugin: "guardrails",
     },
+    HookEntry {
+        name: "warn-gh-merge-preflight",
+        description: "Pre-flight checklist nudge before gh pr merge (draft, worktree, verify)",
+        plugin: "guardrails",
+    },
     // rules
     HookEntry {
         name: "validate-frontmatter",

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -150,6 +150,11 @@ pub const HOOKS: &[HookEntry] = &[
         description: "Pre-flight checklist nudge before gh pr merge (draft, worktree, verify)",
         plugin: "guardrails",
     },
+    HookEntry {
+        name: "warn-coderabbit-retrigger",
+        description: "Warn that CodeRabbit re-trigger comments are no-ops on reviewed content",
+        plugin: "guardrails",
+    },
     // rules
     HookEntry {
         name: "validate-frontmatter",

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -155,6 +155,11 @@ pub const HOOKS: &[HookEntry] = &[
         description: "Warn that CodeRabbit re-trigger comments are no-ops on reviewed content",
         plugin: "guardrails",
     },
+    HookEntry {
+        name: "warn-alias-parsing",
+        description: "Warn when piping aliased-tool output (ls/find/cat/du/df/top) into parsers",
+        plugin: "guardrails",
+    },
     // rules
     HookEntry {
         name: "validate-frontmatter",

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -135,6 +135,11 @@ pub const HOOKS: &[HookEntry] = &[
         description: "Verify and repair issue auto-close after PR create/merge",
         plugin: "guardrails",
     },
+    HookEntry {
+        name: "guard-op-vault-scan",
+        description: "Block uninvited 1Password vault enumeration (op item list)",
+        plugin: "guardrails",
+    },
     // rules
     HookEntry {
         name: "validate-frontmatter",

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -110,6 +110,16 @@ const NON_HOOK_BINARY_SUBCOMMANDS: &[&str] = &[
     "guardrails dismiss-main-branch-warn",
 ];
 
+/// settings.json shell scripts that trip the keyword-overlap heuristic but are
+/// NOT duplicates of plugin hooks. Each entry documents the distinction.
+const KNOWN_DISTINCT_SETTINGS_SCRIPTS: &[&str] = &[
+    // Blocks git writes inside the *Obsidian* vault working copy. Shares the
+    // filename tokens "vault" (with `guardrails guard-op-vault-scan` — a
+    // *1Password* vault check) and "writes" (with `cadence
+    // prevent-secret-writes`), but duplicates neither.
+    "block-vault-git-writes.sh",
+];
+
 /// Plugin name -> list of `<plugin> <subcommand>` strings referenced in its hooks.json.
 fn hooks_json_references() -> BTreeMap<String, Vec<HookRef>> {
     let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
@@ -450,6 +460,9 @@ fn no_plugin_hooks_duplicated_in_settings_json() {
 
     for script in &shell_scripts {
         let filename = script.rsplit('/').next().unwrap_or(script).to_lowercase();
+        if KNOWN_DISTINCT_SETTINGS_SCRIPTS.contains(&filename.as_str()) {
+            continue;
+        }
         let filename_tokens: BTreeSet<String> = filename
             .split(|c: char| !c.is_alphanumeric())
             .filter(|t| !t.is_empty())


### PR DESCRIPTION
## Summary

Five new guardrails checks converting machine-enforceable prose rules from `~/.claude/CLAUDE.md` into deterministic hooks — moving them rightward on the soft→hard enforcement gradient.

| Check | Outcome | Detects |
|---|---|---|
| `guard-op-vault-scan` | **Block** | `op item list` / `op vault list` enumeration (incl. exec wrappers); single-item reads stay allowed |
| `warn-curl-alias` | Nudge | Bare `curl` + `-H`/`--header` (curlie alias infers POST from JSON headers → silent 400s) |
| `warn-gh-merge-preflight` | Nudge | `gh pr merge` → checklist: isDraft, worktree/`--delete-branch`, post-error `mergedAt` verification |
| `warn-coderabbit-retrigger` | Nudge | `@coderabbitai review` comments (content-cached; push a commit instead) |
| `warn-alias-parsing` | Nudge | Aliased tools (cat/find/ls/du/df/top) as pipeline producers |

## Design notes

- One commit per check, each with full registration (clap enum + dispatch + `hook_name()` + registry entry) and colocated tests (guard-clause / happy-path / edge / evasion categories)
- All checks fail open per ADR-0001; quote-stripping prevents prose false positives
- `warn-coderabbit-retrigger` inverts the quote rule: the trigger phrase lives inside the quoted `--body`, so it token-gates on `gh`+`comment` from the stripped command and reads the phrase from the raw command
- `warn-alias-parsing` fires only when an aliased tool is a pipeline *producer* — interactive use and consumer position (`git diff | cat`) stay silent
- Adds `KNOWN_DISTINCT_SETTINGS_SCRIPTS` to the registration audit: `block-vault-git-writes.sh` (Obsidian vault) shares filename tokens with `guard-op-vault-scan` (1Password vault) but duplicates nothing

## Verification

- `make ci` green: fmt-check, clippy `-D warnings`, 20 test binaries, 0 failures
- Binary-level smoke test: all 5 checks fire on matching input (exit 2 / nudge JSON) and stay silent on non-matching input (exit 0)
- hooks.json wiring lands separately in cadence-guardrails (two-PR shape); the local sibling is already wired so the registration audit passes

## Companion PR

cameronsjo/cadence-guardrails (hooks.json wiring with `if:` filters) — merge after this PR and the 0.13.0 release.

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)
