### PR TITLE
fix: validate post-edit content, not the Edit payload

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,6 +211,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]
@@ -257,6 +258,7 @@ version = "0.15.2"
 dependencies = [
  "cadence-hooks-core",
  "regex",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/cadence/src/block_orphaned_todos.rs
+++ b/crates/cadence/src/block_orphaned_todos.rs
@@ -220,6 +220,7 @@ mod tests {
                 content: Some(content.into()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -251,6 +252,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -390,6 +392,7 @@ mod tests {
                 content: Some(make_marker("TODO", false)),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/cadence/src/memory_guard.rs
+++ b/crates/cadence/src/memory_guard.rs
@@ -90,6 +90,7 @@ mod tests {
                 content: Some(content),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -267,6 +267,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -321,6 +322,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -696,6 +698,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -715,6 +718,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -734,6 +738,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -279,7 +279,7 @@ mod tests {
 
     #[test]
     fn edit_env_blocked() {
-        let result = SecretWritesGuard.run(&make_edit_input("/project/.env.local"));
+        let result = SecretWritesGuard.run(&make_edit_input("/project/.env.local", "old", "new"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
@@ -324,6 +324,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -373,13 +374,14 @@ mod tests {
 
     #[test]
     fn edit_key_file_blocked() {
-        let result = SecretWritesGuard.run(&make_edit_input("/etc/ssl/server.key"));
+        let result = SecretWritesGuard.run(&make_edit_input("/etc/ssl/server.key", "old", "new"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]
     fn edit_private_pem_blocked() {
-        let result = SecretWritesGuard.run(&make_edit_input("/etc/ssl/server-key.pem"));
+        let result =
+            SecretWritesGuard.run(&make_edit_input("/etc/ssl/server-key.pem", "old", "new"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
@@ -427,13 +429,14 @@ mod tests {
 
     #[test]
     fn edit_env_example_allowed() {
-        let result = SecretWritesGuard.run(&make_edit_input("/project/.env.example"));
+        let result = SecretWritesGuard.run(&make_edit_input("/project/.env.example", "old", "new"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]
     fn edit_env_template_allowed() {
-        let result = SecretWritesGuard.run(&make_edit_input("/project/.env.template"));
+        let result =
+            SecretWritesGuard.run(&make_edit_input("/project/.env.template", "old", "new"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
@@ -471,7 +474,7 @@ mod tests {
 
     #[test]
     fn edit_env_backslash_path_blocked() {
-        let result = SecretWritesGuard.run(&make_edit_input(r"C:\Users\dev\.env"));
+        let result = SecretWritesGuard.run(&make_edit_input(r"C:\Users\dev\.env", "old", "new"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
@@ -486,6 +489,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -505,6 +509,7 @@ mod tests {
                 content: Some("content".into()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -123,6 +123,21 @@ fn is_excluded_path(path: &str) -> bool {
         || path.contains(".claude/rules/")
 }
 
+/// Remove violations that were already present in pre-existing content.
+///
+/// For Edit tool calls, a flagged term that appears in both `old_string` and
+/// `new_string` is surrounding context being carried through the edit, not
+/// new content — only *introduced* violations should fire.
+fn subtract_existing(
+    found: Vec<(String, String)>,
+    existing: &[(String, String)],
+) -> Vec<(String, String)> {
+    found
+        .into_iter()
+        .filter(|item| !existing.contains(item))
+        .collect()
+}
+
 /// Blocks content containing prohibited terminology and suggests alternatives.
 pub struct TerminologyGuard;
 
@@ -142,7 +157,20 @@ impl Check for TerminologyGuard {
             return CheckResult::allow();
         }
 
-        let result = check_terminology(content);
+        let mut result = check_terminology(content);
+
+        // Edit tool: only violations *introduced* by this edit count. A term
+        // already present in old_string is pre-existing file content — blocking
+        // on it would prevent edits that don't add anything prohibited (#63).
+        if let Some(old) = input
+            .tool_input
+            .as_ref()
+            .and_then(|ti| ti.old_string.as_deref())
+        {
+            let existing = check_terminology(old);
+            result.blocks = subtract_existing(result.blocks, &existing.blocks);
+            result.nudges = subtract_existing(result.nudges, &existing.nudges);
+        }
 
         // Tier 1: hard block
         if !result.blocks.is_empty() {
@@ -312,6 +340,7 @@ mod tests {
                 content: Some(BLOCK_VIOLATIONS[0].0.to_string()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -369,6 +398,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -388,6 +418,7 @@ mod tests {
                 content: Some(BLOCK_VIOLATIONS[0].0.to_string()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -407,6 +438,7 @@ mod tests {
                 content: Some(BLOCK_VIOLATIONS[0].0.to_string()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -475,6 +507,7 @@ mod tests {
                 content: Some(BLOCK_VIOLATIONS[0].0.to_string()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -495,6 +528,7 @@ mod tests {
                 content: Some(content),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -518,6 +552,85 @@ mod tests {
                 content: Some(BLOCK_VIOLATIONS[0].0.to_string()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
+            }),
+            cwd: None,
+            ..Default::default()
+        };
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    // --- Edit tool: only introduced violations fire (#63) ---
+
+    use cadence_hooks_core::test_builders::make_edit;
+
+    #[test]
+    fn edit_with_preexisting_term_in_context_allowed() {
+        // The flagged term appears in both old_string and new_string — it is
+        // pre-existing file content carried through the edit, not new content.
+        let term = BLOCK_VIOLATIONS[0].0;
+        let input = make_edit(
+            "/project/src/config.rs",
+            &format!("{term} setting\nvalue = 1"),
+            &format!("{term} setting\nvalue = 2"),
+        );
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn edit_introducing_term_blocks() {
+        // The flagged term appears only in new_string — this edit introduces it.
+        let term = BLOCK_VIOLATIONS[0].0;
+        let input = make_edit(
+            "/project/src/config.rs",
+            "value = 1",
+            &format!("value = 2 // uses the {term}"),
+        );
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn edit_with_preexisting_nudge_term_allowed() {
+        let term = NUDGE_VIOLATIONS[0].0;
+        let input = make_edit(
+            "/project/docs/policy.md",
+            &format!("{term} clause, v1"),
+            &format!("{term} clause, v2"),
+        );
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn edit_introducing_one_term_reports_only_that_term() {
+        // old context has term A; new content keeps term A and adds term B —
+        // only B should be reported.
+        let term_a = BLOCK_VIOLATIONS[0].0;
+        let term_b = BLOCK_VIOLATIONS[1].0;
+        let input = make_edit(
+            "/project/src/config.rs",
+            &format!("{term_a} config"),
+            &format!("{term_a} config and {term_b}"),
+        );
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        let msg = result.message.unwrap();
+        assert!(msg.contains(term_b));
+        assert!(!msg.contains(&format!("\"{term_a}\"")));
+    }
+
+    #[test]
+    fn write_with_term_still_blocks() {
+        // Write behavior is unchanged: no old_string, so every violation fires.
+        let input = HookInput {
+            tool_name: Some("Write".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some("/project/src/main.rs".into()),
+                content: Some(BLOCK_VIOLATIONS[0].0.to_string()),
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/cadence/src/validate_env_vars.rs
+++ b/crates/cadence/src/validate_env_vars.rs
@@ -101,6 +101,7 @@ mod tests {
                 content: Some(content.into()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -172,6 +173,7 @@ mod tests {
                 content: Some("process.env.DEBUG".into()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -191,6 +193,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -337,6 +340,7 @@ mod tests {
                 content: None,
                 new_string: Some("process.env.DEBUG".into()),
                 old_string: Some("old".into()),
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/cadence/src/validate_line_endings.rs
+++ b/crates/cadence/src/validate_line_endings.rs
@@ -55,6 +55,7 @@ mod tests {
                 content: Some(content.into()),
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -119,6 +120,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -13,3 +13,6 @@ serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
 brush-parser.workspace = true
+
+[dev-dependencies]
+tempfile = "3"

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -148,7 +148,7 @@ pub struct HookInput {
 }
 
 /// Tool-specific fields from the hook input.
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Default, Deserialize)]
 pub struct ToolInput {
     pub file_path: Option<String>,
     pub path: Option<String>,
@@ -156,6 +156,27 @@ pub struct ToolInput {
     pub content: Option<String>,
     pub new_string: Option<String>,
     pub old_string: Option<String>,
+    /// Edit tool: replace every occurrence of `old_string` (default: first only).
+    pub replace_all: Option<bool>,
+    /// MultiEdit tool: sequence of edit operations applied in order.
+    pub edits: Option<Vec<EditOperation>>,
+}
+
+/// A single edit operation within a MultiEdit tool call.
+#[derive(Debug, Default, Deserialize)]
+pub struct EditOperation {
+    pub old_string: Option<String>,
+    pub new_string: Option<String>,
+    pub replace_all: Option<bool>,
+}
+
+/// Apply a single old→new replacement to a document.
+fn apply_edit(doc: &str, old: &str, new: &str, replace_all: bool) -> String {
+    if replace_all {
+        doc.replace(old, new)
+    } else {
+        doc.replacen(old, new, 1)
+    }
 }
 
 /// The tool response, available in PostToolUse hooks.
@@ -196,10 +217,58 @@ impl HookInput {
     }
 
     /// The content being written (Write tool) or the replacement text (Edit tool).
+    ///
+    /// For Edit, this is the replacement *fragment*, not the resulting document.
+    /// Checks that validate whole-document structure (frontmatter, etc.) must
+    /// use [`Self::effective_content`] instead.
     pub fn content(&self) -> Option<&str> {
         self.tool_input
             .as_ref()
             .and_then(|ti| ti.content.as_deref().or(ti.new_string.as_deref()))
+    }
+
+    /// The full document the tool call will produce.
+    ///
+    /// - Write (`content` present) → the content as-is.
+    /// - Edit (`old_string`/`new_string` present) → reads `file_path` from disk,
+    ///   applies the replacement (honoring `replace_all`), returns the result.
+    /// - MultiEdit (`edits[]` present) → reads the file, applies each edit in order.
+    /// - File unreadable or missing for Edit/MultiEdit → `None` (fail open, ADR-0001).
+    pub fn effective_content(&self) -> Option<String> {
+        let ti = self.tool_input.as_ref()?;
+
+        // Write: content is already the whole document.
+        if let Some(content) = ti.content.as_deref() {
+            return Some(content.to_string());
+        }
+
+        // Edit / MultiEdit: simulate the edit against the on-disk file.
+        let path = self.file_path()?;
+        let on_disk = std::fs::read_to_string(&path).ok()?;
+
+        if let (Some(old), Some(new)) = (ti.old_string.as_deref(), ti.new_string.as_deref()) {
+            return Some(apply_edit(
+                &on_disk,
+                old,
+                new,
+                ti.replace_all.unwrap_or(false),
+            ));
+        }
+
+        if let Some(edits) = ti.edits.as_ref() {
+            let mut doc = on_disk;
+            for edit in edits {
+                let (Some(old), Some(new)) =
+                    (edit.old_string.as_deref(), edit.new_string.as_deref())
+                else {
+                    continue;
+                };
+                doc = apply_edit(&doc, old, new, edit.replace_all.unwrap_or(false));
+            }
+            return Some(doc);
+        }
+
+        None
     }
 
     /// The tool name (Write, Edit, Bash, etc.)
@@ -628,7 +697,7 @@ mod tests {
                 command: command.map(String::from),
                 content: content.map(String::from),
                 new_string: new_string.map(String::from),
-                old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -692,6 +761,119 @@ mod tests {
     fn content_none_when_both_absent() {
         let input = make_input(None, None, None, None, None, None);
         assert_eq!(input.content(), None);
+    }
+
+    // --- effective_content ---
+
+    fn make_disk_edit(path: &str, old: &str, new: &str, replace_all: Option<bool>) -> HookInput {
+        HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(ToolInput {
+                file_path: Some(path.into()),
+                old_string: Some(old.into()),
+                new_string: Some(new.into()),
+                replace_all,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn apply_edit_replaces_first_occurrence_only() {
+        assert_eq!(apply_edit("a b a", "a", "x", false), "x b a");
+    }
+
+    #[test]
+    fn apply_edit_replace_all_replaces_every_occurrence() {
+        assert_eq!(apply_edit("a b a", "a", "x", true), "x b x");
+    }
+
+    #[test]
+    fn effective_content_write_returns_content() {
+        let input = make_input(Some("Write"), Some("/a.md"), None, None, Some("doc"), None);
+        assert_eq!(input.effective_content().as_deref(), Some("doc"));
+    }
+
+    #[test]
+    fn effective_content_edit_simulates_against_disk() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("doc.md");
+        std::fs::write(&path, "line one\nline two\nline three\n").unwrap();
+
+        let input = make_disk_edit(path.to_str().unwrap(), "line two", "line 2", None);
+        assert_eq!(
+            input.effective_content().as_deref(),
+            Some("line one\nline 2\nline three\n")
+        );
+    }
+
+    #[test]
+    fn effective_content_edit_honors_replace_all() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("doc.md");
+        std::fs::write(&path, "x x x").unwrap();
+
+        let input = make_disk_edit(path.to_str().unwrap(), "x", "y", Some(true));
+        assert_eq!(input.effective_content().as_deref(), Some("y y y"));
+    }
+
+    #[test]
+    fn effective_content_edit_missing_file_is_none() {
+        let input = make_disk_edit("/nonexistent/path/doc.md", "a", "b", None);
+        assert_eq!(input.effective_content(), None);
+    }
+
+    #[test]
+    fn effective_content_multi_edit_applies_sequentially() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("doc.md");
+        std::fs::write(&path, "alpha beta gamma").unwrap();
+
+        let input = HookInput {
+            tool_name: Some("MultiEdit".into()),
+            tool_input: Some(ToolInput {
+                file_path: Some(path.to_str().unwrap().into()),
+                edits: Some(vec![
+                    EditOperation {
+                        old_string: Some("alpha".into()),
+                        new_string: Some("one".into()),
+                        replace_all: None,
+                    },
+                    EditOperation {
+                        old_string: Some("gamma".into()),
+                        new_string: Some("three".into()),
+                        replace_all: None,
+                    },
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(input.effective_content().as_deref(), Some("one beta three"));
+    }
+
+    #[test]
+    fn effective_content_none_without_content_or_edit_fields() {
+        let input = make_input(Some("Read"), Some("/a.md"), None, None, None, None);
+        assert_eq!(input.effective_content(), None);
+    }
+
+    #[test]
+    fn deserialize_edit_with_replace_all() {
+        let json = r#"{"tool_name":"Edit","tool_input":{"file_path":"/a.md","old_string":"a","new_string":"b","replace_all":true}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.tool_input.as_ref().unwrap().replace_all, Some(true));
+    }
+
+    #[test]
+    fn deserialize_multi_edit_payload() {
+        let json = r#"{"tool_name":"MultiEdit","tool_input":{"file_path":"/a.md","edits":[{"old_string":"a","new_string":"b"},{"old_string":"c","new_string":"d","replace_all":true}]}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let edits = input.tool_input.as_ref().unwrap().edits.as_ref().unwrap();
+        assert_eq!(edits.len(), 2);
+        assert_eq!(edits[0].old_string.as_deref(), Some("a"));
+        assert_eq!(edits[1].replace_all, Some(true));
     }
 
     #[test]

--- a/crates/core/src/test_builders.rs
+++ b/crates/core/src/test_builders.rs
@@ -6,21 +6,16 @@
 //! cadence-hooks-core = { workspace = true, features = ["test-builders"] }
 //! ```
 
-use crate::{HookInput, ToolInput, ToolResponse};
+use crate::{EditOperation, HookInput, ToolInput, ToolResponse};
 
 /// Build a `HookInput` for a `Bash` tool invocation.
 pub fn make_bash(cmd: &str) -> HookInput {
     HookInput {
         tool_name: Some("Bash".into()),
         tool_input: Some(ToolInput {
-            file_path: None,
-            path: None,
             command: Some(cmd.into()),
-            content: None,
-            new_string: None,
-            old_string: None,
+            ..Default::default()
         }),
-        cwd: None,
         ..Default::default()
     }
 }
@@ -30,12 +25,8 @@ pub fn make_bash_with_cwd(cmd: &str, cwd: &str) -> HookInput {
     HookInput {
         tool_name: Some("Bash".into()),
         tool_input: Some(ToolInput {
-            file_path: None,
-            path: None,
             command: Some(cmd.into()),
-            content: None,
-            new_string: None,
-            old_string: None,
+            ..Default::default()
         }),
         cwd: Some(cwd.into()),
         ..Default::default()
@@ -48,30 +39,48 @@ pub fn make_write(path: &str, content: &str) -> HookInput {
         tool_name: Some("Write".into()),
         tool_input: Some(ToolInput {
             file_path: Some(path.into()),
-            path: None,
-            command: None,
             content: Some(content.into()),
-            new_string: None,
-            old_string: None,
+            ..Default::default()
         }),
-        cwd: None,
         ..Default::default()
     }
 }
 
 /// Build a `HookInput` for an `Edit` tool invocation.
-pub fn make_edit(path: &str) -> HookInput {
+pub fn make_edit(path: &str, old_string: &str, new_string: &str) -> HookInput {
     HookInput {
         tool_name: Some("Edit".into()),
         tool_input: Some(ToolInput {
             file_path: Some(path.into()),
-            path: None,
-            command: None,
-            content: None,
-            new_string: Some("new".into()),
-            old_string: Some("old".into()),
+            old_string: Some(old_string.into()),
+            new_string: Some(new_string.into()),
+            ..Default::default()
         }),
-        cwd: None,
+        ..Default::default()
+    }
+}
+
+/// Build a `HookInput` for a `MultiEdit` tool invocation.
+///
+/// Each `(old_string, new_string)` pair becomes one edit operation,
+/// applied in order.
+pub fn make_multi_edit(path: &str, edits: &[(&str, &str)]) -> HookInput {
+    HookInput {
+        tool_name: Some("MultiEdit".into()),
+        tool_input: Some(ToolInput {
+            file_path: Some(path.into()),
+            edits: Some(
+                edits
+                    .iter()
+                    .map(|(old, new)| EditOperation {
+                        old_string: Some((*old).into()),
+                        new_string: Some((*new).into()),
+                        replace_all: None,
+                    })
+                    .collect(),
+            ),
+            ..Default::default()
+        }),
         ..Default::default()
     }
 }
@@ -84,18 +93,13 @@ pub fn make_bash_post_tool_use(cmd: &str, stdout: &str) -> HookInput {
     HookInput {
         tool_name: Some("Bash".into()),
         tool_input: Some(ToolInput {
-            file_path: None,
-            path: None,
             command: Some(cmd.into()),
-            content: None,
-            new_string: None,
-            old_string: None,
+            ..Default::default()
         }),
         tool_response: Some(ToolResponse {
             stdout: Some(stdout.into()),
             stderr: None,
         }),
-        cwd: None,
         ..Default::default()
     }
 }

--- a/crates/guardrails/src/guard_dotfiles.rs
+++ b/crates/guardrails/src/guard_dotfiles.rs
@@ -232,7 +232,7 @@ mod tests {
     fn edit_tool_delegated_to_pure_fn() {
         // The pure function is tested above; this just verifies the
         // Check::run plumbing calls it (outcome is Allow because no env var set)
-        let input = make_edit(&zshrc());
+        let input = make_edit(&zshrc(), "old", "new");
         let result = GuardDotfiles.run(&input);
         // CADENCE_GUARD_DOTFILES is not set in test env, so should allow
         assert_eq!(result.outcome, Outcome::Allow);

--- a/crates/guardrails/src/guard_gh_dangerous.rs
+++ b/crates/guardrails/src/guard_gh_dangerous.rs
@@ -174,6 +174,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -993,6 +993,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -412,6 +412,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -338,6 +338,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -365,6 +366,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/metrics/src/snapshot.rs
+++ b/crates/metrics/src/snapshot.rs
@@ -56,6 +56,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             ..Default::default()
         }

--- a/crates/rules/Cargo.toml
+++ b/crates/rules/Cargo.toml
@@ -11,3 +11,4 @@ regex.workspace = true
 
 [dev-dependencies]
 cadence-hooks-core = { workspace = true, features = ["test-builders"] }
+tempfile = "3"

--- a/crates/rules/src/check_security_patterns.rs
+++ b/crates/rules/src/check_security_patterns.rs
@@ -523,6 +523,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -542,6 +543,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -561,6 +563,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()

--- a/crates/rules/src/validate_skill_frontmatter.rs
+++ b/crates/rules/src/validate_skill_frontmatter.rs
@@ -54,10 +54,16 @@ fn extract_frontmatter(content: &str) -> Option<Vec<(String, String)>> {
 
     let mut fields = Vec::new();
     for line in fm_lines {
+        // Indented lines are nested keys (e.g. `author:` under `metadata:`) —
+        // only top-level keys are validated against VALID_FIELDS. The check
+        // must run on the raw line: after `.trim()` every key looks top-level.
+        if line.starts_with(char::is_whitespace) {
+            continue;
+        }
         if let Some(colon_pos) = line.find(':') {
             let key = line[..colon_pos].trim().to_string();
             let value = line[colon_pos + 1..].trim().to_string();
-            if !key.is_empty() && !key.starts_with(' ') {
+            if !key.is_empty() {
                 fields.push((key, value));
             }
         }
@@ -90,11 +96,15 @@ impl Check for ValidateSkillFrontmatter {
             return CheckResult::allow();
         }
 
-        let Some(content) = input.content() else {
+        // Validate the document the tool call will *produce*, not the raw tool
+        // payload. For Edit/MultiEdit this simulates the edit against the
+        // on-disk file — an Edit's new_string is a fragment, not the document.
+        // Unreadable/missing file → None → allow (fail open, ADR-0001).
+        let Some(content) = input.effective_content() else {
             return CheckResult::allow();
         };
 
-        let Some(fields) = extract_frontmatter(content) else {
+        let Some(fields) = extract_frontmatter(&content) else {
             return CheckResult::block("Frontmatter validation failed: file missing YAML frontmatter (must start with ---)".to_string());
         };
 
@@ -372,6 +382,7 @@ mod tests {
                 content: None,
                 new_string: None,
                 old_string: None,
+                ..Default::default()
             }),
             cwd: None,
             ..Default::default()
@@ -411,12 +422,13 @@ mod tests {
     }
 
     #[test]
-    fn frontmatter_with_nested_yaml_parsed() {
-        // The parser trims keys before checking, so "  nested" becomes "nested"
-        // and passes the `!key.starts_with(' ')` check — nested keys ARE included
+    fn frontmatter_nested_keys_excluded() {
+        // Indented (nested) keys belong to a parent mapping — they are not
+        // top-level fields and must not be validated against VALID_FIELDS.
         let content = "---\nname: my-skill\n  nested: value\ndescription: test\n---\n";
         let fields = extract_frontmatter(content).unwrap();
-        assert_eq!(fields.len(), 3); // nested is included after trim
+        assert_eq!(fields.len(), 2);
+        assert!(fields.iter().all(|(k, _)| k != "nested"));
     }
 
     #[test]
@@ -434,25 +446,79 @@ mod tests {
         assert!(msg.contains("Missing required 'description'"));
     }
 
+    // --- Edit/MultiEdit simulation against on-disk files (#60, #63) ---
+
+    use cadence_hooks_core::test_builders::{make_edit, make_multi_edit};
+
+    const VALID_SKILL: &str =
+        "---\nname: my-skill\ndescription: A test skill\n---\n# My Skill\n\nBody text here.\n";
+
+    /// Write a valid SKILL.md into a temp dir shaped like a plugin skill tree.
+    /// Returns (tempdir guard, absolute SKILL.md path).
+    fn on_disk_skill(content: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let skill_dir = dir.path().join("skills/my-skill");
+        std::fs::create_dir_all(&skill_dir).unwrap();
+        let path = skill_dir.join("SKILL.md");
+        std::fs::write(&path, content).unwrap();
+        (dir, path.to_str().unwrap().to_string())
+    }
+
     #[test]
-    fn run_edit_tool_also_validated() {
-        // Edit tool is also validated — the guard checks file_path and content
-        // regardless of tool_name
-        let input = HookInput {
-            tool_name: Some("Edit".into()),
-            tool_input: Some(cadence_hooks_core::ToolInput {
-                file_path: Some("/plugins/skills/my-skill/SKILL.md".into()),
-                path: None,
-                command: None,
-                content: Some("# No frontmatter".into()),
-                new_string: None,
-                old_string: None,
-            }),
-            cwd: None,
-            ..Default::default()
-        };
+    fn run_body_only_edit_on_valid_skill_allowed() {
+        // Regression for #60: a mid-file Edit to a valid SKILL.md must not be
+        // blocked just because the edit fragment lacks frontmatter.
+        let (_dir, path) = on_disk_skill(VALID_SKILL);
+        let input = make_edit(&path, "Body text here.", "Updated body text.");
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn run_edit_corrupting_frontmatter_blocks() {
+        // The false-negative direction: an Edit that breaks the frontmatter of
+        // a valid file must still be caught.
+        let (_dir, path) = on_disk_skill(VALID_SKILL);
+        let input = make_edit(&path, "name: my-skill", "not a valid key line");
         let result = ValidateSkillFrontmatter.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert!(result.message.unwrap().contains("Missing required 'name'"));
+    }
+
+    #[test]
+    fn run_multi_edit_body_edit_on_valid_skill_allowed() {
+        let (_dir, path) = on_disk_skill(VALID_SKILL);
+        let input = make_multi_edit(
+            &path,
+            &[("# My Skill", "# My Skill v2"), ("Body text", "New body")],
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn run_edit_on_missing_file_allowed() {
+        // Fail open (ADR-0001): if the file can't be read, the edit can't be
+        // simulated — allow rather than block on incomplete information.
+        let input = make_edit(
+            "/nonexistent/plugins/skills/my-skill/SKILL.md",
+            "old",
+            "new",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn run_write_with_nested_metadata_allowed() {
+        // Regression for #63 (bug 2): nested keys under `metadata:` are not
+        // unknown top-level fields.
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\nmetadata:\n  author: cameron\n  version: 1.0.0\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]

--- a/crates/session/src/guard.rs
+++ b/crates/session/src/guard.rs
@@ -382,6 +382,8 @@ mod tests {
         let peers = vec![peer("quiet-loom", &["crates/guardrails/"])];
         let input = with_session(make_edit(
             "/Users/dev/cadence-hooks/crates/guardrails/src/lib.rs",
+            "old",
+            "new",
         ));
         let r = run_guard(&input, &peers);
         assert_eq!(r.outcome, Outcome::Nudge);
@@ -393,7 +395,11 @@ mod tests {
     #[test]
     fn edit_outside_peer_lane_allows() {
         let peers = vec![peer("quiet-loom", &["crates/guardrails/"])];
-        let input = with_session(make_edit("/Users/dev/cadence-hooks/crates/core/src/lib.rs"));
+        let input = with_session(make_edit(
+            "/Users/dev/cadence-hooks/crates/core/src/lib.rs",
+            "old",
+            "new",
+        ));
         assert_eq!(run_guard(&input, &peers).outcome, Outcome::Allow);
     }
 
@@ -401,7 +407,7 @@ mod tests {
     fn edit_with_undeclared_peer_allows() {
         // A peer with no declared lane can't produce path collisions.
         let peers = vec![peer("quiet-loom", &[])];
-        let input = with_session(make_edit("/Users/dev/repo/src/anything.rs"));
+        let input = with_session(make_edit("/Users/dev/repo/src/anything.rs", "old", "new"));
         assert_eq!(run_guard(&input, &peers).outcome, Outcome::Allow);
     }
 
@@ -409,7 +415,11 @@ mod tests {
     fn substring_lane_does_not_false_positive() {
         // "crates/guard" must not match "crates/guardrails-other/".
         let peers = vec![peer("quiet-loom", &["crates/guard"])];
-        let input = with_session(make_edit("/repo/crates/guardrails/src/lib.rs"));
+        let input = with_session(make_edit(
+            "/repo/crates/guardrails/src/lib.rs",
+            "old",
+            "new",
+        ));
         assert_eq!(
             run_guard(&input, &peers).outcome,
             Outcome::Allow,


### PR DESCRIPTION
## Summary

Content-validation checks treated an Edit's `new_string` *fragment* as if it were the whole document, blocking every mid-file edit to any valid SKILL.md and forcing Python-in-Bash bypasses across all plugin repos.

Closes #60
Closes #63

### Core (`cadence-hooks-core`)

- `ToolInput` gains `replace_all` and `edits[]` (MultiEdit support), derives `Default`
- New `HookInput::effective_content()` — simulates the Edit/MultiEdit against the on-disk file and returns the document the tool call will *produce*. Unreadable/missing file → `None` (fail open, ADR-0001)
- `content()` is untouched — fragment semantics remain for checks that want them
- Test builders: `make_edit(path, old, new)` (signature change) + new `make_multi_edit(path, edits)`

### validate-frontmatter (#60, #63 bug 1 + 2)

- Validates `effective_content()` instead of the raw Edit payload — body-only edits to valid files now pass; edits that *corrupt* frontmatter still block
- Nested-key guard fixed: indented lines are skipped **before** trimming, so `metadata.author` / `metadata.version` are no longer flagged as unknown top-level fields
- The test that codified the dead-code guard as correct (`frontmatter_with_nested_yaml_parsed`) is replaced by `frontmatter_nested_keys_excluded`

### terminology (same defect class)

- Edit tool calls now only fire on violations *introduced* by the edit (present in `new_string`, absent from `old_string`). Pre-existing flagged terms in surrounding context lines no longer block unrelated edits
- Write behavior unchanged

## Verification

- `make ci` green (fmt-check + clippy `-D warnings` + 23 test suites, 0 failures)
- Manual repro against `./target/release/cadence-hooks`:
  - body-only Edit on valid on-disk SKILL.md → rc=0 (was rc=2)
  - nested-metadata Write → rc=0 (was rc=2)
  - missing-frontmatter Write → rc=2 (still blocks)
  - Edit carrying pre-existing flagged term in context → rc=0 (was rc=2)
  - Edit introducing flagged term → rc=2 (still blocks)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
