### PR TITLE
fix: downgrade guard-pr-issue-link to warn-pr-issue-link nudge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- `guard-pr-issue-link` renamed to `warn-pr-issue-link` and downgraded from a hard block to a nudge. PRs without a linked issue are a routine, intentional workflow; the check now reminds about closing keywords instead of blocking `gh pr create`. The companion `verify-pr-autoclose` (PostToolUse, advisory) is unchanged and still covers broken issue refs.
+
 ## [0.13.0] - 2026-06-01
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Hooks are organized by the plugin they serve:
 | `check-idle-return` | PreToolUse | Nudge after idle periods between edits |
 | `nudge-upgrade-after-push` | PostToolUse (Bash) | Nudge to schedule a brew upgrade after pushing cadence-hooks to main |
 | `guard-dotfiles` | PreToolUse (Edit, Write) | Block direct edits to production dotfiles (opt-in via `CADENCE_GUARD_DOTFILES=1`) |
-| `guard-pr-issue-link` | PreToolUse (Bash) | Block `gh pr create` without a closing issue keyword (`Closes #N`) in the body |
+| `warn-pr-issue-link` | PreToolUse (Bash) | Nudge when `gh pr create` has no closing issue keyword (`Closes #N`) in the body |
 | `verify-pr-autoclose` | PostToolUse (Bash) | Verify issue auto-close refs after PR create; close stragglers after merge |
 | `guard-op-vault-scan` | PreToolUse (Bash) | Block 1Password vault enumeration (`op item list`); single-item reads stay allowed |
 | `warn-curl-alias` | PreToolUse (Bash) | Warn when bare `curl` (aliased to curlie) is used with custom headers |

--- a/crates/guardrails/src/issue_refs.rs
+++ b/crates/guardrails/src/issue_refs.rs
@@ -1,9 +1,9 @@
 //! Shared closing-keyword detection for GitHub issue references.
 //!
-//! Both `guard_pr_issue_link` (boolean: does the PR body link an issue?) and
+//! Both `warn_pr_issue_link` (boolean: does the PR body link an issue?) and
 //! `verify_pr_autoclose` (extraction: which issues does it close?) recognize
 //! the same GitHub closing keywords. One regex serves both so the pattern
-//! cannot drift between guards.
+//! cannot drift between checks.
 
 use regex::Regex;
 use std::sync::LazyLock;

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -17,8 +17,6 @@ pub mod guard_gh_write;
 pub mod guard_git_init;
 /// Block uninvited 1Password vault enumeration (`op item list`).
 pub mod guard_op_vault_scan;
-/// Block `gh pr create` when the PR body has no closing keyword linking to an issue.
-pub mod guard_pr_issue_link;
 /// Block `git push` to remotes owned by others.
 pub mod guard_push_remote;
 /// Shared closing-keyword detection for GitHub issue references.
@@ -41,5 +39,7 @@ pub mod warn_curl_alias;
 pub mod warn_gh_merge_preflight;
 /// Warn when editing files directly on main/master branch.
 pub mod warn_main_branch;
+/// Remind on `gh pr create` when the PR body has no closing keyword linking to an issue.
+pub mod warn_pr_issue_link;
 /// Warn about untracked files during git commit operations.
 pub mod warn_untracked;

--- a/crates/guardrails/src/verify_pr_autoclose.rs
+++ b/crates/guardrails/src/verify_pr_autoclose.rs
@@ -15,7 +15,7 @@ use std::sync::LazyLock;
 // Pure helpers
 // ---------------------------------------------------------------------------
 
-// Closing-keyword detection is shared with guard_pr_issue_link via issue_refs.
+// Closing-keyword detection is shared with warn_pr_issue_link via issue_refs.
 pub use crate::issue_refs::extract_refs;
 
 /// Parse a git remote URL into `(host, "owner/repo")`.

--- a/crates/guardrails/src/warn_pr_issue_link.rs
+++ b/crates/guardrails/src/warn_pr_issue_link.rs
@@ -1,10 +1,12 @@
-//! Block `gh pr create` when the PR body has no closing keyword linking to an issue.
+//! Remind on `gh pr create` when the PR body has no closing keyword linking to an issue.
 //!
-//! Detects `gh pr create` commands and ensures the PR body contains a recognized
-//! closing keyword (`closes`, `fixes`, `resolves` and their variants) followed by
-//! an issue reference (`#N`). Port improvement over the original Bash version:
-//! when `--body-file`/`-F` is present, the file's contents are also scanned so
-//! the keyword inside the file is not false-blocked.
+//! Detects `gh pr create` commands and nudges (never blocks) when the PR body
+//! lacks a recognized closing keyword (`closes`, `fixes`, `resolves` and their
+//! variants) followed by an issue reference (`#N`). PRs without a linked issue
+//! are a routine, intentional workflow — this check only reminds, so an issue
+//! that does exist gets auto-closed on merge. When `--body-file`/`-F` is
+//! present, the file's contents are also scanned so a keyword inside the file
+//! is not false-flagged.
 
 use crate::issue_refs::has_closing_keyword;
 use cadence_hooks_core::shell::{strip_quotes, tokenize};
@@ -44,8 +46,8 @@ pub(crate) enum BodyFile {
     Unreadable,
 }
 
-/// Pure decision function. Returns `Some(deny_message)` when the PR should be
-/// blocked, `None` when it should be allowed.
+/// Pure decision function. Returns `Some(nudge_message)` when the PR body has
+/// no closing keyword, `None` when it does (or when the check doesn't apply).
 pub(crate) fn judge_pr_create(command: &str, body_file: &BodyFile) -> Option<String> {
     // Only guard `gh pr create`. Strip quoted regions first so text like
     // `echo "gh pr create ..."` is treated as data, not a command.
@@ -60,32 +62,32 @@ pub(crate) fn judge_pr_create(command: &str, body_file: &BodyFile) -> Option<Str
     }
 
     match body_file {
-        // File read and contains a keyword — allow.
+        // File read and contains a keyword — silent.
         BodyFile::Contents(contents) if has_closing_keyword(contents) => None,
-        // File read but no keyword anywhere — deny.
-        BodyFile::Contents(_) => Some(deny_message()),
-        // Flag present but the file could not be read — fail OPEN (ADR-0001).
-        // This is the guard's own verification failure (write/hook race,
-        // permissions, path resolution), not the user's violation.
+        // File read but no keyword anywhere — nudge.
+        BodyFile::Contents(_) => Some(nudge_message()),
+        // Flag present but the file could not be read — stay silent (ADR-0001).
+        // This is the check's own verification failure (write/hook race,
+        // permissions, path resolution), not the user's omission.
         BodyFile::Unreadable => None,
-        // No body file and no keyword in the command — deny.
-        BodyFile::Absent => Some(deny_message()),
+        // No body file and no keyword in the command — nudge.
+        BodyFile::Absent => Some(nudge_message()),
     }
 }
 
-fn deny_message() -> String {
-    "🚫 guard-pr-issue-link: PR body must include a closing keyword linking to a GitHub Issue\n   \
-     (e.g., 'Closes #123').\n   \
-     Fix: add 'Closes #N', 'Fixes #N', or 'Resolves #N' to the PR body before creating."
+fn nudge_message() -> String {
+    "warn-pr-issue-link: PR body has no closing keyword (Closes/Fixes/Resolves #N). \
+     If this PR addresses an existing issue, add one so it auto-closes on merge. \
+     If there's no issue, carry on."
         .to_string()
 }
 
-/// Blocks `gh pr create` when no closing keyword is found in the PR body.
-pub struct PrIssueLinkGuard;
+/// Nudges on `gh pr create` when no closing keyword is found in the PR body.
+pub struct WarnPrIssueLink;
 
-impl Check for PrIssueLinkGuard {
+impl Check for WarnPrIssueLink {
     fn name(&self) -> &str {
-        "guard-pr-issue-link"
+        "warn-pr-issue-link"
     }
 
     fn run(&self, input: &HookInput) -> CheckResult {
@@ -108,7 +110,7 @@ impl Check for PrIssueLinkGuard {
         };
 
         match judge_pr_create(command, &body_file) {
-            Some(msg) => CheckResult::block(msg),
+            Some(msg) => CheckResult::nudge(msg),
             None => CheckResult::allow(),
         }
     }
@@ -163,9 +165,9 @@ mod tests {
         );
     }
 
-    // Test case 5: no closing keyword in inline body — deny
+    // Test case 5: no closing keyword in inline body — nudge
     #[test]
-    fn inline_body_no_keyword_denied() {
+    fn inline_body_no_keyword_nudged() {
         assert!(
             judge_pr_create(
                 r#"gh pr create --title x --body "no link here""#,
@@ -182,9 +184,9 @@ mod tests {
         assert!(judge_pr_create("gh pr create -t x -F body.md", &contents).is_none());
     }
 
-    // Test case 6b: --body-file flag present but file unreadable — fail OPEN (ADR-0001).
-    // An unreadable file is the guard's own verification failure (write/hook race,
-    // permissions, path resolution) — never block the user on it.
+    // Test case 6b: --body-file flag present but file unreadable — stay silent (ADR-0001).
+    // An unreadable file is the check's own verification failure (write/hook race,
+    // permissions, path resolution) — never bother the user about it.
     #[test]
     fn body_file_unreadable_fails_open() {
         assert!(
@@ -196,9 +198,9 @@ mod tests {
         );
     }
 
-    // Test case 7: "#5" without closing keyword — deny
+    // Test case 7: "#5" without closing keyword — nudge
     #[test]
-    fn bare_issue_reference_without_keyword_denied() {
+    fn bare_issue_reference_without_keyword_nudged() {
         assert!(judge_pr_create(r#"gh pr create --body "see #5""#, &BodyFile::Absent).is_some());
     }
 
@@ -234,9 +236,9 @@ mod tests {
         );
     }
 
-    // Extra: body file with no keyword — deny
+    // Extra: body file with no keyword — nudge
     #[test]
-    fn body_file_without_keyword_denied() {
+    fn body_file_without_keyword_nudged() {
         let contents =
             BodyFile::Contents("This is a detailed description with no issue link.".into());
         assert!(judge_pr_create("gh pr create -t x -F body.md", &contents).is_some());
@@ -298,7 +300,7 @@ mod tests {
 
     // `--body-file` appearing inside quoted body text is data, not a flag.
     // Treating it as a flag turns the phantom (unreadable) path into a
-    // fail-open bypass: no keyword anywhere, yet the PR is allowed.
+    // silent bypass: no keyword anywhere, yet no reminder fires.
     #[test]
     fn quoted_body_text_mentioning_body_file_is_not_a_flag() {
         let cmd = r#"gh pr create --title x --body "see --body-file foo""#;
@@ -313,7 +315,7 @@ mod tests {
 
     // gh accepts `--body-file=path` — must resolve the same as the spaced form,
     // otherwise the flag goes undetected and a keyword-bearing file is ignored
-    // (false block).
+    // (false nudge).
     #[test]
     fn extracts_equals_form_body_file_path() {
         let cmd = "gh pr create --title x --body-file=./body.md";
@@ -321,8 +323,8 @@ mod tests {
     }
 
     // Quoted paths containing spaces must be captured whole — truncating at the
-    // first space makes the file unreadable, and the fail-open path would then
-    // let an unverified PR through.
+    // first space makes the file unreadable, and the silent path would then
+    // skip the reminder for an unverified PR.
     #[test]
     fn extracts_double_quoted_path_with_spaces() {
         let cmd = r#"gh pr create -F "docs/pr bodies/body.md""#;
@@ -344,16 +346,16 @@ mod tests {
     // ---- Check::run integration tests ----
 
     #[test]
-    fn check_blocks_pr_create_without_keyword() {
-        let result = PrIssueLinkGuard.run(&make_bash(
+    fn check_nudges_pr_create_without_keyword() {
+        let result = WarnPrIssueLink.run(&make_bash(
             r#"gh pr create --title "my PR" --body "no issue link""#,
         ));
-        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
     }
 
     #[test]
     fn check_allows_pr_create_with_keyword() {
-        let result = PrIssueLinkGuard.run(&make_bash(
+        let result = WarnPrIssueLink.run(&make_bash(
             r#"gh pr create --title "my PR" --body "Closes #5""#,
         ));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -361,24 +363,24 @@ mod tests {
 
     #[test]
     fn check_allows_non_pr_create() {
-        let result = PrIssueLinkGuard.run(&make_bash("git status"));
+        let result = WarnPrIssueLink.run(&make_bash("git status"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     // End-to-end: quoted body text mentioning --body-file must NOT become a
-    // phantom unreadable file (which would fail open). No keyword → block.
+    // phantom unreadable file (which would stay silent). No keyword → nudge.
     #[test]
-    fn check_blocks_quoted_body_file_mention_without_keyword() {
-        let result = PrIssueLinkGuard.run(&make_bash(
+    fn check_nudges_quoted_body_file_mention_without_keyword() {
+        let result = WarnPrIssueLink.run(&make_bash(
             r#"gh pr create --title x --body "see --body-file foo""#,
         ));
-        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
     }
 
-    // Check::run with an unreadable body file — fail open end-to-end.
+    // Check::run with an unreadable body file — stay silent end-to-end.
     #[test]
     fn check_allows_unreadable_body_file() {
-        let result = PrIssueLinkGuard.run(&make_bash(
+        let result = WarnPrIssueLink.run(&make_bash(
             "gh pr create -t x --body-file /nonexistent/dir/body-that-cannot-exist.md",
         ));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
@@ -392,26 +394,34 @@ mod tests {
             cwd: None,
             ..Default::default()
         };
-        let result = PrIssueLinkGuard.run(&input);
+        let result = WarnPrIssueLink.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
-    fn deny_message_includes_fix_line() {
-        let msg = deny_message();
-        assert!(msg.contains("Closes #N"));
-        assert!(msg.contains("Fixes #N"));
-        assert!(msg.contains("Resolves #N"));
+    fn nudge_message_lists_closing_keywords() {
+        let msg = nudge_message();
+        assert!(msg.contains("Closes/Fixes/Resolves #N"));
     }
 
-    // The deny message names this check (not the legacy plugin name) so a
-    // blocked user can find the responsible guard.
+    // The nudge never reads as a block: no emoji, no imperative "Fix:" line,
+    // and it explicitly tells the user it's fine to proceed without an issue.
     #[test]
-    fn deny_message_names_the_check() {
-        let msg = deny_message();
+    fn nudge_message_is_advisory_not_blocking() {
+        let msg = nudge_message();
+        assert!(!msg.contains("🚫"));
+        assert!(!msg.contains("Fix:"));
+        assert!(msg.contains("carry on"));
+    }
+
+    // The nudge message names this check so the user can find (and silence)
+    // the responsible hook.
+    #[test]
+    fn nudge_message_names_the_check() {
+        let msg = nudge_message();
         assert!(
-            msg.contains("guard-pr-issue-link:"),
-            "deny message should name the check, got: {msg}"
+            msg.contains("warn-pr-issue-link:"),
+            "nudge message should name the check, got: {msg}"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,8 +149,8 @@ enum GuardrailsCommands {
     WarnUntracked,
     /// Block direct edits to production dotfiles (opt-in via CADENCE_GUARD_DOTFILES=1)
     GuardDotfiles,
-    /// Block `gh pr create` without a closing issue keyword in the body
-    GuardPrIssueLink,
+    /// Nudge when `gh pr create` has no closing issue keyword in the body
+    WarnPrIssueLink,
     /// Verify issue auto-close after PR create/merge; close stragglers
     VerifyPrAutoclose,
     /// Block uninvited 1Password vault enumeration (op item list)
@@ -261,7 +261,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::NudgeUpgradeAfterPush => "nudge-upgrade-after-push",
             GuardrailsCommands::WarnUntracked => "warn-untracked",
             GuardrailsCommands::GuardDotfiles => "guard-dotfiles",
-            GuardrailsCommands::GuardPrIssueLink => "guard-pr-issue-link",
+            GuardrailsCommands::WarnPrIssueLink => "warn-pr-issue-link",
             GuardrailsCommands::VerifyPrAutoclose => "verify-pr-autoclose",
             GuardrailsCommands::GuardOpVaultScan => "guard-op-vault-scan",
             GuardrailsCommands::WarnCurlAlias => "warn-curl-alias",
@@ -586,8 +586,8 @@ fn main() {
                 &cadence_hooks_guardrails::guard_dotfiles::GuardDotfiles,
                 pre,
             ),
-            GuardrailsCommands::GuardPrIssueLink => run_check_from_stdin(
-                &cadence_hooks_guardrails::guard_pr_issue_link::PrIssueLinkGuard,
+            GuardrailsCommands::WarnPrIssueLink => run_check_from_stdin(
+                &cadence_hooks_guardrails::warn_pr_issue_link::WarnPrIssueLink,
                 pre,
             ),
             GuardrailsCommands::VerifyPrAutoclose => run_check_from_stdin(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -156,8 +156,8 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::PreToolUse),
     },
     HookEntry {
-        name: "guard-pr-issue-link",
-        description: "Block gh pr create without a closing issue keyword",
+        name: "warn-pr-issue-link",
+        description: "Nudge when gh pr create has no closing issue keyword",
         plugin: "guardrails",
         event: Some(HookEvent::PreToolUse),
     },


### PR DESCRIPTION
## Why

`guard-pr-issue-link` (added in #47) hard-blocks `gh pr create` whenever the PR body lacks a closing keyword (`Closes/Fixes/Resolves #N`). That policy assumes every PR must link a pre-existing issue — but PRs without issues are a routine, intentional workflow here. The block fires on every such PR, including this one's companion.

## What

- **Rename** `guard-pr-issue-link` → `warn-pr-issue-link` per the repo's severity convention (`guard-*` blocks, `warn-*` nudges)
- **Downgrade** from `CheckResult::block` (exit 2, stderr) to `CheckResult::nudge` (exit 0, `additionalContext`)
- Advisory message: reminds about closing keywords when an issue exists, explicitly says "carry on" when there isn't one
- Module/struct/clap/registry/README/CHANGELOG all follow the rename
- `verify-pr-autoclose` (PostToolUse, advisory) is **unchanged** — it still covers broken issue refs after create/merge

## Compatibility

The old subcommand name now fails open (exit 1, unknown-subcommand guidance) per ADR-0001 — a stale hooks.json calling `guard-pr-issue-link` can never block.

Companion PR: cameronsjo/cadence-guardrails (hooks.json rename), to be merged after this one.

## Verification

- `make ci` green locally (fmt + clippy -D warnings + all tests, including hook registration audit against the renamed sibling hooks.json)
- Manual stdin tests: no-keyword → exit 0 + nudge JSON; `Closes #5` → exit 0 silent; old name → exit 1 fail-open

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * The PR issue-link guardrail is now advisory instead of blocking pull request creation
  * Users creating pull requests without a closing issue keyword receive a friendly reminder instead of being prevented from proceeding
  * The check has been renamed and repositioned to better reflect its nudge-based behavior
  * Documentation updated to reflect the new non-blocking approach

<!-- end of auto-generated comment: release notes by coderabbit.ai -->