### PR TITLE
fix(guard-op-vault-scan): tokenized detection robust to op global flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   longer hide it. `git checkout .` and worktree-touching `git restore .` (any
   discard-all pathspec: `.`, `./`, `:/`) block; staged-only restore stays
   allowed; restore of named paths nudges.
+- **guard-op-vault-scan: tokenized adjacent-pair detection robust to global
+  flags** (#81 on claude-configurations). Detection no longer enumerates command
+  shapes with a regex — each shell segment is tokenized, and a scan is any `op`
+  invocation (basename of the command word) with an `item`/`vault` token
+  immediately followed by `list` after the command word. 1Password global flags
+  between `op` and the subcommand (`op --format json item list`,
+  `op --account x item list`, `op --cache item list`, `op --session abc item
+  list`) no longer evade the guard, and quoted-prose protection plus shell-wrapper
+  expansion (`bash -c '…'`) are now structural via `command_segments`.
 
 ## [0.27.0] - 2026-06-10
 

--- a/crates/guardrails/src/guard_op_vault_scan.rs
+++ b/crates/guardrails/src/guard_op_vault_scan.rs
@@ -5,21 +5,22 @@
 //! any session it reads far more secret metadata than a task needs. Single-item
 //! reads (`op read op://...`, `op item get <name>`) stay allowed — the guard
 //! targets enumeration, not access.
+//!
+//! Detection is tokenized, not regex-based. A flag-run regex cannot tell that
+//! `--format json` is a flag plus its value without enumerating every
+//! value-taking flag, so any global flag between `op` and the subcommand
+//! (`op --format json item list`, `op --account x item list`, `op --cache item
+//! list`, `op --session abc item list`) would evade it — the exact brittleness
+//! this guard fixes. Instead, each shell segment is tokenized: if the segment's
+//! command word is `op` and an `item`/`vault` token is immediately followed by
+//! `list` anywhere after the command word, it's a scan. Intervening flags are
+//! just skipped tokens, value-flag or not.
 
-use cadence_hooks_core::shell::strip_quotes;
+use cadence_hooks_core::shell::{command_segments, tokenize};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
-use regex::Regex;
-use std::sync::LazyLock;
 
-/// Matches `op item list` / `op vault list` enumeration commands.
-static OP_VAULT_SCAN: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\bop\s+(item|vault)\s+list\b").expect("pattern should compile"));
-
-/// Matches shell exec wrappers that can hide a scan inside quotes.
-static EXEC_WRAPPER: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"\b(bash|sh|zsh)\s+-c\b").expect("pattern should compile"));
-
-/// Blocks `op item list` vault enumeration; single-item reads are allowed.
+/// Blocks `op item list` / `op vault list` vault enumeration; single-item reads
+/// are allowed.
 pub struct OpVaultScanGuard;
 
 fn block_message(found: &str) -> String {
@@ -30,6 +31,39 @@ fn block_message(found: &str) -> String {
          vault scans read every item's metadata and trip the auto-mode classifier.\n   \
          Allowed: single-item reads like `op read op://vault/item/field` or `op item get <name>`"
     )
+}
+
+/// If `segment` is an `op` invocation that enumerates the vault, return the
+/// matched keyword (`item` or `vault`) for the block message.
+///
+/// A scan is: the command word's basename is `op`, and some adjacent pair after
+/// the command word is `item`/`vault` immediately followed by `list`. Tokenizing
+/// (not regex) is what makes this robust to global flags — every token between
+/// `op` and the subcommand is simply skipped, no value-flag enumeration needed.
+/// Quoted prose can't fire: an `echo "... op item list"` segment's command word
+/// is `echo`, and the quoted run is a single token.
+///
+/// Documented edges:
+/// - `$OP_CMD item list` stays unseen — token 0 is `$OP_CMD`, not `op` (the
+///   existing gap test; the auto-mode classifier is the backstop).
+/// - `op run -- ./tool item list` would match (no real-world shape — accepted).
+fn vault_scan_keyword(segment: &str) -> Option<&'static str> {
+    let tokens = tokenize(segment);
+    let first = tokens.first()?;
+    let cmd = first.rsplit('/').next().unwrap_or(first);
+    if cmd != "op" {
+        return None;
+    }
+    // Adjacent pairs strictly after the command word (token 0).
+    tokens
+        .windows(2)
+        .skip(1)
+        .find_map(|pair| match pair[0].as_str() {
+            "item" | "vault" if pair[1] == "list" => {
+                Some(if pair[0] == "item" { "item" } else { "vault" })
+            }
+            _ => None,
+        })
 }
 
 impl Check for OpVaultScanGuard {
@@ -46,19 +80,12 @@ impl Check for OpVaultScanGuard {
             return CheckResult::allow();
         }
 
-        // Strip quoted strings so prose mentioning the command doesn't fire.
-        let stripped = strip_quotes(command);
-
-        // Pass 1: direct invocation (after stripping quotes)
-        if let Some(m) = OP_VAULT_SCAN.find(&stripped) {
-            return CheckResult::block(block_message(m.as_str().trim()));
-        }
-
-        // Pass 2: inside exec wrappers (bash -c 'op item list')
-        if EXEC_WRAPPER.is_match(&stripped)
-            && let Some(m) = OP_VAULT_SCAN.find(command)
-        {
-            return CheckResult::block(block_message(m.as_str().trim()));
+        // `command_segments` splits chains/pipes AND expands shell wrappers
+        // (`bash -c '…'`), so the wrapper case is structural — no separate pass.
+        for segment in command_segments(command) {
+            if let Some(kw) = vault_scan_keyword(&segment) {
+                return CheckResult::block(block_message(&format!("op {kw} list")));
+            }
         }
 
         CheckResult::allow()
@@ -151,6 +178,46 @@ mod tests {
         assert_eq!(result.outcome, Outcome::Block);
     }
 
+    // --- #81: global flags between `op` and the subcommand ---
+
+    #[test]
+    fn op_global_flag_format_json_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op --format json item list | grep token"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_global_flag_format_equals_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op --format=json item list | grep api"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_global_flag_account_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op --account my.1password.com item list"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_global_flag_cache_blocked() {
+        let result = OpVaultScanGuard.run(&make_bash("op --cache item list"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_global_flag_session_blocked() {
+        let result =
+            OpVaultScanGuard.run(&make_bash("op --session abc item list | awk '{print $1}'"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
+    #[test]
+    fn op_absolute_path_blocked() {
+        // The command word may be a path; its basename is what's matched.
+        let result = OpVaultScanGuard.run(&make_bash("/usr/local/bin/op item list"));
+        assert_eq!(result.outcome, Outcome::Block);
+    }
+
     // --- block message quality ---
 
     #[test]
@@ -187,6 +254,15 @@ mod tests {
     fn hyphenated_lookalike_allowed() {
         // "op-item-list" is a different word, not the op CLI
         let result = OpVaultScanGuard.run(&make_bash("op-item-list --help"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn op_item_get_named_list_allowed() {
+        // An item literally named "list": tokens are [op, item, get, list].
+        // The adjacent pairs (item, get) and (get, list) never match
+        // item|vault + list, so this single-item read stays allowed.
+        let result = OpVaultScanGuard.run(&make_bash("op item get list"));
         assert_eq!(result.outcome, Outcome::Allow);
     }
 


### PR DESCRIPTION
## Summary

`guard-op-vault-scan` enumerated 1Password command shapes with two regex passes
(`\bop\s+(item|vault)\s+list\b` plus an exec-wrapper pass). That construction
missed any CLI global flag placed between `op` and the subcommand, because a
regex cannot tell that `--format json` is a flag plus its value without
enumerating every value-taking flag — the exact brittleness being fixed. So
`op --format json item list`, `op --account x item list`, `op --cache item
list`, and `op --session abc item list` all evaded the guard.

This replaces both regex passes with a **tokenized adjacent-pair** scan:

- Split the command with `cadence_hooks_core::shell::command_segments` (this
  also subsumes the old exec-wrapper pass — `bash -c '…'` expansion is
  structural now).
- `tokenize` each segment; a segment is a scan when the basename of token 0 is
  `op` and an `item`/`vault` token is immediately followed by `list` anywhere
  after the command word.
- Intervening flags are simply skipped tokens — no value-flag enumeration.
- Quoted-prose protection is structural (an `echo "… op item list"` segment's
  command word is `echo`, and the quoted run is a single token), so
  `strip_quotes` and both regexes are deleted.

Documented edges preserved: `$OP_CMD item list` stays unseen (token 0 isn't
`op` — existing gap test, auto-mode classifier is the backstop); the contrived
`op run -- ./tool item list` would match (no real-world shape — accepted).

## Verification

### TDD — RED tests (failed on the pre-change regex code, now green)

The five #81 global-flag repros were written first and watched fail
(`left: Allow, right: Block`):

- `op_global_flag_format_json_blocked`
- `op_global_flag_format_equals_blocked`
- `op_global_flag_account_blocked`
- `op_global_flag_cache_blocked`
- `op_global_flag_session_blocked`

The new `op_absolute_path_blocked` (`/usr/local/bin/op item list`) and
`op_item_get_named_list_allowed` (`op item get list`) already passed on the old
code — kept as regression armor for the new logic.

### Test counts

- `cargo test -p cadence-hooks-guardrails guard_op_vault_scan::` → **24 passed,
  0 failed** (was 19; +6 blocks via #81 globals/path, +1 allow for an item
  named `list`, minus assertions folded in).
- Full guardrails crate → **521 passed, 0 failed**.
- `make ci`: fmt-check clean, clippy `-D warnings` clean, all crate tests pass.
  The only failing target is `tests/hook_registration_audit.rs`
  (`all_binary_subcommands_are_registered`, `no_cross_plugin_hooks`) — the known
  sibling-checkout noise that GitHub CI skips (no siblings on CI).

### Live pre/post repro

Each command fed as a JSON payload to the guard binary (never run as a real
`op` command). PRE = current `origin/main` binary, POST = this branch. exit
0 = allow, 2 = block.

| Command | PRE | POST | Expect |
|---|---|---|---|
| `op --format json item list \| grep token` | 0 | 2 | 2 |
| `op --format=json item list \| grep api` | 0 | 2 | 2 |
| `op --account my.1password.com item list` | 0 | 2 | 2 |
| `op --cache item list` | 0 | 2 | 2 |
| `op --session abc item list \| awk '{print $1}'` | 0 | 2 | 2 |
| `op item list` | 2 | 2 | 2 |
| `op item list --vault Private \| grep api` | 2 | 2 | 2 |
| `bash -c 'op item list'` | 2 | 2 | 2 |
| `echo start && op item list \| head -5` | 2 | 2 | 2 |
| `op vault list` | 2 | 2 | 2 |
| `/usr/local/bin/op item list` | 2 | 2 | 2 |
| `op read op://Private/GitHub Token/credential` | 0 | 0 | 0 |
| `op item get "GitHub Token" --fields label=token` | 0 | 0 | 0 |
| `op item get list` | 0 | 0 | 0 |
| `op whoami` | 0 | 0 | 0 |
| `echo 'never run op item list uninvited'` | 0 | 0 | 0 |
| `op-item-list --help` | 0 | 0 | 0 |
| `$OP_CMD item list` | 0 | 0 | 0 |

The five #81 repros flip `0 → 2`; existing coverage and all allows hold.

Closes cameronsjo/claude-configurations#81

🤖 Generated with [Claude Code](https://claude.com/claude-code)
