### PR TITLE
fix: tolerate BrokenPipe when writing stdin to early-exit children

### DIFF
--- a/tests/selective_disable.rs
+++ b/tests/selective_disable.rs
@@ -17,6 +17,10 @@ fn cadence_hooks() -> Command {
 }
 
 /// Spawns the binary with JSON on stdin and returns the completed output.
+///
+/// A child that decides its outcome without reading stdin (a bypassed or
+/// disabled hook exits immediately) may close the pipe before the write
+/// completes — that BrokenPipe is expected, not a test failure (#59).
 fn run_with_stdin(mut cmd: Command, input: &str) -> std::process::Output {
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -24,7 +28,11 @@ fn run_with_stdin(mut cmd: Command, input: &str) -> std::process::Output {
 
     let mut child = cmd.spawn().expect("failed to execute binary");
     if let Some(ref mut stdin) = child.stdin {
-        stdin.write_all(input.as_bytes()).unwrap();
+        match stdin.write_all(input.as_bytes()) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(e) => panic!("failed to write to child stdin: {e}"),
+        }
     }
     child.wait_with_output().expect("failed to wait on binary")
 }

--- a/tests/try_hook.rs
+++ b/tests/try_hook.rs
@@ -19,6 +19,10 @@ fn cadence_hooks() -> Command {
 }
 
 /// Spawns the binary with JSON on stdin and returns the completed output.
+///
+/// A child that decides its outcome without reading stdin (a bypassed or
+/// disabled hook exits immediately) may close the pipe before the write
+/// completes — that BrokenPipe is expected, not a test failure (#59).
 fn run_with_stdin(mut cmd: Command, input: &str) -> std::process::Output {
     cmd.stdin(std::process::Stdio::piped())
         .stdout(std::process::Stdio::piped())
@@ -26,7 +30,11 @@ fn run_with_stdin(mut cmd: Command, input: &str) -> std::process::Output {
 
     let mut child = cmd.spawn().expect("failed to execute binary");
     if let Some(ref mut stdin) = child.stdin {
-        stdin.write_all(input.as_bytes()).unwrap();
+        match stdin.write_all(input.as_bytes()) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(e) => panic!("failed to write to child stdin: {e}"),
+        }
     }
     child.wait_with_output().expect("failed to wait on binary")
 }

--- a/tests/version_mismatch.rs
+++ b/tests/version_mismatch.rs
@@ -186,7 +186,13 @@ fn valid_subcommand_with_empty_input_allows() {
         .and_then(|mut child| {
             use std::io::Write;
             if let Some(ref mut stdin) = child.stdin {
-                stdin.write_all(b"{}")?;
+                // BrokenPipe means the child exited before reading stdin —
+                // expected for early-exit paths, not a test failure (#59).
+                if let Err(e) = stdin.write_all(b"{}")
+                    && e.kind() != std::io::ErrorKind::BrokenPipe
+                {
+                    return Err(e);
+                }
             }
             child.wait_with_output()
         })


### PR DESCRIPTION
## Summary

`run_with_stdin` in the integration tests does `stdin.write_all(...).unwrap()`. A hook child that decides its outcome **without reading stdin** — bypassed (`CADENCE_BYPASS`) or disabled (`CADENCE_DISABLE`) hooks exit immediately — can close the pipe before the write completes. The resulting `BrokenPipe` panics the helper and makes the test flaky.

Closes #59

## Changes

- `tests/selective_disable.rs` — `run_with_stdin` ignores `ErrorKind::BrokenPipe`; any other write error still panics
- `tests/try_hook.rs` — same helper, same fix
- `tests/version_mismatch.rs` — the inline `write_all(b"{}")?` gets the same tolerance

## Verification

`make ci` green (exit 0, all suites, 0 failures). The flake is a race so it can't be reproduced deterministically, but the failure mode (panic on BrokenPipe) is now structurally impossible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
