### PR TITLE
feat(git-safety): judge every command in a chain, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- `core::shell::split_segments` / `command_segments` — quote-aware splitting of a
+  shell command into its top-level segments (`&&`, `||`, `;`, `|`, `&`, newline),
+  with recursive `sh -c '…'` wrapper expansion. The shared primitive guards use
+  to judge every command a shell will run, not just the first.
+
+### Fixed
+
+- **git-safety: compound-command and quote-aware bypasses** (#61, #62, #63).
+  git-safety now judges every command in a chain — `git status && git push
+  --force origin main` no longer slips because the first command is benign — and
+  sees through `sh -c '…'` wrappers, matches path-form git (`/usr/bin/git`),
+  reads quoted flags (`"--force"`), and exempts an alias definition only for its
+  own segment instead of the whole command line.
+
 ## [0.25.0] - 2026-06-08
 
 ### Added

--- a/crates/cadence/src/git_safety.rs
+++ b/crates/cadence/src/git_safety.rs
@@ -9,6 +9,7 @@
 //! `--no-optional-locks`) are stripped so that flag injection and
 //! whitespace padding cannot bypass detection.
 
+use cadence_hooks_core::shell::{command_segments, tokenize};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Protected branch names that trigger blocks instead of warnings.
@@ -21,30 +22,40 @@ const GIT_GLOBAL_FLAGS_WITH_ARG: &[&str] = &["-C", "--git-dir", "--work-tree"];
 /// Git global options that are standalone (no following argument).
 const GIT_GLOBAL_FLAGS_STANDALONE: &[&str] = &["--no-pager", "--no-optional-locks", "--bare"];
 
-/// Normalize a git command string for reliable matching.
+/// True if a token is the `git` command word — either bare `git` or a path
+/// ending in `/git` (e.g. `/usr/bin/git`, `./git`). Closes the absolute/relative
+/// path-git evasion: matching only the exact token `git` let `/usr/bin/git push
+/// --force` slip the normalizer.
+fn is_git_word(token: &str) -> bool {
+    token == "git" || token.ends_with("/git")
+}
+
+/// Normalize a single command segment into matchable tokens.
 ///
-/// 1. Collapse all runs of whitespace to single spaces and trim.
+/// 1. Quote-aware tokenization ([`tokenize`]): a quoted flag like `"--force"`
+///    becomes a clean `--force` token, while a whole command quoted as an
+///    argument stays one token and can never masquerade as the git command word.
 /// 2. Strip git global options that appear between `git` and the subcommand
 ///    (`-C <path>`, `--git-dir=<path>`, `--work-tree=<path>`, `--no-pager`,
 ///    `--no-optional-locks`, `--bare`).
 ///
-/// Returns the normalized string lowercased.
-fn normalize_git_command(command: &str) -> String {
-    let lower = command.to_lowercase();
-    // Collapse whitespace
-    let tokens: Vec<&str> = lower.split_whitespace().collect();
-    let mut result: Vec<&str> = Vec::with_capacity(tokens.len());
+/// Returns the lowercased token list. The caller must judge these tokens
+/// directly (not a re-joined string), or a quoted span with internal spaces
+/// would re-fragment and defeat the quote-awareness.
+fn normalize_git_command(command: &str) -> Vec<String> {
+    let tokens = tokenize(&command.to_lowercase());
+    let mut result: Vec<String> = Vec::with_capacity(tokens.len());
     let mut i = 0;
     let mut seen_git = false;
     let mut seen_subcommand = false;
 
     while i < tokens.len() {
-        let token = tokens[i];
+        let token = tokens[i].as_str();
 
         // Pass through everything before `git`
         if !seen_git {
-            result.push(token);
-            if token == "git" {
+            result.push(token.to_string());
+            if is_git_word(token) {
                 seen_git = true;
             }
             i += 1;
@@ -84,11 +95,11 @@ fn normalize_git_command(command: &str) -> String {
             seen_subcommand = true;
         }
 
-        result.push(token);
+        result.push(token.to_string());
         i += 1;
     }
 
-    result.join(" ")
+    result
 }
 
 /// Check whether a short flag cluster (e.g., `-fu`, `-xfd`) contains a
@@ -140,7 +151,7 @@ impl GitSafetyGuard {
     /// Returns `Some(reason)` if blocked, `None` if not.
     fn check_blocked(&self, normalized: &str, tokens: &[&str]) -> Option<String> {
         // Find the git subcommand position
-        let git_pos = tokens.iter().position(|t| *t == "git")?;
+        let git_pos = tokens.iter().position(|t| is_git_word(t))?;
         let sub_pos = git_pos + 1;
         if sub_pos >= tokens.len() {
             return None;
@@ -274,7 +285,7 @@ impl GitSafetyGuard {
     /// Check the normalized tokens for warned operations.
     /// Returns `Some(message)` if warned, `None` if not.
     fn check_warned(&self, tokens: &[&str]) -> Option<String> {
-        let git_pos = tokens.iter().position(|t| *t == "git")?;
+        let git_pos = tokens.iter().position(|t| is_git_word(t))?;
         let sub_pos = git_pos + 1;
         if sub_pos >= tokens.len() {
             return None;
@@ -339,32 +350,43 @@ impl Check for GitSafetyGuard {
             return CheckResult::allow();
         };
 
-        let lower = command.to_lowercase();
-
-        if !lower.contains("git") {
+        if !command.to_lowercase().contains("git") {
             return CheckResult::allow();
         }
 
-        // Skip alias definitions to avoid false positives
-        if is_alias_definition(command) {
-            return CheckResult::allow();
+        // Judge each command segment independently so a benign first command
+        // (`git status &&`, `cd x &&`) can't shield a destructive sibling, and
+        // a command hidden in `sh -c '…'` is still seen. Block precedence: any
+        // segment blocks → block; else any warns → nudge.
+        let mut should_warn = false;
+        for segment in command_segments(command) {
+            // Per-segment alias check: a `git config alias.x …` segment is
+            // exempt, but a destructive sibling in the same chain is not.
+            if is_alias_definition(&segment) {
+                continue;
+            }
+
+            let norm_tokens = normalize_git_command(&segment);
+            let tokens: Vec<&str> = norm_tokens.iter().map(String::as_str).collect();
+            // Joined form is only for the substring-based reflog/gc checks; the
+            // git-word match runs on the span-preserved token list above.
+            let normalized = tokens.join(" ");
+
+            if self.check_blocked(&normalized, &tokens).is_some() {
+                return CheckResult::block(format!(
+                    "BLOCKED: Dangerous git operation detected.\n\n\
+                     Command: {command}\n\n\
+                     This operation could cause data loss or rewrite shared history.\n\
+                     If you really need to do this, run it manually outside Claude Code."
+                ));
+            }
+
+            if self.check_warned(&tokens).is_some() {
+                should_warn = true;
+            }
         }
 
-        let normalized = normalize_git_command(command);
-        let tokens: Vec<&str> = normalized.split_whitespace().collect();
-
-        // Check absolute blocks first
-        if let Some(_reason) = self.check_blocked(&normalized, &tokens) {
-            return CheckResult::block(format!(
-                "BLOCKED: Dangerous git operation detected.\n\n\
-                 Command: {command}\n\n\
-                 This operation could cause data loss or rewrite shared history.\n\
-                 If you really need to do this, run it manually outside Claude Code."
-            ));
-        }
-
-        // Check warnings
-        if let Some(_reason) = self.check_warned(&tokens) {
+        if should_warn {
             return CheckResult::nudge(format!(
                 "Git operation may modify history or lose work: {command}"
             ));
@@ -386,7 +408,7 @@ mod tests {
     #[test]
     fn normalize_collapses_whitespace() {
         assert_eq!(
-            normalize_git_command("git  push  --force  origin  main"),
+            normalize_git_command("git  push  --force  origin  main").join(" "),
             "git push --force origin main"
         );
     }
@@ -394,7 +416,7 @@ mod tests {
     #[test]
     fn normalize_strips_no_pager() {
         assert_eq!(
-            normalize_git_command("git --no-pager push --force origin main"),
+            normalize_git_command("git --no-pager push --force origin main").join(" "),
             "git push --force origin main"
         );
     }
@@ -402,7 +424,7 @@ mod tests {
     #[test]
     fn normalize_strips_c_flag() {
         assert_eq!(
-            normalize_git_command("git -C /some/path push --force origin main"),
+            normalize_git_command("git -C /some/path push --force origin main").join(" "),
             "git push --force origin main"
         );
     }
@@ -410,7 +432,7 @@ mod tests {
     #[test]
     fn normalize_strips_git_dir_eq() {
         assert_eq!(
-            normalize_git_command("git --git-dir=/foo/.git push --force origin main"),
+            normalize_git_command("git --git-dir=/foo/.git push --force origin main").join(" "),
             "git push --force origin main"
         );
     }
@@ -418,7 +440,7 @@ mod tests {
     #[test]
     fn normalize_strips_work_tree() {
         assert_eq!(
-            normalize_git_command("git --work-tree /foo push --force origin main"),
+            normalize_git_command("git --work-tree /foo push --force origin main").join(" "),
             "git push --force origin main"
         );
     }
@@ -426,7 +448,7 @@ mod tests {
     #[test]
     fn normalize_strips_no_optional_locks() {
         assert_eq!(
-            normalize_git_command("git --no-optional-locks status"),
+            normalize_git_command("git --no-optional-locks status").join(" "),
             "git status"
         );
     }
@@ -436,7 +458,8 @@ mod tests {
         assert_eq!(
             normalize_git_command(
                 "git --no-pager -C /repo --git-dir=/repo/.git push -f origin main"
-            ),
+            )
+            .join(" "),
             "git push -f origin main"
         );
     }
@@ -1062,5 +1085,106 @@ mod tests {
             "git  --no-pager  -C /repo  push  origin  main  --force",
         ));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    // ---------------------------------------------------------------
+    // #61: chained command — only the first git was inspected
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn benign_first_then_force_push_main_blocked() {
+        // The bypass: `git status` is benign, so the force-push slipped through.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git status && git push --force origin main",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn benign_first_then_reset_hard_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input("ls && git reset --hard"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn force_push_main_after_semicolon_blocked() {
+        let result =
+            GitSafetyGuard.run(&make_bash_input("echo done; git push --force origin main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn force_push_main_after_pipe_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input("true | git push --force origin main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    // ---------------------------------------------------------------
+    // #63: quote-aware tokenization — path/escaped git and quoted flags
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn absolute_path_git_force_push_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input("/usr/bin/git push --force origin main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn relative_path_git_force_push_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input("./git push --force origin main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn quoted_force_flag_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input(r#"git push "--force" origin main"#));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn sh_c_wrapped_force_push_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input("sh -c 'git push --force origin main'"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    // ---------------------------------------------------------------
+    // #62: alias check exempted the whole command line
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn alias_config_then_force_push_blocked() {
+        // The config-alias segment is exempt, but the chained force-push is not.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git config alias.fp 'push --force' && git push --force origin main",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    // ---------------------------------------------------------------
+    // False-block guards: quoted-as-argument commands must stay allowed
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn echo_of_force_push_string_allowed() {
+        // `git` lives inside a quoted argument to echo — not a git command.
+        let result = GitSafetyGuard.run(&make_bash_input(r#"echo "git push --force origin main""#));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn echo_single_quoted_git_then_ls_allowed() {
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "echo 'use git push --force carefully' && ls",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn commit_message_with_reset_hard_text_allowed() {
+        // `reset --hard` and `;` are inside the commit message — not commands.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            r#"git commit -m "wip; reset --hard test""#,
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/core/src/shell.rs
+++ b/crates/core/src/shell.rs
@@ -211,6 +211,130 @@ fn resolve_cd_target(target: &str, effective: &str) -> String {
     }
 }
 
+/// Maximum recursion depth for shell-wrapper expansion in [`command_segments`].
+const MAX_WRAPPER_DEPTH: usize = 3;
+
+/// Push `current` (trimmed) onto `segments` as a new segment, dropping it if
+/// empty, then clear `current`. Helper for [`split_segments`].
+fn flush_segment(segments: &mut Vec<String>, current: &mut String) {
+    let trimmed = current.trim();
+    if !trimmed.is_empty() {
+        segments.push(trimmed.to_string());
+    }
+    current.clear();
+}
+
+/// Split a shell command into top-level command segments.
+///
+/// Splits on the control operators `&&`, `||`, `;`, `|`, `&`, and newlines —
+/// but never inside `'…'` or `"…"` quotes, so `echo "a && b"` is one segment
+/// and `git commit -m "fix; bug"` is one segment. Multi-character operators
+/// (`&&`, `||`) are consumed before their single-character prefixes (`&`, `|`).
+/// Quote characters are preserved within each segment; segments are trimmed and
+/// empty segments dropped.
+///
+/// This is syntactic splitting, not shell execution: it does not expand
+/// subshells (`$(…)`, backticks) or honor backslash escapes (consistent with
+/// [`tokenize`]). Heredoc bodies split on their newlines — accepted here, since
+/// the guards consuming this favor catching a hidden dangerous command over
+/// preserving heredoc text. To also see inside `sh -c '…'` wrappers, use
+/// [`command_segments`].
+pub fn split_segments(command: &str) -> Vec<String> {
+    let mut segments = Vec::new();
+    let mut current = String::new();
+    let mut quote: Option<char> = None;
+    let mut chars = command.chars().peekable();
+
+    while let Some(c) = chars.next() {
+        if let Some(q) = quote {
+            current.push(c);
+            if c == q {
+                quote = None;
+            }
+            continue;
+        }
+        match c {
+            '\'' | '"' => {
+                quote = Some(c);
+                current.push(c);
+            }
+            '&' => {
+                // `&&` and `&` are both separators; consume the second `&`.
+                if chars.peek() == Some(&'&') {
+                    chars.next();
+                }
+                flush_segment(&mut segments, &mut current);
+            }
+            '|' => {
+                // `||` and `|` are both separators; consume the second `|`.
+                if chars.peek() == Some(&'|') {
+                    chars.next();
+                }
+                flush_segment(&mut segments, &mut current);
+            }
+            ';' | '\n' => flush_segment(&mut segments, &mut current),
+            _ => current.push(c),
+        }
+    }
+    flush_segment(&mut segments, &mut current);
+    segments
+}
+
+/// Like [`split_segments`], but also expands shell wrappers: any segment whose
+/// command word is `sh`/`bash`/`zsh`/`dash` invoked with `-c <script>` also
+/// contributes `<script>`'s own segments, recursively (bounded depth). The
+/// wrapper segment itself is still included, so a guard sees both the literal
+/// `sh -c '…'` invocation and the command(s) it will run.
+///
+/// This is the "every command that will actually execute" view: it surfaces a
+/// dangerous command hidden inside `sh -c 'git push --force origin main'` that
+/// plain segment splitting would leave buried in a quoted argument.
+pub fn command_segments(command: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    expand_segments(command, 0, &mut out);
+    out
+}
+
+/// Recursive worker for [`command_segments`].
+fn expand_segments(command: &str, depth: usize, out: &mut Vec<String>) {
+    for segment in split_segments(command) {
+        match shell_c_argument(&segment) {
+            Some(inner) if depth < MAX_WRAPPER_DEPTH => {
+                out.push(segment);
+                expand_segments(&inner, depth + 1, out);
+            }
+            _ => out.push(segment),
+        }
+    }
+}
+
+/// If `segment` is a `sh`/`bash`/`zsh`/`dash` invocation carrying a `-c
+/// <script>` argument, return the script. The command word may be a bare name
+/// or a path (`/bin/sh`). The `-c` may stand alone or appear in a short cluster
+/// such as `-lc` (login shell + command); the script is the token following the
+/// flag that carries `c`.
+fn shell_c_argument(segment: &str) -> Option<String> {
+    let tokens = tokenize(segment);
+    let first = tokens.first()?;
+    let cmd = first.rsplit('/').next().unwrap_or(first);
+    if !matches!(cmd, "sh" | "bash" | "zsh" | "dash") {
+        return None;
+    }
+    for (i, tok) in tokens.iter().enumerate().skip(1) {
+        let carries_c =
+            tok == "-c" || (tok.starts_with('-') && !tok.starts_with("--") && tok.contains('c'));
+        if carries_c {
+            return tokens.get(i + 1).cloned();
+        }
+        // First non-flag token without a `-c` means this isn't the `-c` form
+        // (e.g. `sh script.sh`) — no inline script to expand.
+        if !tok.starts_with('-') {
+            return None;
+        }
+    }
+    None
+}
+
 /// Regex pattern for detecting shell loops (`for ... in` / `while ... do`).
 pub static LOOP_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"\bfor\s+\w+\s+in\b|\bwhile\b.*;\s*do\b").expect("pattern should compile")
@@ -296,6 +420,125 @@ mod tests {
             tokenize(r#"echo "unclosed rest of line"#),
             vec!["echo", "unclosed rest of line"]
         );
+    }
+
+    // --- split_segments ---
+
+    #[test]
+    fn split_segments_single_command() {
+        assert_eq!(split_segments("git status"), vec!["git status"]);
+    }
+
+    #[test]
+    fn split_segments_and_operator() {
+        assert_eq!(
+            split_segments("git status && git push --force origin main"),
+            vec!["git status", "git push --force origin main"]
+        );
+    }
+
+    #[test]
+    fn split_segments_each_operator() {
+        assert_eq!(split_segments("a && b"), vec!["a", "b"]);
+        assert_eq!(split_segments("a || b"), vec!["a", "b"]);
+        assert_eq!(split_segments("a ; b"), vec!["a", "b"]);
+        assert_eq!(split_segments("a | b"), vec!["a", "b"]);
+        assert_eq!(split_segments("a & b"), vec!["a", "b"]);
+        assert_eq!(split_segments("a\nb"), vec!["a", "b"]);
+    }
+
+    #[test]
+    fn split_segments_double_operators_not_split_into_singles() {
+        // `&&`/`||` must not leave an empty segment between the two chars.
+        assert_eq!(split_segments("x&&y"), vec!["x", "y"]);
+        assert_eq!(split_segments("x||y"), vec!["x", "y"]);
+    }
+
+    #[test]
+    fn split_segments_operators_inside_double_quotes_preserved() {
+        assert_eq!(split_segments(r#"echo "a && b""#), vec![r#"echo "a && b""#]);
+    }
+
+    #[test]
+    fn split_segments_operators_inside_single_quotes_preserved() {
+        assert_eq!(
+            split_segments("git commit -m 'fix: a; b | c'"),
+            vec!["git commit -m 'fix: a; b | c'"]
+        );
+    }
+
+    #[test]
+    fn split_segments_empty_segments_dropped() {
+        assert_eq!(split_segments(";; a ;;"), vec!["a"]);
+        assert_eq!(split_segments(""), Vec::<String>::new());
+        assert_eq!(split_segments("   "), Vec::<String>::new());
+    }
+
+    #[test]
+    fn split_segments_trims_whitespace() {
+        assert_eq!(
+            split_segments("  git status  &&  ls  "),
+            vec!["git status", "ls"]
+        );
+    }
+
+    // --- command_segments (wrapper expansion) ---
+
+    #[test]
+    fn command_segments_plain_chain_matches_split() {
+        assert_eq!(
+            command_segments("git status && git push --force origin main"),
+            vec!["git status", "git push --force origin main"]
+        );
+    }
+
+    #[test]
+    fn command_segments_expands_sh_c() {
+        assert_eq!(
+            command_segments("sh -c 'git push --force origin main'"),
+            vec![
+                "sh -c 'git push --force origin main'",
+                "git push --force origin main"
+            ]
+        );
+    }
+
+    #[test]
+    fn command_segments_expands_bash_c_double_quoted_with_operators() {
+        assert_eq!(
+            command_segments(r#"bash -c "a && b""#),
+            vec![r#"bash -c "a && b""#, "a", "b"]
+        );
+    }
+
+    #[test]
+    fn command_segments_expands_path_shell_and_login_cluster() {
+        assert_eq!(
+            command_segments("/bin/bash -lc 'rm -rf .env'"),
+            vec!["/bin/bash -lc 'rm -rf .env'", "rm -rf .env"]
+        );
+    }
+
+    #[test]
+    fn command_segments_nested_wrappers_bounded() {
+        // Two levels of sh -c nest cleanly; depth bound prevents runaway.
+        let out = command_segments(r#"sh -c "sh -c 'echo deep'""#);
+        assert!(out.contains(&"echo deep".to_string()));
+    }
+
+    #[test]
+    fn command_segments_non_wrapper_not_expanded() {
+        // `echo` is not a shell wrapper — its quoted argument stays glued.
+        assert_eq!(
+            command_segments(r#"echo "git push --force origin main""#),
+            vec![r#"echo "git push --force origin main""#]
+        );
+    }
+
+    #[test]
+    fn command_segments_sh_with_script_file_not_expanded() {
+        // `sh script.sh` has no inline `-c` script to surface.
+        assert_eq!(command_segments("sh deploy.sh"), vec!["sh deploy.sh"]);
     }
 
     #[test]

--- a/docs/plans/2026-06-10-wave1-compound-command-guards.md
+++ b/docs/plans/2026-06-10-wave1-compound-command-guards.md
@@ -1,0 +1,156 @@
+# Wave 1: Compound-Command Guard Hardening (cadence-hooks)
+
+## Context
+
+The bug-hunt sweep (issues #61–#106) found that the most dangerous P0s share one
+root cause: **guards re-derive shell command structure ad-hoc and get it wrong.**
+Three trust-bearing guards inspect a Bash command as if it were a single command,
+so a benign first segment lets a destructive second segment slip:
+
+- **#61** `git status && git push --force origin main` — git-safety only inspects the *first* `git`.
+- **#67** `gh pr comment -R me/owned 1 && gh repo delete evil/unowned --yes` — guard-gh-write resolves the *first* `-R` for the whole chain.
+- **#75** `echo ok > safe.txt && echo SECRET > .env` — prevent-secret-writes inspects only the *first* redirect.
+
+git-safety additionally mis-parses single commands three ways (**#63**): it keeps
+quote characters (`"--force"` ≠ `--force`), matches only the exact token `git`
+(so `/usr/bin/git` evades), and can't see into `sh -c '…'`. And its alias check
+(**#62**) exempts the *entire* command line, so `git config alias.x … && git push --force origin main`
+is waved through.
+
+`core::shell` already provides quote-aware `tokenize` and a cd-chain-aware
+`parse_work_dir`, but **no reusable command-segment splitter** — each guard
+re-invents it. This wave builds that missing primitive once and routes the three
+guards through it. P0 anchor: *silent failure to guard*. Outcome: the chain-blind
+bypasses close, and no legitimate chained command starts getting falsely blocked.
+
+**Closes this wave:** #61, #62, #63 (git-safety) · #67 (gh-write) · #75 (secret-writes) — 4 P0 + 1 P1.
+
+## Keystone: command-segment splitting in `core::shell`
+
+Add two pure, exhaustively-tested functions to `crates/core/src/shell.rs`
+(sibling to `tokenize`/`parse_work_dir`):
+
+```rust
+/// Split a command on top-level control operators (&& || ; | & newline),
+/// honoring quotes — operators inside '…' or "…" do NOT split. Segments
+/// are trimmed; empties dropped. Multi-char operators (&&, ||) are matched
+/// before their single-char prefixes (&, |).
+pub fn split_segments(command: &str) -> Vec<String>
+
+/// split_segments, then recursively expand shell wrappers: a segment whose
+/// command word is sh/bash/zsh/dash with `-c <arg>` also yields <arg> parsed
+/// as its own segments. Bounded recursion depth (3). This is the
+/// "every command that will actually execute" view guards should consume.
+pub fn command_segments(command: &str) -> Vec<String>
+```
+
+**Why `tokenize` (not `strip_quotes`) is the correct primitive — the crux:**
+`tokenize` keeps a quoted *span* as one token. `git push "--force"` →
+`["git","push","--force"]` (quoted flag → clean token → caught), but
+`echo "git push --force origin main"` → `["echo","git push --force origin main"]`
+(whole quoted string stays glued → never equals `"git"` → not a git command).
+Span-preservation distinguishes a quoted *flag* from a command quoted *as an
+argument*. Lock both into tests.
+
+**Test matrix (core):** quote-protected operators (`git commit -m "fix: a; b"`,
+`echo "x && y"` → 1 segment); each operator splits (`&&`,`||`,`;`,`|`,`&`,`\n`);
+`||`/`&&` not mis-split into `|`/`&`; `sh -c 'git push --force origin main'` →
+inner segment surfaced; nested `sh -c 'a && b'` → two inner segments; depth bound
+honored; empty/whitespace input → `[]`. Known edge to note in a doc comment:
+heredoc bodies split on newlines (accepted — favors catching the bypass).
+
+## PR 1 — git-safety adopts `command_segments` (#61, #62, #63)
+
+`crates/cadence/src/git_safety.rs`. Restructure `GitSafetyGuard::run`:
+
+- Iterate `command_segments(command)`; judge each segment independently. **Block
+  precedence:** any segment blocks → block; else any warns → nudge; else allow.
+  The block/nudge message still quotes the original full `command`.
+- Run `is_alias_definition` **per segment** (closes #62 — exempts only the config
+  segment, not its siblings).
+- In `normalize_git_command`, tokenize with `core::shell::tokenize` instead of
+  `split_whitespace` (strips quotes → closes #63 quoted-flag). Keep the existing
+  global-flag stripping.
+- Match the git command word as `t == "git" || t.ends_with("/git")` in
+  `check_blocked`/`check_warned` (closes #63 path/escaped git). `sh -c '…'` is
+  handled upstream by `command_segments`.
+- All ~80 existing tests are single-segment and must stay green.
+
+**New tests:** `git status && git push --force origin main` → Block;
+`/usr/bin/git push --force origin main` → Block; `git push "--force" origin main`
+→ Block; `sh -c 'git push --force origin main'` → Block;
+`git config alias.fp '…' && git push --force origin main` → Block (#62).
+**False-block guards:** `echo "git push --force origin main"` → Allow;
+`echo 'use git push --force carefully' && ls` → Allow;
+`git commit -m "wip; reset --hard test"` → Allow.
+
+## PR 2 — guard-gh-write per-segment target resolution (#67)
+
+`crates/guardrails/src/guard_gh_write.rs`. The AST loop paths
+(`AllTargetsExplicit`/`MissingTargets`/`ParseFailed`) already handle multi-command
+loops — the gap is the **`NoLoops` + write-detection tail** (lines 496–602), which
+treats the whole string as one command.
+
+- After `LoopAnalysis::NoLoops`, iterate `command_segments(command)`. For each
+  segment that `is_write_command`, resolve its target **from that segment's text**
+  (`extract_repo_flag_str`/`REPO_SUBCOMMAND`/`API_REPOS` run on the segment, not
+  the whole command) with the per-segment work_dir (`parse_work_dir` over the
+  command prefix up to that segment). Block on the first disallowed / unresolvable
+  write segment; allow only if every write segment passes.
+- Preserve the structured `BlockMetadata` payloads and the unconfigured fail-safe.
+- Confirm `analyze_gh_loops` returns `NoLoops` for a plain `&&` chain (add a guard
+  test) so the new path actually engages.
+
+**New tests:** `gh pr comment -R me/owned 1 && gh repo delete evil/unowned --yes`
+→ Block; two owned segments → Allow; single command unchanged across the existing
+suite. **False-block guard:** `gh pr list && gh issue view 1 -R me/owned` (reads)
+→ Allow.
+
+## PR 3 — prevent-secret-writes per-segment redirects (#75)
+
+`crates/cadence/src/prevent_secret_writes.rs`. `redirect_target` (line 11) finds
+only the *first* `>`/`>>` in the whole string.
+
+- `bash_targets_env_file` iterates `command_segments(command)`; per segment, scan
+  **all** redirect operators (`>`, `>>`, `>|`, `N>`, `N>>` incl. `2>`) for targets,
+  plus `rm_targets`, quote-aware via `tokenize`. Block if any target is a dangerous
+  `.env`.
+- Scope strictly to #75 (chained/stderr/`>|`/quoted redirects). #76 (tee/cp/mv/dd),
+  #86 (quote-aware false-blocks) stay for wave 2 — the existing `bash_tee_env_not_detected`
+  / `bash_cp_env_not_detected` "known gap" tests remain asserting Allow.
+
+**New tests:** `echo ok > safe.txt && echo SECRET > .env` → Block;
+`echo SECRET 2> .env` → Block; `echo SECRET >| .env` → Block;
+`cmd > a.txt; echo S > .env` → Block. **False-block guard:**
+`echo "redirect > .env in a string" > note.txt` → Allow.
+
+## Release
+
+Hold the version across all three PRs (merge-train discipline, repo CLAUDE.md):
+resolve any `Cargo.toml`/`Cargo.lock` version conflict to main's current value so
+merges don't auto-tag. After PR 3 lands, `make bump VERSION=0.27.0` once →
+`cargo check` → commit → push → `auto-tag.yml` cuts the single release. Add CHANGELOG
+bullets under `[0.27.0]` attributing the five issues.
+
+## Verification
+
+Per PR, before commit:
+- `export PATH="$HOME/.cargo/bin:$PATH" && make ci` (fmt-check + clippy `-D warnings`
+  + all tests) green. Treat first GitHub CI run as the real clippy verdict (local
+  toolchain may trail).
+- `cargo test -p cadence-hooks-core shell::` for the keystone; per-guard module
+  tests for adoption.
+- Manual repro against the built binary: `cadence-hooks try cadence git-safety`
+  and hand-built payloads — confirm `git status && git push --force origin main`
+  now exits 2 (was 0). Same for the #67/#75 chain repros.
+- Re-run the original bypass commands from issues #61/#67/#75 against
+  `./target/debug/cadence-hooks` to prove each now blocks.
+
+After the release: PR `Closes` trailers auto-close #61, #62, #63, #67, #75 on
+`cameronsjo/claude-configurations`.
+
+## Out of scope (wave 2 candidates, same primitive)
+
+#71/#72/#73 git-safety precision · #65/#66 secret-leaks operand/verb-list ·
+#76/#86 secret-writes writers/quote-FP · #78/#81/#88 gh/op/dangerous coverage.
+All build on `command_segments` — cheaper once it exists.


### PR DESCRIPTION
## What

Wave 1 of the bug-hunt fixes (#61–#106). Introduces the shared command-segment
splitter the chain-blind guards were missing, and routes git-safety through it.

## The root cause

git-safety inspected a Bash command as a single command, so a benign first
segment shielded a destructive second:

```
git status && git push --force origin main   # slipped — exit 0
```

It also mis-parsed single commands three ways (#63 — path-form git, quoted flags,
`sh -c '…'` wrappers) and exempted the whole command line on any alias
definition (#62).

## The fix

New in `core::shell`:

- `split_segments` — quote-aware split on `&&` / `||` / `;` / `|` / `&` / newline
- `command_segments` — that, plus recursive `sh -c '…'` wrapper expansion

git-safety now judges every segment independently (block precedence), tokenizes
quote-aware (so `"--force"` is read, but `echo "git push --force"` stays inert —
the quoted span never equals the git command word), matches path-form git, and
runs the alias exemption per segment.

## Verification

- `make ci`: fmt + clippy clean; git-safety suite **109 passed**, `core::shell`
  **81 passed** (22 new). The lone local audit failure is the documented
  sibling-wiring lag (`all_binary_subcommands_are_registered`), which GitHub CI
  skips; `registry_matches_clap_dispatch` passes.
- Live binary: the six bypass variants now exit 2; the false-block guards
  (`echo "git push --force …"`, a `reset --hard` inside a commit message) stay
  exit 0. The pre-fix 0.26.0 binary exits 0 on the headline case.

This is the keystone for wave 1 — PR2 (guard-gh-write #67) and PR3
(prevent-secret-writes #75) reuse `command_segments`. Version held; one 0.27.0
release after PR3.

Closes cameronsjo/claude-configurations#61
Closes cameronsjo/claude-configurations#62
Closes cameronsjo/claude-configurations#63

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Git-safety guard now evaluates every command in a chain and properly handles quoted content to prevent bypasses.
  * Improved detection of git binary invocations including path-based variants.
  * Enhanced flag parsing and alias exemption handling applied per command segment rather than to the entire command line.

* **New Features**
  * Added quote-aware shell command segmentation utility for improved command analysis.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->