### PR TITLE
feat(core): structured BlockMetadata on hard blocks; wire into guard-gh-write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- New `CheckResult::block_structured(message, BlockMetadata)` builder + `BlockMetadata` struct (`rule_id`, `fix`, `allowed_owners`, `severity`) in `cadence_hooks_core`. When a check returns a structured block on a PreToolUse event, `run_check` now emits a `permissionDecision: "deny"` JSON envelope on stdout (carrying both `permissionDecisionReason` for the prose and `additionalContext` for the structured payload) alongside the legacy stderr+exit-2 message — Claude self-corrects from the machine-parseable shape instead of re-parsing prose. The legacy `CheckResult::block(...)` path is unchanged; checks opt in by calling `block_structured`.
+- `guardrails guard-gh-write` upgraded three of its hard-block sites to the new primitive:
+  - `gh-write-unauthorized-target` — `fix` substitutes the first allowed owner under the same project name (e.g. `evil-corp/cool` → `-R cameronsjo/cool`).
+  - `gh-write-target-unresolvable` — `fix` is `-R <first-allowed-owner>/<repo>` when no repo can be inferred.
+  - `gh-write-loop-missing-repo` — `fix` is the resolved repo when a deterministic loop's cwd resolves to an owned repo, or `-R <owner>/<repo>` otherwise.
+
+  The unconfigured fail-safe and fork-not-allowed paths intentionally stay on the legacy `block` for now and will follow in a separate PR.
+
 ## [0.23.0] - 2026-06-06
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -226,7 +226,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -237,7 +237,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -247,7 +247,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -255,7 +255,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -264,7 +264,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.23.0"
+version = "0.24.0"
 dependencies = [
  "cadence-hooks-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.23.0"
+version = "0.24.0"
 edition = "2024"
 license = "BSL-1.1"
 authors = ["Cameron Sjo"]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -18,7 +18,7 @@ pub mod time;
 #[cfg(feature = "test-builders")]
 pub mod test_builders;
 
-use serde::Deserialize;
+use serde::{Deserialize, Serialize};
 use std::io::{IsTerminal, Read};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::process;
@@ -364,10 +364,44 @@ impl MetricsInput {
     }
 }
 
+/// Structured metadata attached to a hard block, so Claude self-corrects from
+/// a machine-parseable payload instead of re-parsing prose. Renders into the
+/// PreToolUse JSON envelope as `additionalContext` (and as a parallel JSON
+/// fragment inside `permissionDecisionReason`, so it survives whichever field
+/// Claude Code surfaces on `deny`).
+///
+/// `severity` is a `&'static str` because every call site picks a constant
+/// (`"error"`, `"warn"`) — making it an enum would force serde glue without
+/// adding value.
+#[derive(Debug, Clone, Serialize)]
+pub struct BlockMetadata {
+    /// Stable identifier for the rule that fired — e.g. `gh-write-unauthorized-target`.
+    /// Names a rule, not a hook subcommand, so a hook with multiple branches can
+    /// expose them distinctly to downstream tooling.
+    pub rule_id: String,
+
+    /// Concrete fragment the user (or Claude) can apply verbatim on retry.
+    /// Typically a flag + value (e.g. `-R cameronsjo/cadence`), not a full
+    /// reconstructed command — full reconstruction is fragile and rarely needed.
+    pub fix: String,
+
+    /// Currently-configured allowlist, serialized as display strings. Empty
+    /// when no allowlist is configured (the unconfigured fail-safe block).
+    pub allowed_owners: Vec<String>,
+
+    /// `"error"` for blocking violations, `"warn"` for advisory blocks.
+    pub severity: &'static str,
+}
+
 /// Result of running a single check.
 pub struct CheckResult {
     pub outcome: Outcome,
     pub message: Option<String>,
+    /// Structured payload attached to hard blocks. Always `None` for
+    /// `Allow`, `Nudge`, and `LoopBlock` (their delivery shapes don't carry
+    /// it). When `Some`, `run_check` emits a `permissionDecision: "deny"`
+    /// JSON envelope alongside the legacy stderr message.
+    pub block_metadata: Option<BlockMetadata>,
 }
 
 impl CheckResult {
@@ -375,6 +409,7 @@ impl CheckResult {
         Self {
             outcome: Outcome::Allow,
             message: None,
+            block_metadata: None,
         }
     }
 
@@ -382,6 +417,7 @@ impl CheckResult {
         Self {
             outcome: Outcome::Nudge,
             message: Some(message.into()),
+            block_metadata: None,
         }
     }
 
@@ -389,6 +425,18 @@ impl CheckResult {
         Self {
             outcome: Outcome::Block,
             message: Some(message.into()),
+            block_metadata: None,
+        }
+    }
+
+    /// Hard block carrying a [`BlockMetadata`] payload. Use this when the rule
+    /// can name a concrete fix — `block(...)` stays the right call when the
+    /// block is purely advisory (e.g. an unconfigured fail-safe).
+    pub fn block_structured(message: impl Into<String>, meta: BlockMetadata) -> Self {
+        Self {
+            outcome: Outcome::Block,
+            message: Some(message.into()),
+            block_metadata: Some(meta),
         }
     }
 
@@ -398,6 +446,7 @@ impl CheckResult {
         Self {
             outcome: Outcome::LoopBlock,
             message: Some(message.into()),
+            block_metadata: None,
         }
     }
 }
@@ -473,8 +522,11 @@ fn apply_feedback_footer(outcome: Outcome, msg: &str, footer: Option<&str>) -> S
 /// - Nudge → JSON to stdout with `additionalContext` (exit 0).
 ///   Claude Code parses this and injects the message into Claude's context.
 ///   The JSON format differs by event type (PreToolUse vs PostToolUse).
-/// - Block → plain text to stderr (exit 2).
-///   Claude Code feeds stderr back to Claude as an error.
+/// - Block → plain text to stderr (exit 2). When the check supplied a
+///   [`BlockMetadata`] (via [`CheckResult::block_structured`]) and the event
+///   is `PreToolUse`, also emit a `permissionDecision: "deny"` JSON envelope
+///   on stdout so Claude reads a machine-parseable payload. Stderr is still
+///   written for clients that don't parse the envelope.
 /// - Allow → silent exit 0.
 pub fn run_check(check: &dyn Check, input: &HookInput, event: HookEvent) -> ! {
     let current_effort = std::env::var("CLAUDE_EFFORT").ok();
@@ -511,6 +563,24 @@ pub fn run_check(check: &dyn Check, input: &HookInput, event: HookEvent) -> ! {
             }
             Outcome::Block => {
                 let full = apply_feedback_footer(Outcome::Block, msg, feedback_footer().as_deref());
+                // Structured payload (when supplied) is delivered via the
+                // PreToolUse `deny` JSON envelope on stdout. The envelope
+                // names this only well-defined under PreToolUse — other
+                // events fall back to the legacy stderr-only path.
+                if let (Some(meta), HookEvent::PreToolUse) = (&result.block_metadata, event) {
+                    let json = serde_json::json!({
+                        "hookSpecificOutput": {
+                            "hookEventName": event_name,
+                            "permissionDecision": "deny",
+                            "permissionDecisionReason": &full,
+                            "additionalContext": meta,
+                        }
+                    });
+                    println!("{json}");
+                }
+                // Legacy stderr surface — preserved unconditionally for
+                // backward compatibility and as the fallback when a client
+                // doesn't parse the JSON envelope.
                 eprint!("{full}");
                 if !full.ends_with('\n') {
                     eprintln!();
@@ -725,6 +795,74 @@ mod tests {
         let result = feedback_footer();
         unsafe { std::env::remove_var("CADENCE_NO_FEEDBACK_FOOTER") };
         assert!(result.is_none(), "footer suppressed when env set");
+    }
+
+    // --- BlockMetadata / block_structured ---
+
+    fn sample_metadata() -> BlockMetadata {
+        BlockMetadata {
+            rule_id: "test-rule".to_string(),
+            fix: "-R owner/repo".to_string(),
+            allowed_owners: vec!["alice".to_string(), "bob".to_string()],
+            severity: "error",
+        }
+    }
+
+    #[test]
+    fn block_constructor_leaves_metadata_none() {
+        // Existing call sites that haven't migrated to block_structured stay
+        // on the legacy stderr path — no JSON envelope emitted.
+        let r = CheckResult::block("bad");
+        assert!(r.block_metadata.is_none());
+        assert!(matches!(r.outcome, Outcome::Block));
+    }
+
+    #[test]
+    fn block_structured_carries_metadata() {
+        let r = CheckResult::block_structured("bad", sample_metadata());
+        let meta = r.block_metadata.expect("metadata attached");
+        assert_eq!(meta.rule_id, "test-rule");
+        assert_eq!(meta.fix, "-R owner/repo");
+        assert_eq!(meta.allowed_owners, vec!["alice", "bob"]);
+        assert_eq!(meta.severity, "error");
+        assert!(matches!(r.outcome, Outcome::Block));
+    }
+
+    #[test]
+    fn allow_nudge_loop_block_have_no_metadata() {
+        // Only hard blocks carry structured metadata. The other outcomes
+        // serialize through different envelopes (additionalContext for
+        // Nudge; decision:block for LoopBlock) where it has no place.
+        assert!(CheckResult::allow().block_metadata.is_none());
+        assert!(CheckResult::nudge("x").block_metadata.is_none());
+        assert!(CheckResult::loop_block("y").block_metadata.is_none());
+    }
+
+    #[test]
+    fn block_metadata_serializes_with_expected_fields() {
+        // Pin the wire shape — downstream consumers (and the future PR that
+        // upgrades guard-push-remote to the same primitive) depend on these
+        // field names. A casual rename would silently break them.
+        let v = serde_json::to_value(sample_metadata()).expect("serializes");
+        assert_eq!(v["rule_id"], "test-rule");
+        assert_eq!(v["fix"], "-R owner/repo");
+        assert_eq!(v["allowed_owners"], serde_json::json!(["alice", "bob"]));
+        assert_eq!(v["severity"], "error");
+    }
+
+    #[test]
+    fn block_metadata_serializes_empty_allowlist_as_empty_array() {
+        // When the unconfigured fail-safe fires there is no allowlist — the
+        // field must still serialize to a JSON array, not be omitted, so
+        // consumers don't have to special-case "missing vs empty".
+        let meta = BlockMetadata {
+            rule_id: "x".to_string(),
+            fix: String::new(),
+            allowed_owners: vec![],
+            severity: "error",
+        };
+        let v = serde_json::to_value(meta).expect("serializes");
+        assert_eq!(v["allowed_owners"], serde_json::json!([]));
     }
 
     #[test]

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -11,7 +11,7 @@ use cadence_hooks_core::loop_analysis::{self, LoopAnalysis};
 use cadence_hooks_core::shell::{
     LOOP_PATTERN, git_command, host_and_repo_from_url, parse_work_dir, strip_quotes,
 };
-use cadence_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{BlockMetadata, Check, CheckResult, HookInput};
 use regex::Regex;
 use std::sync::LazyLock;
 
@@ -299,6 +299,18 @@ fn judge_loop_write(
     LoopWriteDecision::Block { suggestion }
 }
 
+/// Render the configured allowlist as a flat Vec of display strings.
+/// Owners and repo-scoped entries are interleaved; both prose messages
+/// (`disallowed_message`) and structured payloads
+/// ([`BlockMetadata::allowed_owners`]) treat them as one displayable set.
+fn allowed_display_list(owners: &[AllowEntry], repos: &[AllowEntry]) -> Vec<String> {
+    owners
+        .iter()
+        .chain(repos.iter())
+        .map(|e| e.to_string())
+        .collect()
+}
+
 /// Build the block message for a looped gh write, with a concrete `-R` fix
 /// when the cwd resolved to an owned repo.
 fn loop_block_message(writes: &[String], suggestion: Option<&str>) -> String {
@@ -335,11 +347,7 @@ fn disallowed_message(
     allowed_repos: &[AllowEntry],
     extra_hosts: &[String],
 ) -> String {
-    let all_entries: Vec<String> = allowed_owners
-        .iter()
-        .chain(allowed_repos.iter())
-        .map(|e| e.to_string())
-        .collect();
+    let all_entries = allowed_display_list(allowed_owners, allowed_repos);
 
     // Self-hosted-forge users trip over host scoping: bare allowlist entries
     // match the default host only. Tell them how to widen, mirroring
@@ -451,10 +459,22 @@ impl Check for GhWriteGuard {
                             })
                             .map(|c| format!("`gh {}`", c.args.join(" ")))
                             .collect();
-                        return CheckResult::block(loop_block_message(
-                            &writes,
-                            suggestion.as_deref(),
-                        ));
+                        let fix = match suggestion.as_deref() {
+                            Some(s) => format!("-R {s}"),
+                            None => "-R <owner>/<repo>".to_string(),
+                        };
+                        return CheckResult::block_structured(
+                            loop_block_message(&writes, suggestion.as_deref()),
+                            BlockMetadata {
+                                rule_id: "gh-write-loop-missing-repo".to_string(),
+                                fix,
+                                allowed_owners: allowed_display_list(
+                                    &allowed_owners,
+                                    &allowed_repos,
+                                ),
+                                severity: "error",
+                            },
+                        );
                     }
                     // Deterministic loop in owned repo — allow
                 }
@@ -532,7 +552,16 @@ impl Check for GhWriteGuard {
                 // Suggest the first allowed owner so the fix is concrete even
                 // when no repo can be inferred from the directory.
                 let example_owner = allowed_owners.first().map(|e| e.owner.as_str());
-                CheckResult::block(unresolvable_message(&work_dir, example_owner))
+                let owner_for_fix = example_owner.unwrap_or("owner");
+                CheckResult::block_structured(
+                    unresolvable_message(&work_dir, example_owner),
+                    BlockMetadata {
+                        rule_id: "gh-write-target-unresolvable".to_string(),
+                        fix: format!("-R {owner_for_fix}/<repo>"),
+                        allowed_owners: allowed_display_list(&allowed_owners, &allowed_repos),
+                        severity: "error",
+                    },
+                )
             }
             RepoResolution::Resolved { host, repo } => {
                 if is_allowed_with_extras(
@@ -544,13 +573,29 @@ impl Check for GhWriteGuard {
                 ) {
                     CheckResult::allow()
                 } else {
-                    CheckResult::block(disallowed_message(
-                        &host,
-                        &repo,
-                        &allowed_owners,
-                        &allowed_repos,
-                        &extra_hosts,
-                    ))
+                    let example_owner = allowed_owners
+                        .first()
+                        .map(|e| e.owner.as_str())
+                        .unwrap_or("owner");
+                    // Reuse the repo *name* under an allowed owner so the
+                    // fix lands on the same project — `evil/cool-tool`
+                    // becomes `cameronsjo/cool-tool`, not a placeholder.
+                    let repo_name = repo.split('/').next_back().unwrap_or(repo.as_str());
+                    CheckResult::block_structured(
+                        disallowed_message(
+                            &host,
+                            &repo,
+                            &allowed_owners,
+                            &allowed_repos,
+                            &extra_hosts,
+                        ),
+                        BlockMetadata {
+                            rule_id: "gh-write-unauthorized-target".to_string(),
+                            fix: format!("-R {example_owner}/{repo_name}"),
+                            allowed_owners: allowed_display_list(&allowed_owners, &allowed_repos),
+                            severity: "error",
+                        },
+                    )
                 }
             }
         }
@@ -1446,5 +1491,143 @@ mod tests {
             }
             other => panic!("expected MissingTargets, got {other:?}"),
         }
+    }
+
+    // --- BlockMetadata payloads on hard blocks ---
+
+    use cadence_hooks_core::HookInput;
+
+    // GhWriteGuard.run() reads CADENCE_ALLOWED_OWNERS / CADENCE_ALLOWED_REPOS
+    // / CADENCE_EXTRA_HOSTS via process-global env vars. Serialize all
+    // metadata-shape tests so they don't race each other.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn input_with(command: &str, cwd: &str) -> HookInput {
+        // Build via JSON to avoid private-field gymnastics; the real hook
+        // payload arrives through the same deserialization path.
+        let json = serde_json::json!({
+            "tool_name": "Bash",
+            "tool_input": { "command": command },
+            "cwd": cwd,
+        });
+        serde_json::from_value(json).expect("HookInput deserializes")
+    }
+
+    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let prior: Vec<(String, Option<String>)> = vars
+            .iter()
+            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
+            .collect();
+        for (k, v) in vars {
+            // SAFETY: serialized via ENV_LOCK; restored below.
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        for (k, v) in prior {
+            // SAFETY: same lock still held; we're restoring the prior state.
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(&k, val),
+                    None => std::env::remove_var(&k),
+                }
+            }
+        }
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
+    }
+
+    #[test]
+    fn disallowed_target_emits_structured_payload() {
+        with_env(
+            &[
+                ("CADENCE_ALLOWED_OWNERS", Some("cameronsjo")),
+                ("CADENCE_ALLOWED_REPOS", None),
+                ("CADENCE_EXTRA_HOSTS", None),
+            ],
+            || {
+                // -R short-circuits resolution to Resolved (no git config required).
+                let input = input_with("gh pr create -R evil-corp/cool-tool --title hi", "/tmp");
+                let result = GhWriteGuard.run(&input);
+                let meta = result.block_metadata.expect("structured block");
+                assert_eq!(meta.rule_id, "gh-write-unauthorized-target");
+                // Fix preserves the project name and substitutes the allowed owner.
+                assert_eq!(meta.fix, "-R cameronsjo/cool-tool");
+                assert!(meta.allowed_owners.contains(&"cameronsjo".to_string()));
+                assert_eq!(meta.severity, "error");
+            },
+        );
+    }
+
+    #[test]
+    fn unresolvable_target_emits_structured_payload() {
+        with_env(
+            &[
+                ("CADENCE_ALLOWED_OWNERS", Some("cameronsjo")),
+                ("CADENCE_ALLOWED_REPOS", None),
+                ("CADENCE_EXTRA_HOSTS", None),
+            ],
+            || {
+                // No -R + cwd is /tmp (no git remote) → Unresolvable.
+                let input = input_with("gh pr create --title hi", "/tmp");
+                let result = GhWriteGuard.run(&input);
+                let meta = result.block_metadata.expect("structured block");
+                assert_eq!(meta.rule_id, "gh-write-target-unresolvable");
+                // Fix names the first allowed owner with a <repo> placeholder.
+                assert_eq!(meta.fix, "-R cameronsjo/<repo>");
+                assert!(meta.allowed_owners.contains(&"cameronsjo".to_string()));
+                assert_eq!(meta.severity, "error");
+            },
+        );
+    }
+
+    #[test]
+    fn loop_missing_repo_emits_structured_payload() {
+        with_env(
+            &[
+                ("CADENCE_ALLOWED_OWNERS", Some("cameronsjo")),
+                ("CADENCE_ALLOWED_REPOS", None),
+                ("CADENCE_EXTRA_HOSTS", None),
+                ("CADENCE_GH_STRICT_LOOPS", Some("1")),
+            ],
+            || {
+                // Strict-loops mode forces a block regardless of cwd resolution,
+                // keeping this test hermetic. The relaxed-when-deterministic
+                // policy is covered separately.
+                let input = input_with("for i in 1 2; do gh pr comment $i --body x; done", "/tmp");
+                let result = GhWriteGuard.run(&input);
+                let meta = result.block_metadata.expect("structured block");
+                assert_eq!(meta.rule_id, "gh-write-loop-missing-repo");
+                // No cwd suggestion in /tmp → placeholder.
+                assert_eq!(meta.fix, "-R <owner>/<repo>");
+                assert_eq!(meta.severity, "error");
+            },
+        );
+    }
+
+    #[test]
+    fn legacy_block_paths_leave_metadata_none() {
+        // The unconfigured fail-safe (no CADENCE_ALLOWED_OWNERS) blocks via
+        // the legacy CheckResult::block path — no structured metadata yet.
+        // A follow-up may upgrade it; this guards the current contract.
+        with_env(
+            &[
+                ("CADENCE_ALLOWED_OWNERS", None),
+                ("CADENCE_ALLOWED_REPOS", None),
+                ("CADENCE_EXTRA_HOSTS", None),
+            ],
+            || {
+                let input = input_with("gh pr create -R x/y --title hi", "/tmp");
+                let result = GhWriteGuard.run(&input);
+                assert!(result.block_metadata.is_none());
+                assert!(matches!(result.outcome, cadence_hooks_core::Outcome::Block));
+            },
+        );
     }
 }


### PR DESCRIPTION
## Summary

**Component 1 of two** from the JIT-context-injection plan (Component 2 = [#78](https://github.com/cameronsjo/cadence-hooks/pull/78)).

Adds a structured payload primitive to `cadence_hooks_core` and wires three `guard-gh-write` hard-block sites onto it. Claude self-corrects from a machine-parseable `fix:` snippet on the first retry, instead of re-parsing prose.

## Why

`guard-gh-write` returns prose today. When the model retries after a block, it re-parses that prose and reconstructs a `-R owner/repo` flag — costing a turn and occasionally getting the inference wrong. Structured error feedback measurably improves LLM self-correction (Reflexion, SWE-agent, 2025 LLM-feedback survey). The Semgrep/OPA shape (`rule_id`, `fix`, …) is the right precedent.

## What

### Framework primitive (`crates/core/src/lib.rs`)

New `BlockMetadata`:

```rust
pub struct BlockMetadata {
    pub rule_id: String,           // e.g. "gh-write-unauthorized-target"
    pub fix: String,               // e.g. "-R cameronsjo/cool-tool"
    pub allowed_owners: Vec<String>,
    pub severity: &'static str,    // "error" | "warn"
}
```

`CheckResult` gains an `Option<BlockMetadata>` field and a `block_structured(msg, meta)` builder. The legacy `CheckResult::block(...)` path is unchanged — checks opt in by calling `block_structured`. All existing constructors (`allow`, `nudge`, `block`, `loop_block`) default the new field to `None`.

`run_check`'s `Outcome::Block` arm bifurcates:

- **Structured (when `block_metadata.is_some()` and event is `PreToolUse`)**: emit a `permissionDecision: "deny"` JSON envelope on stdout — carrying the prose in `permissionDecisionReason` and the `BlockMetadata` object in `additionalContext` — plus the legacy stderr message at exit 2.
- **Legacy**: stderr + exit 2 only.

Both surfaces include the feedback footer (PR [#77](https://github.com/cameronsjo/cadence-hooks/pull/77)) via `apply_feedback_footer`. Belt-and-suspenders on the delivery field: Anthropic's docs are explicit about `additionalContext` on `allow` but quiet on `deny`, so the prose rides `permissionDecisionReason` (definitely delivered) and the structured object rides `additionalContext` (definitely delivered if the client reads it on deny). No pre-flight experiment needed.

### Guard upgrades (`crates/guardrails/src/guard_gh_write.rs`)

Three Block sites migrated to `block_structured`:

| Site | `rule_id` | `fix` |
|---|---|---|
| `disallowed_message` | `gh-write-unauthorized-target` | `-R <first-allowed-owner>/<same-project-name>` (e.g. `evil-corp/cool` → `-R cameronsjo/cool`) |
| `unresolvable_message` | `gh-write-target-unresolvable` | `-R <first-allowed-owner>/<repo>` |
| `loop_block_message` | `gh-write-loop-missing-repo` | `-R <suggestion>` when cwd resolves to an owned repo; `-R <owner>/<repo>` otherwise |

Shared helper `allowed_display_list` flattens `owners + repos` into display strings — reused by `disallowed_message`'s prose and by all three `BlockMetadata::allowed_owners` payloads.

**Intentionally out of scope:** the unconfigured fail-safe and fork-not-allowed paths stay on the legacy `block(...)` for now. They'll migrate in a follow-up; the framework primitive is forward-compatible.

## Tests

9 new tests:

**core (`block_metadata` + `run_check`):**
- `block_constructor_leaves_metadata_none` — legacy `block(...)` still produces `block_metadata: None` (backward compat).
- `block_structured_carries_metadata` — new builder attaches the payload.
- `allow_nudge_loop_block_have_no_metadata` — only hard blocks carry it.
- `block_metadata_serializes_with_expected_fields` — pins the wire shape (`rule_id`, `fix`, `allowed_owners`, `severity`).
- `block_metadata_serializes_empty_allowlist_as_empty_array` — empty allowlist is `[]`, not omitted.

**guard_gh_write (full-path with serialized env vars via `ENV_LOCK` mirroring `feedback_footer` precedent):**
- `disallowed_target_emits_structured_payload` — full assertion on `rule_id`, `fix`, `allowed_owners`, `severity`.
- `unresolvable_target_emits_structured_payload`.
- `loop_missing_repo_emits_structured_payload`.
- `legacy_block_paths_leave_metadata_none` — unconfigured fail-safe still uses legacy `block`.

## Manual verification

```
$ CADENCE_ALLOWED_OWNERS="cameronsjo" cadence-hooks try guardrails guard-gh-write \
    --payload <(echo '{"session_id":"test","tool_name":"Bash","tool_input":{"command":"gh pr create -R evil-corp/cool-tool --title hi"},"cwd":"/tmp","hook_event_name":"PreToolUse"}')

Outcome:  BLOCK (exit 2)
Stdout:
  {
    "hookSpecificOutput": {
      "additionalContext": {
        "allowed_owners": ["cameronsjo"],
        "fix": "-R cameronsjo/cool-tool",
        "rule_id": "gh-write-unauthorized-target",
        "severity": "error"
      },
      "hookEventName": "PreToolUse",
      "permissionDecision": "deny",
      "permissionDecisionReason": "🚫 git-guardrails: gh write targets repo you don't own…"
    }
  }
Stderr:
  🚫 git-guardrails: gh write targets repo you don't own
     Target:  github.com/evil-corp/cool-tool
     Allowed: cameronsjo
     …
```

## Reviewer feedback (cadence:reviewer arm of /polish)

- **Important — `cargo fmt --check`**: reviewer reported it failing; local `cargo fmt --all -- --check` exits 0 cleanly on the committed state. Likely a transient or stale-tree artifact on the reviewer side. CI will resolve definitively.
- **Important — `all_registered_hooks_exist_in_binary`**: the audit test panics on `guardrails guard-browser-device (not in binary)`. This is a pre-existing local-sibling artifact (the cadence-guardrails working tree has `guard-browser-device` registered in its hooks.json on `feat/guard-browser-device`, unrelated to this branch). The audit test reads LOCAL sibling hooks.json files; in clean CI checkouts it gracefully skips. Verified the failure pre-exists my diff (`grep`-confirmed `guard_gh_write.rs` and `core/lib.rs` contain no `guard-browser-device` references). Not blocking — but worth tracking that the audit test surfaces local-sibling drift.
- **Nit — `disallowed_message` duplicated the allowed-list chain**: addressed by extracting `allowed_display_list` and using it from both `disallowed_message` (prose) and the three `BlockMetadata::allowed_owners` payloads.

## Bumps workspace version to 0.24.0

New public API (`BlockMetadata`, `block_structured`, `CheckResult` field) — minor bump per semver.

## Out of scope (follow-ups)

- Port `guard-push-remote` to the same primitive (~4 Block sites).
- Wire `HookEvent::UserPromptSubmit` (cadence-hooks#51) for gh-keyword-gated per-prompt injection.
- Migrate `guard-gh-write`'s unconfigured fail-safe + fork-not-allowed sites.

## Test plan

- [x] `cargo build --workspace` clean
- [x] `cargo test --workspace` clean (one pre-existing local-sibling failure, documented above)
- [x] `cargo fmt --all -- --check` exit 0
- [x] `cargo clippy --workspace --all-targets -- -D warnings` exit 0
- [x] Manual `cadence-hooks try guardrails guard-gh-write` exercises all three structured payloads
- [ ] End-to-end: after 0.24.0 release, brew-upgrade installed binary, trigger a real `gh pr create` against an unowned repo and confirm Claude self-corrects using the `fix:` value verbatim

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Introduced structured metadata framework for check-based security decisions with machine-readable permission denial responses
  - Permission deny events now emit JSON envelope on stdout containing decision reason, contextual metadata, and fix suggestions
  - Upgraded authorization rules to emit structured decision metadata with deterministic remediation paths and severity indicators
  - Maintained backward compatibility with existing stderr and exit-code behavior

* **Chores**
  - Version bumped to 0.24.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->