### PR TITLE
feat: inject gh allowlist + -R rule on SessionStart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   — it trusts the model to act on the message, then opens the gate. (Companion
   `mcp__claude-in-chrome__.*` matcher ships in `cadence-guardrails`'s `hooks.json`.)
 - `warn-overshare` (cadence): nudges Claude to audit about-to-ship content (commit messages, PR/issue bodies, changed files) for personal-context overshare — disabilities, neurodivergence, health, relationships, family, non-technical biographical detail. Fires on `git push`, `git commit`, `gh pr create`, `gh pr edit`, `gh issue create`, `gh issue comment`, and Write/Edit to `docs/field-reports/` paths. Skips writes under `$OBSIDIAN_VAULT` (the safe destination for personal context) and to `docs/blog/*retro*` paths (retros feed blog articles and are intentionally personal). Session-scoped bypass: `CADENCE_SKIP_OVERSHARE_AUDIT=1`. (Companion `hooks.json` wiring ships in `cadence-guardrails`.)
+- New `guardrails inject-gh-context` check (SessionStart): renders the configured gh-write allowlist (`CADENCE_ALLOWED_OWNERS`, `CADENCE_ALLOWED_REPOS`, `CADENCE_EXTRA_HOSTS`) and the `gh ... -R owner/repo` rule into Claude's context at session start, resume, and post-compaction. Companion wiring ships in `cadence-canon`'s `hooks.json`. Primes the model with the same context `guard-gh-write` enforces, recovering "silent damage" cases where `cwd`'s remote happens to be allowlisted but is not the intended write target.
 
 ## [0.23.0] - 2026-06-06
 

--- a/crates/guardrails/src/inject_gh_context.rs
+++ b/crates/guardrails/src/inject_gh_context.rs
@@ -1,0 +1,156 @@
+//! `guardrails inject-gh-context` — SessionStart hook.
+//!
+//! Injects the gh-write allowlist + `-R owner/repo` rule into Claude's
+//! context at session start (and after compaction). Primes the model with
+//! the same context [`guard_gh_write`](super::guard_gh_write) enforces, so
+//! writes target the right repo on the first try — recovering Mode A
+//! "silent damage" cases where cwd's remote happens to be allowed but
+//! isn't the intended write target.
+//!
+//! Wired by `cadence-canon`'s `hooks.json` on `matcher: startup|resume|compact`.
+
+use cadence_hooks_core::config::{AllowEntry, default_host, env_allow_entries, env_extra_hosts};
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+
+/// Inject gh allowlist + `-R` rule on session start.
+pub struct InjectGhContext;
+
+impl Check for InjectGhContext {
+    fn name(&self) -> &str {
+        "inject-gh-context"
+    }
+
+    fn run(&self, _input: &HookInput) -> CheckResult {
+        let owners = env_allow_entries("CADENCE_ALLOWED_OWNERS");
+        let repos = env_allow_entries("CADENCE_ALLOWED_REPOS");
+        let extras = env_extra_hosts();
+        let default = default_host();
+        CheckResult::nudge(render_context(&owners, &repos, &extras, &default))
+    }
+}
+
+/// Pure renderer: build the SessionStart context message from a parsed
+/// allowlist. Exposed for unit testing without env-var fiddling.
+pub fn render_context(
+    owner_entries: &[AllowEntry],
+    repo_entries: &[AllowEntry],
+    extra_hosts: &[String],
+    default_host: &str,
+) -> String {
+    let mut msg = String::from("git-guardrails (gh writes):\n");
+    msg.push_str(
+        "- gh writes (pr/issue/release/repo/api -X POST|PUT|PATCH|DELETE) are policed by an allowlist.\n",
+    );
+    msg.push_str(
+        "- Always pass `-R owner/repo` for gh writes. Without it, the target is inferred from cwd's git remote — silently wrong in worktrees and when cwd is not the intended repo.\n",
+    );
+    msg.push_str("- Reads (`gh pr list`, `gh issue view`, etc.) work without `-R`.\n");
+
+    if owner_entries.is_empty() && repo_entries.is_empty() {
+        msg.push_str(
+            "- Allowlist is empty (CADENCE_ALLOWED_OWNERS / CADENCE_ALLOWED_REPOS unset). Set these to enable guard-gh-write enforcement.\n",
+        );
+    } else {
+        if !owner_entries.is_empty() {
+            let owners: Vec<String> = owner_entries.iter().map(|e| e.to_string()).collect();
+            msg.push_str(&format!("- Allowed owners: {}\n", owners.join(", ")));
+        }
+        if !repo_entries.is_empty() {
+            let repos: Vec<String> = repo_entries.iter().map(|e| e.to_string()).collect();
+            msg.push_str(&format!("- Allowed repos: {}\n", repos.join(", ")));
+        }
+    }
+
+    msg.push_str(&format!("- Default host: {default_host}"));
+    if !extra_hosts.is_empty() {
+        msg.push_str(&format!("; extra hosts: {}", extra_hosts.join(", ")));
+    }
+    msg.push('\n');
+    msg
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::config::parse_allow_entries;
+
+    #[test]
+    fn renders_owners_list() {
+        let owners = parse_allow_entries("cameronsjo cameron");
+        let msg = render_context(&owners, &[], &[], "github.com");
+        assert!(msg.contains("Allowed owners: cameronsjo, cameron"));
+    }
+
+    #[test]
+    fn renders_repos_list() {
+        let repos = parse_allow_entries("external/shared-repo");
+        let msg = render_context(&[], &repos, &[], "github.com");
+        assert!(msg.contains("Allowed repos: external/shared-repo"));
+    }
+
+    #[test]
+    fn host_qualified_owner_renders_verbatim() {
+        let owners = parse_allow_entries("git.sjo.lol/cameron");
+        let msg = render_context(&owners, &[], &[], "github.com");
+        assert!(msg.contains("Allowed owners: git.sjo.lol/cameron"));
+    }
+
+    #[test]
+    fn warns_when_allowlist_empty() {
+        let msg = render_context(&[], &[], &[], "github.com");
+        assert!(msg.contains("Allowlist is empty"));
+        assert!(!msg.contains("Allowed owners:"));
+        assert!(!msg.contains("Allowed repos:"));
+    }
+
+    #[test]
+    fn includes_dash_r_rule() {
+        let msg = render_context(&[], &[], &[], "github.com");
+        assert!(msg.contains("`-R owner/repo`"));
+    }
+
+    #[test]
+    fn explains_reads_work_without_flag() {
+        let msg = render_context(&[], &[], &[], "github.com");
+        assert!(msg.contains("Reads"));
+        assert!(msg.contains("without `-R`"));
+    }
+
+    #[test]
+    fn includes_default_host() {
+        let msg = render_context(&[], &[], &[], "github.com");
+        assert!(msg.contains("Default host: github.com"));
+    }
+
+    #[test]
+    fn includes_extra_hosts_when_set() {
+        let extras = vec!["git.sjo.lol".to_string()];
+        let msg = render_context(&[], &[], &extras, "github.com");
+        assert!(msg.contains("extra hosts: git.sjo.lol"));
+    }
+
+    #[test]
+    fn omits_extra_hosts_line_when_unset() {
+        let msg = render_context(&[], &[], &[], "github.com");
+        assert!(!msg.contains("extra hosts:"));
+    }
+
+    #[test]
+    fn check_name_matches_subcommand() {
+        assert_eq!(InjectGhContext.name(), "inject-gh-context");
+    }
+
+    #[test]
+    fn check_returns_nudge_with_message() {
+        // Hermetic: this check does not read cwd or git state, so HookInput::default
+        // is enough. Env vars may or may not be set in the test process; we only
+        // assert the shape (Nudge + non-empty message), not the content.
+        let input = HookInput::default();
+        let result = InjectGhContext.run(&input);
+        assert!(matches!(result.outcome, Outcome::Nudge));
+        let msg = result.message.expect("nudge always carries a message");
+        assert!(msg.contains("git-guardrails"));
+        assert!(msg.contains("`-R owner/repo`"));
+    }
+}

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -21,6 +21,8 @@ pub mod guard_git_init;
 pub mod guard_op_vault_scan;
 /// Block `git push` to remotes owned by others.
 pub mod guard_push_remote;
+/// Inject the gh-write allowlist + `-R` rule on SessionStart.
+pub mod inject_gh_context;
 /// Shared closing-keyword detection for GitHub issue references.
 pub mod issue_refs;
 /// Nudge to schedule a brew upgrade after pushing cadence-hooks to main.

--- a/src/main.rs
+++ b/src/main.rs
@@ -167,6 +167,8 @@ enum GuardrailsCommands {
     WarnAliasParsing,
     /// Block the first Claude-in-Chrome action per session until the device is confirmed
     GuardBrowserDevice,
+    /// Inject the gh-write allowlist + `-R` rule on SessionStart
+    InjectGhContext,
     /// Snooze warn-main-branch for this repo for the given duration
     DismissMainBranchWarn {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
@@ -276,6 +278,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::WarnCoderabbitRetrigger => "warn-coderabbit-retrigger",
             GuardrailsCommands::WarnAliasParsing => "warn-alias-parsing",
             GuardrailsCommands::GuardBrowserDevice => "guard-browser-device",
+            GuardrailsCommands::InjectGhContext => "inject-gh-context",
             // dismiss-main-branch-warn is a CLI action, not a hook —
             // it has no PreToolUse/PostToolUse wiring and isn't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
@@ -629,6 +632,10 @@ fn main() {
             GuardrailsCommands::GuardBrowserDevice => run_check_from_stdin(
                 &cadence_hooks_guardrails::guard_browser_device::GuardBrowserDevice,
                 pre,
+            ),
+            GuardrailsCommands::InjectGhContext => run_check_from_stdin(
+                &cadence_hooks_guardrails::inject_gh_context::InjectGhContext,
+                session,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {
                 cadence_hooks_guardrails::dismiss_main_branch_warn::run_dismiss(&for_);

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -209,6 +209,12 @@ pub const HOOKS: &[HookEntry] = &[
         plugin: "guardrails",
         event: Some(HookEvent::PreToolUse),
     },
+    HookEntry {
+        name: "inject-gh-context",
+        description: "Inject the gh-write allowlist + `-R` rule on SessionStart",
+        plugin: "guardrails",
+        event: Some(HookEvent::SessionStart),
+    },
     // rules
     HookEntry {
         name: "validate-frontmatter",


### PR DESCRIPTION
## Summary

Adds new `guardrails inject-gh-context` check (SessionStart) that renders the configured gh-write allowlist + the `gh ... -R owner/repo` rule into Claude's context at session start, resume, and post-compaction.

This is **Component 2 of two** from the `cadence-guardrails — JIT context injection + structured block messages` plan. Component 1 (structured `BlockMetadata` on `guard-gh-write`) ships in a follow-on PR.

## Why

`guard-gh-write` does its SAST job correctly: it blocks writes to repos outside `CADENCE_ALLOWED_OWNERS`. But the most expensive failure mode is **upstream** of the block — when Claude is in owned repo X and runs `gh issue create` without `-R`, the call targets X (whose remote IS allowlisted) instead of the intended owned repo Y. The block never fires. Silent damage, no error.

The plan's research identified SessionStart context injection as the right vehicle for this — Claude needs to know the `-R` rule before turn 1, not after a block. Idiomatic per Anthropic docs and proven by the existing `session start` precedent in `cadence-canon`.

## What

New check:
- `crates/guardrails/src/inject_gh_context.rs` — pure `render_context()` + `InjectGhContext: Check`
- Reads `CADENCE_ALLOWED_OWNERS`, `CADENCE_ALLOWED_REPOS`, `CADENCE_EXTRA_HOSTS` via existing `cadence_hooks_core::config` helpers
- Returns `CheckResult::nudge(...)` — the framework wraps it as `hookSpecificOutput.additionalContext` (same delivery surface as `session start`)
- Renders allowlist as a bulleted block; falls back to "Allowlist is empty (...)" when neither env var is set, so the missing-config state is visible rather than misleading

Wiring:
- `src/main.rs` — new `GuardrailsCommands::InjectGhContext` clap variant, dispatch via `run_check_from_stdin(..., session)`
- `src/registry.rs` — `HOOKS` entry with `event: Some(HookEvent::SessionStart)`
- `crates/guardrails/src/lib.rs` — new `pub mod inject_gh_context`

Companion `hooks.json` wiring lives in [cameronsjo/cadence-canon#3](https://github.com/cameronsjo/cadence-canon/pull/3).

## Tests

11 new unit tests covering:
- `render_context` with various allowlist combinations (owners only, repos only, host-qualified, empty, extra hosts)
- Empty-allowlist warning path
- Required substring presence (`-R owner/repo`, "Default host:", reads-work-without-flag)
- `Check::name()` matches the subcommand
- `Check::run()` returns `Outcome::Nudge` with a non-empty message

```
test result: ok. 11 passed; 0 failed; 0 ignored; 0 measured
```

## Manual verification

```
$ CADENCE_ALLOWED_OWNERS="cameronsjo cameron" CADENCE_EXTRA_HOSTS="git.sjo.lol" \
    cadence-hooks try guardrails inject-gh-context

Hook:     guardrails inject-gh-context — Inject the gh-write allowlist + `-R` rule on SessionStart
Event:    SessionStart
Outcome:  NUDGE (exit 0)
Context injected (what Claude sees):

  git-guardrails (gh writes):
  - gh writes (pr/issue/release/repo/api -X POST|PUT|PATCH|DELETE) are policed by an allowlist.
  - Always pass `-R owner/repo` for gh writes. Without it, the target is inferred from cwd's git remote — silently wrong in worktrees and when cwd is not the intended repo.
  - Reads (`gh pr list`, `gh issue view`, etc.) work without `-R`.
  - Allowed owners: cameronsjo, cameron
  - Default host: github.com; extra hosts: git.sjo.lol
```

## Out of scope (follow-ups)

- **Component 1**: structured `BlockMetadata` on `guard-gh-write` (`rule_id`, `fix`, `allowed_owners`, `severity`) so blocks return a machine-parseable payload Claude self-corrects from on the first retry. Separate PR after this one soaks.
- Port `guard-push-remote` to the same structured-block primitive (after Component 1 lands).
- Wire `HookEvent::UserPromptSubmit` (cadence-hooks#51) with gh-keyword-gated per-prompt injection.

## Test plan

- [x] `cargo build -p cadence-hooks-guardrails` clean
- [x] `cargo test --workspace` clean apart from `hook_registration_audit` failures attributable to (a) the cadence-canon companion PR not yet merged and (b) an unrelated cadence-guardrails sibling on `feat/guard-browser-device` — both are local-sibling artifacts, CI runs in a clean checkout where the audit test SKIPS by design
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] Manual `cadence-hooks try guardrails inject-gh-context` exercises the rendered output
- [ ] End-to-end: brew-upgrade installed binary, install cadence-canon companion PR via BRAT or local checkout, start fresh session, confirm context appears via session JSONL grep

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced `inject-gh-context` guardrail hook that automatically injects the configured GitHub write allowlist (allowed owners, repos, and hosts) along with `-R` command guidance into the session context at session start, resume, and post-compaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->