### PR TITLE
feat(core): feedback-channel footer on hard blocks (0.23.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.23.0] - 2026-06-06
+
+### Added
+
+- Hard blocks now carry a feedback-channel footer — `If this fired in error: /cadence:feedback` — appended to the stderr message of any `Outcome::Block`. It turns a false-positive block into one structured issue on the meta-repo (`cameronsjo/claude-configurations`) via the new `cadence:feedback` skill, instead of silent friction. Nudges and loop-blocks are untouched (they aren't errors). Suppress with `CADENCE_NO_FEEDBACK_FOOTER` set to any non-empty value.
+
 ## [0.21.0] - 2026-06-05
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.21.0"
+version = "0.23.0"
 dependencies = [
  "cadence-hooks-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.21.0"
+version = "0.23.0"
 edition = "2024"
 license = "BSL-1.1"
 authors = ["Cameron Sjo"]

--- a/README.md
+++ b/README.md
@@ -295,6 +295,7 @@ All cadence-hooks config lives under the `CADENCE_*` prefix. `OBSIDIAN_VAULT` is
 |----------|---------|---------|
 | `CADENCE_DISABLE` | all hooks | Comma-separated hook names to skip (e.g., `git-safety,warn-main-branch`) |
 | `CADENCE_BYPASS` | all hooks | Set to `1` to skip all enforcement (maintenance bypass) |
+| `CADENCE_NO_FEEDBACK_FOOTER` | all hooks | Set to any non-empty value to suppress the `If this fired in error: /cadence:feedback` footer appended to hard blocks |
 | `CADENCE_ALLOWED_OWNERS` | `guard-push-remote`, `guard-gh-write` | Space or comma-separated usernames |
 | `CADENCE_ALLOWED_REPOS` | `guard-gh-write` | Space or comma-separated `owner/repo` pairs |
 | `CADENCE_EXTRA_HOSTS` | `guard-push-remote`, `guard-gh-write` | Self-hosted forge hosts that bare entries (`cameron`) should match in addition to the default host |

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -432,6 +432,39 @@ fn should_skip_for_effort(skip_levels: &[&str], current: Option<&str>) -> bool {
     skip_levels.contains(&effective)
 }
 
+/// The feedback-channel footer appended to hard blocks. Points the user at the
+/// `cadence:feedback` skill so a false-positive block becomes one structured
+/// issue on the meta-repo instead of silent friction.
+const FEEDBACK_FOOTER: &str = "\n\nIf this fired in error: /cadence:feedback";
+
+/// Resolve the feedback footer from the environment.
+///
+/// Returns `None` when `CADENCE_NO_FEEDBACK_FOOTER` is set to any non-empty
+/// value (the suppression toggle), otherwise the [`FEEDBACK_FOOTER`] text.
+fn feedback_footer() -> Option<String> {
+    let suppressed = std::env::var("CADENCE_NO_FEEDBACK_FOOTER")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false);
+    if suppressed {
+        None
+    } else {
+        Some(FEEDBACK_FOOTER.to_string())
+    }
+}
+
+/// Compose the message body emitted for an outcome, appending the feedback
+/// footer to **hard blocks only** (never Nudge/LoopBlock/Allow — they aren't
+/// errors the user needs a feedback channel for).
+///
+/// `footer` is the resolved footer ([`feedback_footer`]); passing it in keeps
+/// this pure and unit-testable without mutating process-global env.
+fn apply_feedback_footer(outcome: Outcome, msg: &str, footer: Option<&str>) -> String {
+    match (outcome, footer) {
+        (Outcome::Block, Some(f)) => format!("{msg}{f}"),
+        _ => msg.to_string(),
+    }
+}
+
 /// Run a single check, emit output, and exit.
 ///
 /// Routing:
@@ -477,8 +510,9 @@ pub fn run_check(check: &dyn Check, input: &HookInput, event: HookEvent) -> ! {
                 println!("{json}");
             }
             Outcome::Block => {
-                eprint!("{msg}");
-                if !msg.ends_with('\n') {
+                let full = apply_feedback_footer(Outcome::Block, msg, feedback_footer().as_deref());
+                eprint!("{full}");
+                if !full.ends_with('\n') {
                     eprintln!();
                 }
             }
@@ -630,6 +664,67 @@ mod tests {
         assert_eq!(Outcome::Nudge.code(), 0);
         assert_eq!(Outcome::LoopBlock.code(), 0);
         assert_eq!(Outcome::Block.code(), 2);
+    }
+
+    // --- feedback footer ---
+
+    #[test]
+    fn feedback_footer_appends_to_blocks() {
+        let out = apply_feedback_footer(Outcome::Block, "blocked: nope", Some(FEEDBACK_FOOTER));
+        assert!(out.starts_with("blocked: nope"));
+        assert!(out.contains("/cadence:feedback"));
+        assert!(out.ends_with(FEEDBACK_FOOTER));
+    }
+
+    #[test]
+    fn feedback_footer_skips_nudge_loop_block_and_allow() {
+        // The footer is a block-only affordance — nudges and loop-blocks are not
+        // errors the user needs a feedback channel for, so they pass through.
+        assert_eq!(
+            apply_feedback_footer(Outcome::Nudge, "heads up", Some(FEEDBACK_FOOTER)),
+            "heads up"
+        );
+        assert_eq!(
+            apply_feedback_footer(Outcome::LoopBlock, "rewrite", Some(FEEDBACK_FOOTER)),
+            "rewrite"
+        );
+        assert_eq!(
+            apply_feedback_footer(Outcome::Allow, "", Some(FEEDBACK_FOOTER)),
+            ""
+        );
+    }
+
+    #[test]
+    fn feedback_footer_omitted_from_block_when_suppressed() {
+        // `None` models the CADENCE_NO_FEEDBACK_FOOTER suppression path.
+        assert_eq!(
+            apply_feedback_footer(Outcome::Block, "blocked", None),
+            "blocked"
+        );
+    }
+
+    // `feedback_footer()` reads process-global env; serialize the two
+    // env-mutating tests so they don't race each other. No other test touches
+    // this variable, so the lock only guards this pair.
+    static FOOTER_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    #[test]
+    fn feedback_footer_present_by_default() {
+        let _guard = FOOTER_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against the other env-mutating footer test.
+        unsafe { std::env::remove_var("CADENCE_NO_FEEDBACK_FOOTER") };
+        let footer = feedback_footer().expect("footer present by default");
+        assert!(footer.contains("/cadence:feedback"));
+    }
+
+    #[test]
+    fn feedback_footer_suppressed_by_env() {
+        let _guard = FOOTER_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against the other env-mutating footer test.
+        unsafe { std::env::set_var("CADENCE_NO_FEEDBACK_FOOTER", "1") };
+        let result = feedback_footer();
+        unsafe { std::env::remove_var("CADENCE_NO_FEEDBACK_FOOTER") };
+        assert!(result.is_none(), "footer suppressed when env set");
     }
 
     #[test]


### PR DESCRIPTION
## What

Hard blocks (`Outcome::Block`) now carry a feedback-channel footer on their stderr message:

```
If this fired in error: /cadence:feedback
```

This turns a false-positive block into **one structured issue** on the meta-repo (`cameronsjo/claude-configurations`) via the new `cadence:feedback` skill, instead of silent friction. Part of the cadence feedback flywheel (`/cadence:feedback` + `/cadence:who-am-i`).

## Scope

- **Blocks only.** Nudges and loop-blocks are untouched — they aren't errors that need a feedback channel.
- **Suppressible** via `CADENCE_NO_FEEDBACK_FOOTER` set to any non-empty value (documented in the README env table).
- Footer composition is a pure, unit-tested helper (`apply_feedback_footer`); the env read is isolated in `feedback_footer()`.

## Tests

5 new tests in `crates/core`: footer appends to blocks; skips nudge/loop-block/allow; omitted when suppressed; present by default; suppressed by env (env tests serialized via a mutex).

Verified on a real block (`guard-gh-write` → unowned repo): footer present by default, absent with `CADENCE_NO_FEEDBACK_FOOTER=1`, both exit 2.

Bumps workspace version `0.21.0 → 0.23.0` (0.22.0 reserved for #75). Merge to main triggers `auto-tag.yml` → release → Homebrew tap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)