### PR TITLE
docs: route all cadence-hooks issues to claude-configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -437,9 +437,15 @@ Requires Rust 2024 edition (1.85+).
 
 ## Reporting issues
 
-Bug reports and feature requests for the binary belong here: [Issues](https://github.com/cameronsjo/cadence-hooks/issues/new/choose).
-
-Two templates are available — Bug report (capture version, OS, plugin namespace, hook name, env, and repro) and Feature request. Issues about plugin distribution, marketplace metadata, or `hooks.json` wiring belong in [claude-configurations](https://github.com/cameronsjo/claude-configurations/issues) instead.
+All cadence ecosystem issues — including everything about this binary (a wrong
+block/allow decision, a guard bug, a feature request, plus plugin distribution,
+marketplace metadata, and `hooks.json` wiring) — go to one tracker:
+[**claude-configurations**](https://github.com/cameronsjo/claude-configurations/issues).
+There is no separate per-repo tracker; the meta-repo `CLAUDE.md` issue-filing
+rule is the single source of truth. When reporting a binary bug, capture
+`cadence-hooks --version`, OS, plugin namespace, hook name, relevant `CADENCE_*`
+env, and a repro (a payload via `cadence-hooks try …`). The fastest path from a
+hook firing in error is `/cadence:feedback`.
 
 ## License
 


### PR DESCRIPTION
## What

Broaden the README "Reporting issues" section to route **all** cadence-hooks
issues to `claude-configurations`.

## Why

The README previously sent binary bugs/feature requests to the cadence-hooks
issue tracker and only distribution/marketplace/`hooks.json`-wiring issues to
claude-configurations — directly contradicting the meta-repo rule that all
cadence ecosystem issues land in one tracker. This resolves that contradiction.

## Changes

- One tracker for everything (binary bugs, guard decisions, feature requests,
  distribution/wiring), citing the meta-repo `CLAUDE.md` issue-filing rule as the
  single source of truth.
- Keeps the binary-bug capture checklist (`--version`, OS, namespace, hook name,
  `CADENCE_*` env, repro) and points at `/cadence:feedback` as the fast path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated issue reporting guidelines to consolidate all ecosystem issues to a unified tracker with enhanced reporting templates and debugging resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->