### PR TITLE
feat: honor CLAUDE_CONFIG_DIR for global state paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Global state paths (metrics, persona ledger, the `doctor` plugin scan) now honor `CLAUDE_CONFIG_DIR`, matching Claude Code's own config-dir relocation, instead of hardcoding `~/.claude`. A new `cadence_hooks_core::paths` module resolves the config dir (first non-empty comma entry, `~`-expanded; falls back to `~/.claude`); `doctor`'s plugin scan falls back to `~/.claude/plugins` when the config-dir variant is absent, staying correct whichever directory the plugin loader uses.
 - `guard-pr-issue-link` renamed to `warn-pr-issue-link` and downgraded from a hard block to a nudge. PRs without a linked issue are a routine, intentional workflow; the check now reminds about closing keywords instead of blocking `gh pr create`. The companion `verify-pr-autoclose` (PostToolUse, advisory) is unchanged and still covers broken issue refs.
 
 ## [0.13.0] - 2026-06-01

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "brush-parser",
  "regex",
@@ -216,7 +216,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -225,7 +225,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -236,7 +236,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -246,7 +246,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -254,7 +254,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -263,7 +263,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.17.0"
+version = "0.18.0"
 dependencies = [
  "cadence-hooks-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.17.0"
+version = "0.18.0"
 edition = "2024"
 license = "BSL-1.1"
 authors = ["Cameron Sjo"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod config;
 pub mod loop_analysis;
+pub mod paths;
 pub mod shell;
 
 #[cfg(feature = "test-builders")]

--- a/crates/core/src/paths.rs
+++ b/crates/core/src/paths.rs
@@ -1,0 +1,132 @@
+//! Resolving Claude Code's global config directory.
+//!
+//! Claude Code honors a `CLAUDE_CONFIG_DIR` environment variable that relocates
+//! its entire global config/state tree (default `~/.claude`). Hooks are **not**
+//! handed a config-dir env var at runtime, so any code that resolves a global
+//! path must read the variable itself.
+//!
+//! The variable's value may be a comma-separated list of directories; for the
+//! purpose of *writing* state (metrics, persona ledger, insights) we take the
+//! first non-empty entry. The pure [`resolve_config_dir`] form keeps the logic
+//! unit-testable without touching process env (which is process-global and
+//! races parallel tests), mirroring the `expand_tilde`/`expand_tilde_with`
+//! split elsewhere in the workspace.
+
+use std::path::PathBuf;
+
+/// Claude Code's global config dir, honoring `CLAUDE_CONFIG_DIR` (else `~/.claude`).
+pub fn claude_config_dir() -> PathBuf {
+    let cfg = std::env::var("CLAUDE_CONFIG_DIR").ok();
+    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
+    resolve_config_dir(cfg.as_deref(), &home)
+}
+
+/// Pure form: first non-empty comma entry of `config_dir`, `~`-expanded;
+/// else `<home>/.claude`.
+pub fn resolve_config_dir(config_dir: Option<&str>, home: &str) -> PathBuf {
+    if let Some(first) = config_dir.and_then(|raw| {
+        raw.split(',')
+            .map(str::trim)
+            .find(|s| !s.is_empty())
+            .map(str::to_owned)
+    }) {
+        return expand_tilde_with(&first, home);
+    }
+    PathBuf::from(home).join(".claude")
+}
+
+/// Replace a leading `~/` (or a bare `~`) with `home`; pass other paths through.
+pub fn expand_tilde_with(s: &str, home: &str) -> PathBuf {
+    if let Some(rest) = s.strip_prefix("~/") {
+        PathBuf::from(home).join(rest)
+    } else if s == "~" {
+        PathBuf::from(home)
+    } else {
+        PathBuf::from(s)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn unset_falls_back_to_home_dot_claude() {
+        assert_eq!(
+            resolve_config_dir(None, "/home/test"),
+            PathBuf::from("/home/test/.claude")
+        );
+    }
+
+    #[test]
+    fn empty_string_falls_back_to_home_dot_claude() {
+        assert_eq!(
+            resolve_config_dir(Some(""), "/home/test"),
+            PathBuf::from("/home/test/.claude")
+        );
+    }
+
+    #[test]
+    fn single_absolute_path() {
+        assert_eq!(
+            resolve_config_dir(Some("/custom/claude"), "/home/test"),
+            PathBuf::from("/custom/claude")
+        );
+    }
+
+    #[test]
+    fn tilde_prefixed_path_expands() {
+        assert_eq!(
+            resolve_config_dir(Some("~/work-claude"), "/home/test"),
+            PathBuf::from("/home/test/work-claude")
+        );
+    }
+
+    #[test]
+    fn comma_list_takes_first_entry() {
+        assert_eq!(
+            resolve_config_dir(Some("/first,/second,/third"), "/home/test"),
+            PathBuf::from("/first")
+        );
+    }
+
+    #[test]
+    fn leading_empty_comma_entry_is_skipped() {
+        assert_eq!(
+            resolve_config_dir(Some(",/real"), "/home/test"),
+            PathBuf::from("/real")
+        );
+    }
+
+    #[test]
+    fn whitespace_around_entries_is_trimmed() {
+        assert_eq!(
+            resolve_config_dir(Some("  /spaced  ,  /other  "), "/home/test"),
+            PathBuf::from("/spaced")
+        );
+    }
+
+    #[test]
+    fn all_empty_entries_fall_back() {
+        assert_eq!(
+            resolve_config_dir(Some(" , , "), "/home/test"),
+            PathBuf::from("/home/test/.claude")
+        );
+    }
+
+    #[test]
+    fn expand_tilde_with_handles_prefix_bare_and_absolute() {
+        assert_eq!(
+            expand_tilde_with("~/x/y", "/home/test"),
+            PathBuf::from("/home/test/x/y")
+        );
+        assert_eq!(
+            expand_tilde_with("~", "/home/test"),
+            PathBuf::from("/home/test")
+        );
+        assert_eq!(
+            expand_tilde_with("/abs/path", "/home/test"),
+            PathBuf::from("/abs/path")
+        );
+    }
+}

--- a/crates/lab/src/config.rs
+++ b/crates/lab/src/config.rs
@@ -76,10 +76,10 @@ impl Config {
         }
     }
 
-    /// The default persona root: `${HOME:-/tmp}/.claude/persona`.
+    /// The default persona root: `<config_dir>/persona`, where `<config_dir>`
+    /// honors `CLAUDE_CONFIG_DIR` (else `~/.claude`).
     pub fn persona_root() -> PathBuf {
-        let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-        PathBuf::from(home).join(".claude").join("persona")
+        cadence_hooks_core::paths::claude_config_dir().join("persona")
     }
 
     /// Load defaults, then apply any `<persona_root>/config.json` override.
@@ -96,19 +96,11 @@ impl Config {
     }
 }
 
-/// Expand a leading `~/` to the home directory.
+/// Expand a leading `~/` to the home directory. Delegates to the shared
+/// [`cadence_hooks_core::paths::expand_tilde_with`] so the logic lives in one place.
 fn expand_tilde(s: &str) -> PathBuf {
     let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    expand_tilde_with(s, &home)
-}
-
-/// Pure form of [`expand_tilde`] — replaces a leading `~/` with `home`.
-fn expand_tilde_with(s: &str, home: &str) -> PathBuf {
-    if let Some(rest) = s.strip_prefix("~/") {
-        PathBuf::from(home).join(rest)
-    } else {
-        PathBuf::from(s)
-    }
+    cadence_hooks_core::paths::expand_tilde_with(s, &home)
 }
 
 #[derive(Debug, Default, Deserialize)]
@@ -251,14 +243,10 @@ mod tests {
     }
 
     #[test]
-    fn expand_tilde_replaces_home() {
-        assert_eq!(
-            expand_tilde_with("~/x/y", "/home/test"),
-            PathBuf::from("/home/test/x/y")
-        );
-        assert_eq!(
-            expand_tilde_with("/abs/path", "/home/test"),
-            PathBuf::from("/abs/path")
-        );
+    fn expand_tilde_uses_home_env() {
+        // The pure `~`-expansion logic is covered by `cadence_hooks_core::paths`;
+        // here we just confirm the local wrapper reads $HOME and passes through
+        // absolute paths.
+        assert_eq!(expand_tilde("/abs/path"), PathBuf::from("/abs/path"));
     }
 }

--- a/crates/metrics/src/common.rs
+++ b/crates/metrics/src/common.rs
@@ -22,10 +22,10 @@ pub fn is_git_commit(command: &str) -> bool {
     commit_regex().is_match(command)
 }
 
-/// The metrics root: `${HOME:-/tmp}/.claude/metrics`.
+/// The metrics root: `<config_dir>/metrics`, where `<config_dir>` honors
+/// `CLAUDE_CONFIG_DIR` (else `~/.claude`).
 pub fn metrics_dir() -> PathBuf {
-    let home = std::env::var("HOME").unwrap_or_else(|_| "/tmp".to_string());
-    PathBuf::from(home).join(".claude").join("metrics")
+    cadence_hooks_core::paths::claude_config_dir().join("metrics")
 }
 
 /// The per-session state directory: `<metrics_dir>/state`.

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -240,8 +240,18 @@ fn scan_hooks_json(plugin: &str, path: &Path, raw: &str, json: &serde_json::Valu
     findings
 }
 
-/// Claude Code's plugins directory (`~/.claude/plugins`).
+/// Claude Code's plugins directory.
+///
+/// Prefers `<config_dir>/plugins` (honoring `CLAUDE_CONFIG_DIR`), but it is
+/// unverified whether Claude Code's plugin loader relocates `plugins/` along
+/// with the rest of the config tree — it may keep it at `~/.claude` regardless.
+/// So when the config-dir variant does not exist, fall back to
+/// `$HOME/.claude/plugins`. This stays correct under either loader behavior.
 fn plugins_dir() -> Option<PathBuf> {
+    let config_variant = cadence_hooks_core::paths::claude_config_dir().join("plugins");
+    if config_variant.exists() {
+        return Some(config_variant);
+    }
     let home = std::env::var("HOME").ok()?;
     Some(PathBuf::from(home).join(".claude/plugins"))
 }


### PR DESCRIPTION
## What

Make cadence-hooks honor `CLAUDE_CONFIG_DIR` — the (undocumented) env var that relocates Claude Code's entire global config/state tree (default `~/.claude`). Previously every global-path resolver hardcoded `${HOME}/.claude`, so a user or second profile that set the var had metrics logging, the persona ledger, and the `doctor` plugin scan silently read/write the wrong directory.

## How

- **New `cadence_hooks_core::paths` module** — `claude_config_dir()` reads `CLAUDE_CONFIG_DIR` (first non-empty comma entry, `~`-expanded) and falls back to `~/.claude`. The pure `resolve_config_dir(config_dir, home)` form is unit-tested without touching process env (env is process-global and races parallel tests), mirroring the existing `expand_tilde`/`expand_tilde_with` split.
- **`metrics_dir()`** → `claude_config_dir().join("metrics")`.
- **`persona_root()`** → `claude_config_dir().join("persona")`; lab's local `expand_tilde` now delegates to the shared `core::paths::expand_tilde_with`. Explicit user override paths in `config.json` are unchanged — only the default root moves.
- **`doctor`'s `plugins_dir()`** made defensive: prefer `<config_dir>/plugins`, fall back to `~/.claude/plugins` when that path is absent. It's unverified whether Claude Code's plugin loader relocates `plugins/`, so this stays correct under either behavior.

Project-local `.claude/` paths and `/tmp` temp files are untouched — they're not the global tree.

## Verification

- `make ci` green (fmt-check + clippy `-D warnings` + tests). 9 new `resolve_config_dir` unit tests cover: unset → `~/.claude`, empty string, single path, `~/`-prefix, comma list (takes first), leading-empty comma entry, whitespace trimming, all-empty.
- Runtime smoke: `CLAUDE_CONFIG_DIR=/tmp/cfgtest cadence-hooks doctor` exits 0 — the config-dir variant has no `plugins/`, so it falls back to the real `~/.claude/plugins` and scans 42 plugins cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
