### PR TITLE
fix(prevent-secret-writes): inspect every redirect in a chain, not just the first

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   resolved the whole chain. Each write segment resolves its own target (and a
   write hidden in `sh -c '…'` is seen); the first unowned/unresolvable write
   blocks. Loop handling and structured block payloads are unchanged.
+- **prevent-secret-writes: every redirect in a chain is inspected** (#75). The
+  guard scanned only the first `>`/`>>`, so `echo ok > safe.txt && echo SECRET >
+  .env` slipped. It now scans each command segment for all redirect operators —
+  `>`, `>>`, `>|`, and stderr/fd forms (`2>`) — quote-aware (a `>` inside a
+  string is literal), plus `rm` targets, and sees writes hidden in `sh -c '…'`.
+  `split_segments` also no longer mis-splits the `>|` clobber operator as a pipe.
 
 ## [0.25.0] - 2026-06-08
 

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -5,20 +5,74 @@
 //! Safe templates (.env.example, .env.test) are always allowed.
 
 use crate::secret_patterns::{SAFE_SUFFIXES, is_ambiguous, is_blocked, is_safe_template};
+use cadence_hooks_core::shell::command_segments;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
-/// Extract the redirect target from a command (the token after > or >>).
-fn redirect_target(command: &str) -> Option<&str> {
-    // Find > or >> and grab the next whitespace-delimited token
-    let lower = command;
-    let rest = if let Some(pos) = lower.find(">>") {
-        &lower[pos + 2..]
-    } else if let Some(pos) = lower.find('>') {
-        &lower[pos + 1..]
-    } else {
-        return None;
-    };
-    rest.split_whitespace().next()
+/// Extract every redirect target in a command segment — the filename after each
+/// `>`, `>>`, `>|`, `2>`, `&>`, etc. Quote-aware: a `>` inside `'…'`/`"…"` is
+/// literal text, not a redirect (so `echo "a > b" > c` targets only `c`). This
+/// catches stderr, clobber, glued (`>file`), and multiple redirects in one
+/// segment — the old single-`>` scan saw only the first.
+fn redirect_targets(segment: &str) -> Vec<String> {
+    let chars: Vec<char> = segment.chars().collect();
+    let mut targets = Vec::new();
+    let mut i = 0;
+    let mut quote: Option<char> = None;
+
+    while i < chars.len() {
+        let c = chars[i];
+        if let Some(q) = quote {
+            if c == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            '\'' | '"' => {
+                quote = Some(c);
+                i += 1;
+            }
+            '>' => {
+                i += 1;
+                // Consume a doubled `>>` (append) or `>|` (clobber).
+                if i < chars.len() && (chars[i] == '>' || chars[i] == '|') {
+                    i += 1;
+                }
+                // Skip whitespace between the operator and the filename.
+                while i < chars.len() && chars[i].is_whitespace() {
+                    i += 1;
+                }
+                // Collect the target token, honoring a quoted filename.
+                let mut target = String::new();
+                while i < chars.len() {
+                    let tc = chars[i];
+                    if tc == '\'' || tc == '"' {
+                        i += 1;
+                        while i < chars.len() && chars[i] != tc {
+                            target.push(chars[i]);
+                            i += 1;
+                        }
+                        if i < chars.len() {
+                            i += 1; // closing quote
+                        }
+                        continue;
+                    }
+                    if tc.is_whitespace() || matches!(tc, '>' | '<' | '|' | ';' | '&') {
+                        break;
+                    }
+                    target.push(tc);
+                    i += 1;
+                }
+                if !target.is_empty() {
+                    targets.push(target);
+                }
+            }
+            _ => i += 1,
+        }
+    }
+
+    targets
 }
 
 /// Extract rm targets from a command (tokens after rm that aren't flags).
@@ -51,23 +105,24 @@ fn is_dangerous_env_target(target: &str) -> bool {
 
 /// Check if a bash command targets .env files destructively.
 fn bash_targets_env_file(command: &str) -> bool {
-    let lower = command.to_lowercase();
-
-    if !lower.contains(".env") {
+    // Quick reject: nothing to guard if no `.env` token appears anywhere.
+    if !command.to_lowercase().contains(".env") {
         return false;
     }
 
-    // Check redirect target specifically
-    if let Some(target) = redirect_target(&lower)
-        && is_dangerous_env_target(target)
-    {
-        return true;
-    }
-
-    // Check rm targets specifically
-    for target in rm_targets(&lower) {
-        if is_dangerous_env_target(target) {
-            return true;
+    // Judge each command segment independently so a benign first redirect can't
+    // shield a dangerous one later in the chain, and a write hidden in
+    // `sh -c '…'` is still seen. `is_dangerous_env_target` lowercases per token.
+    for segment in command_segments(command) {
+        for target in redirect_targets(&segment) {
+            if is_dangerous_env_target(&target) {
+                return true;
+            }
+        }
+        for target in rm_targets(&segment) {
+            if is_dangerous_env_target(target) {
+                return true;
+            }
         }
     }
 
@@ -560,5 +615,57 @@ mod tests {
     fn bash_rm_env_example_allowed() {
         // rm target is a safe template
         assert!(!bash_targets_env_file("rm .env.example"));
+    }
+
+    // --- #75: per-segment, all-operator redirect scanning ---
+
+    #[test]
+    fn chained_benign_then_secret_redirect_blocked() {
+        // The bypass: only the first redirect (safe.txt) was inspected.
+        assert!(bash_targets_env_file(
+            "echo ok > safe.txt && echo SECRET > .env"
+        ));
+    }
+
+    #[test]
+    fn stderr_redirect_to_env_blocked() {
+        assert!(bash_targets_env_file("echo SECRET 2> .env"));
+    }
+
+    #[test]
+    fn clobber_redirect_to_env_blocked() {
+        assert!(bash_targets_env_file("echo SECRET >| .env"));
+    }
+
+    #[test]
+    fn semicolon_chained_secret_redirect_blocked() {
+        assert!(bash_targets_env_file("cmd > a.txt; echo S > .env"));
+    }
+
+    #[test]
+    fn sh_c_wrapped_secret_redirect_blocked() {
+        assert!(bash_targets_env_file("sh -c 'echo SECRET > .env'"));
+    }
+
+    #[test]
+    fn quoted_redirect_text_not_flagged() {
+        // The `> .env` inside the quoted string is literal text; only the real
+        // `> note.txt` redirect counts — must not block.
+        assert!(!bash_targets_env_file(
+            r#"echo "redirect > .env in a string" > note.txt"#
+        ));
+    }
+
+    #[test]
+    fn dup_fd_redirect_not_flagged() {
+        // `2>&1` duplicates a descriptor — no `.env` file target.
+        assert!(!bash_targets_env_file("echo SECRET > out.txt 2>&1"));
+    }
+
+    #[test]
+    fn chained_secret_redirect_blocks_via_run() {
+        let result =
+            SecretWritesGuard.run(&make_bash_input("echo ok > safe.txt && echo SECRET > .env"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 }

--- a/crates/core/src/shell.rs
+++ b/crates/core/src/shell.rs
@@ -266,11 +266,17 @@ pub fn split_segments(command: &str) -> Vec<String> {
                 flush_segment(&mut segments, &mut current);
             }
             '|' => {
-                // `||` and `|` are both separators; consume the second `|`.
-                if chars.peek() == Some(&'|') {
-                    chars.next();
+                // `>|` is the force-clobber redirect operator, not a pipe —
+                // keep it joined to its segment so the target stays attached.
+                if current.trim_end().ends_with('>') {
+                    current.push('|');
+                } else {
+                    // `||` and `|` are both separators; consume the second `|`.
+                    if chars.peek() == Some(&'|') {
+                        chars.next();
+                    }
+                    flush_segment(&mut segments, &mut current);
                 }
-                flush_segment(&mut segments, &mut current);
             }
             ';' | '\n' => flush_segment(&mut segments, &mut current),
             _ => current.push(c),
@@ -480,6 +486,21 @@ mod tests {
             split_segments("  git status  &&  ls  "),
             vec!["git status", "ls"]
         );
+    }
+
+    #[test]
+    fn split_segments_clobber_redirect_not_split_as_pipe() {
+        // `>|` is the force-clobber redirect, not a pipe — must stay one segment.
+        assert_eq!(
+            split_segments("echo secret >| .env"),
+            vec!["echo secret >| .env"]
+        );
+        assert_eq!(
+            split_segments("echo secret >|.env"),
+            vec!["echo secret >|.env"]
+        );
+        // A real pipe still splits.
+        assert_eq!(split_segments("echo x | grep y"), vec!["echo x", "grep y"]);
     }
 
     // --- command_segments (wrapper expansion) ---


### PR DESCRIPTION
## What

Wave 1, PR3 (final adoption) of the bug-hunt fixes. Routes `prevent-secret-writes`
through the `command_segments` primitive from #83.

## The root cause

`redirect_target` scanned for only the **first** `>`/`>>` in the whole command,
so a benign first redirect shielded a dangerous one:

```
echo ok > safe.txt && echo SECRET > .env   # slipped — exit 0
```

`safe.txt` was the only target checked; the secret write to `.env` was never seen.

## The fix

`bash_targets_env_file` now iterates `command_segments(command)` and, per segment,
scans **every** redirect via a quote-aware char scan (`redirect_targets`):

- stdout `>`, append `>>`, clobber `>|`, and fd forms like stderr `2>`
- glued forms with no space (`>.env`)
- a redirect operator **inside quotes is literal text**, so
  `echo "a > .env" > note.txt` targets only `note.txt` (no false block)
- writes hidden in `sh -c '…'` are surfaced

It also fixes `split_segments` mis-splitting the `>|` force-clobber operator as a
pipe (it contains `|`), which would otherwise sever the redirect from its target.

`#76` (tee/cp/mv/dd writers) and `#86` (quote-aware false-block hardening) are
out of scope for this wave — their known-gap tests still assert Allow.

## Verification

- `make ci`: fmt + clippy clean; `prevent_secret_writes` **70 passed** (8 new),
  `core::shell` **82 passed** (1 new for the `>|` fix). The two local audit
  failures are the documented sibling-checkout family (`cadence-canon` wires a
  `guardrails` subcommand; the not-yet-merged subcommand registration) — GitHub
  CI has no siblings and skips them; `registry_matches_clap_dispatch` passes.
- Live binary: the chained bypass now exits 2 (pre-fix 0.26.0 exits 0); stderr,
  clobber, and `sh -c`-wrapped redirects to `.env` exit 2; a quoted `>` in a
  string, a `.env.example` template, and `2>&1` all stay exit 0.

Closes cameronsjo/claude-configurations#75

🤖 Generated with [Claude Code](https://claude.com/claude-code)
