### PR TITLE
fix(secret-guards): catch find -exec reads and find -delete/-exec writes on .env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `git restore <named path>` — since everything after `--` is unambiguously a
   pathspec; discard-all forms (`.`, `./`, `:/`) keep blocking, and bare
   `git checkout <name>` without `--` stays out of scope.
+- **secret guards: `find -exec`/`-delete` no longer escapes the metadata-safe
+  exemption** (#118 on claude-configurations). `find` is metadata-safe on its
+  own, but `find . -name .env -exec cat {} \;` printed contents and `find .
+  -name .env -delete` / `-exec rm {} \;` destroyed the file — both allowed on
+  0.28.0. prevent-secret-leaks now judges the exec-family subcommand (`-exec`,
+  `-execdir`, `-ok`, `-okdir`): a non-metadata-safe action with a dangerous
+  `.env`-family token among find's args blocks, while `-exec ls …` and a plain
+  `find -name .env` stay allowed. prevent-secret-writes blocks `find` carrying
+  `-delete` or an exec-family writer verb (`rm`, `tee`, `cp`, `truncate`, …)
+  against a dangerous env file; safe templates and non-`.env` targets stay
+  allowed.
 
 ## [0.28.0] - 2026-06-10
 

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -41,6 +41,12 @@ fn segment_env_read(segment: &str) -> Option<(String, String)> {
     let tokens = tokenize(segment);
     let first = tokens.first()?;
     let cmd_word = first.rsplit('/').next().unwrap_or(first);
+    // `find` is metadata-safe on its own (`find . -name .env`), but an
+    // exec-family action runs a real command on each hit — judge that
+    // command instead of exempting the whole `find` (#118).
+    if cmd_word == "find" {
+        return find_exec_leak(&tokens);
+    }
     if METADATA_SAFE_COMMANDS.contains(&cmd_word) {
         return None;
     }
@@ -48,6 +54,28 @@ fn segment_env_read(segment: &str) -> Option<(String, String)> {
         .iter()
         .find(|t| !t.chars().any(char::is_whitespace) && is_dangerous_env_token(t))
         .map(|t| (cmd_word.to_string(), t.clone()))
+}
+
+/// `find`'s exec-family flags (`-exec`, `-execdir`, `-ok`, `-okdir`) run their
+/// following token as a command on each matched file. Return the leak when
+/// that command is NOT metadata-safe and a dangerous `.env`-family token
+/// appears among find's arguments (the `-name`/`-path` pattern or a literal
+/// path). A plain `find` with no exec-family action, or one whose action is
+/// metadata-safe (`-exec ls …`), leaks nothing.
+fn find_exec_leak(tokens: &[String]) -> Option<(String, String)> {
+    const EXEC_FLAGS: &[&str] = &["-exec", "-execdir", "-ok", "-okdir"];
+    let sub = tokens
+        .iter()
+        .position(|t| EXEC_FLAGS.contains(&t.as_str()))
+        .and_then(|i| tokens.get(i + 1))?;
+    let sub_word = sub.rsplit('/').next().unwrap_or(sub);
+    if METADATA_SAFE_COMMANDS.contains(&sub_word) {
+        return None;
+    }
+    tokens
+        .iter()
+        .find(|t| !t.chars().any(char::is_whitespace) && is_dangerous_env_token(t))
+        .map(|t| (sub_word.to_string(), t.clone()))
 }
 
 /// Check if a command token sequence appears as the first executed command
@@ -1227,6 +1255,54 @@ mod tests {
     fn bash_substitution_clean_operand_allowed() {
         let result =
             SecretLeaksGuard.run(&make_bash_input("VERSION=$(cat VERSION.txt) make build"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // ---------------------------------------------------------------
+    // #118: find -exec escapes the metadata-safe exemption
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn bash_find_exec_cat_env_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("find . -name .env -exec cat {} \\;"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_find_execdir_base64_env_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input(
+            "find /app -name .env -execdir base64 {} \\;",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_find_ok_cat_env_blocked() {
+        let result =
+            SecretLeaksGuard.run(&make_bash_input("find . -name .env.local -ok cat {} \\;"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_find_exec_ls_env_allowed() {
+        // A metadata-safe exec subcommand does not leak contents.
+        let result =
+            SecretLeaksGuard.run(&make_bash_input("find . -name .env -exec ls -la {} \\;"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn bash_find_name_env_no_exec_allowed() {
+        // Plain find of .env files is metadata only — still allowed.
+        let result = SecretLeaksGuard.run(&make_bash_input("find . -name .env"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn bash_find_exec_cat_non_env_allowed() {
+        // No dangerous env token among find's args.
+        let result =
+            SecretLeaksGuard.run(&make_bash_input("find . -name '*.log' -exec cat {} \\;"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -170,8 +170,43 @@ fn writer_targets(segment: &str) -> Vec<String> {
             }
             targets
         }
+        // `find … -delete` and `find … -exec <writer> …` destroy or overwrite
+        // each matched file (#118). When such an action is present, every
+        // non-flag arg (the `-name`/`-path` pattern, literal paths) is a
+        // candidate target; the shared classifier filters to the dangerous
+        // `.env`-family ones. A plain `find` or a read action (`-exec cat …`)
+        // yields no target — that read is prevent-secret-leaks' concern.
+        "find" => {
+            if find_writes(args) {
+                args.iter()
+                    .filter(|t| !t.starts_with('-'))
+                    .cloned()
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        }
         _ => Vec::new(),
     }
+}
+
+/// True if a `find` invocation deletes or writes its matched files: a
+/// `-delete` action, or an exec-family flag whose command is a writer verb.
+fn find_writes(args: &[String]) -> bool {
+    const EXEC_FLAGS: &[&str] = &["-exec", "-execdir", "-ok", "-okdir"];
+    const WRITER_VERBS: &[&str] = &[
+        "rm", "tee", "cp", "mv", "install", "dd", "truncate", "shred", "unlink", "ln",
+    ];
+    if args.iter().any(|a| a == "-delete") {
+        return true;
+    }
+    args.iter().enumerate().any(|(i, a)| {
+        EXEC_FLAGS.contains(&a.as_str())
+            && args
+                .get(i + 1)
+                .map(|s| s.rsplit('/').next().unwrap_or(s))
+                .is_some_and(|w| WRITER_VERBS.contains(&w))
+    })
 }
 
 /// Check if a bash command targets .env files destructively.
@@ -870,5 +905,46 @@ mod tests {
             "cat > guide.md <<'EOF'\nnever run: echo x > .env\nEOF",
         ));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // --- #118: find -delete / -exec writer escapes ---
+
+    #[test]
+    fn bash_find_delete_env_blocked() {
+        assert!(bash_targets_env_file("find . -name .env -delete"));
+    }
+
+    #[test]
+    fn bash_find_exec_rm_env_blocked() {
+        assert!(bash_targets_env_file("find . -name .env -exec rm {} \\;"));
+    }
+
+    #[test]
+    fn bash_find_execdir_tee_env_blocked() {
+        assert!(bash_targets_env_file(
+            "find /app -name .env -execdir tee {} \\;"
+        ));
+    }
+
+    #[test]
+    fn bash_find_exec_cat_env_allowed_for_writes() {
+        // A read via find-exec is prevent-secret-leaks' concern, not writes.
+        assert!(!bash_targets_env_file("find . -name .env -exec cat {} \\;"));
+    }
+
+    #[test]
+    fn bash_find_name_env_no_action_allowed() {
+        assert!(!bash_targets_env_file("find . -name .env"));
+    }
+
+    #[test]
+    fn bash_find_delete_non_env_allowed() {
+        assert!(!bash_targets_env_file("find . -name '*.tmp' -delete"));
+    }
+
+    #[test]
+    fn bash_find_delete_env_example_allowed() {
+        // Safe template — deleting it is not a secret write.
+        assert!(!bash_targets_env_file("find . -name .env.example -delete"));
     }
 }


### PR DESCRIPTION
## Summary

Wave 3 — `find` was on prevent-secret-leaks' metadata-safe allowlist (correct for `find . -name .env`), but the blanket exemption hid its execution flags: `find . -name .env -exec cat {} \;` printed contents, and `find . -name .env -delete` / `-exec rm {} \;` destroyed the file, all allowed on 0.28.0 (#118).

- **prevent-secret-leaks**: `find` is now branched to `find_exec_leak`, which inspects the subcommand of any `-exec`/`-execdir`/`-ok`/`-okdir` flag. If that subcommand is not metadata-safe AND a dangerous `.env`-family token appears among find's args, it blocks (attributing the leak to the exec'd command). `find . -name .env -exec ls -la {} \;` and a plain `find . -name .env` stay allowed.
- **prevent-secret-writes**: `writer_targets` gains a `find` arm via `find_writes`, which fires on `-delete` or an exec-family flag running a writer verb (`rm`, `tee`, `cp`, `mv`, `install`, `dd`, `truncate`, `shred`, `unlink`, `ln`). The matched env file is then judged by the shared classifier. A find-exec *read* yields no write target — that is prevent-secret-leaks' concern (cross-guard split). Safe templates (`find -name .env.example -delete`) and non-`.env` targets stay allowed.

## Verification

- TDD: 13 behavioral tests (6 blocks + 7 allow), block-side watched failing on the v0.28.0 base, now green. cadence crate: 597 passed.
- `make ci` green (clippy `-D warnings` on stable 1.96) apart from the two documented sibling-checkout audit failures GitHub CI skips.
- Live pre/post repro (`pre` = installed 0.28.0, `post` = this branch; exit codes):

| Case | pre | post |
|---|---|---|
| `find . -name .env -exec cat {} \;` (leaks) | 0 | 2 |
| `find /app -name .env -execdir base64 {} \;` (leaks) | 0 | 2 |
| `find . -name .env -exec ls -la {} \;` (leaks) | 0 | 0 |
| `find . -name .env` (leaks) | 0 | 0 |
| `find . -name .env -delete` (writes) | 0 | 2 |
| `find . -name .env -exec rm {} \;` (writes) | 0 | 2 |
| `find . -name '*.tmp' -delete` (writes) | 0 | 0 |
| `find . -name .env.example -delete` (writes) | 0 | 0 |

Closes cameronsjo/claude-configurations#118

🤖 Generated with [Claude Code](https://claude.com/claude-code)
