### PR TITLE
fix(secret-guards): block .envrc on the tool side, not just Bash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `git restore <named path>` — since everything after `--` is unambiguously a
   pathspec; discard-all forms (`.`, `./`, `:/`) keep blocking, and bare
   `git checkout <name>` without `--` stays out of scope.
+- **secret guards: `.envrc` blocked on the tool side, not just Bash** (#119 on
+  claude-configurations). `.envrc` was treated as dangerous in Bash (`cat
+  .envrc` blocked) but `BLOCKED_FILENAMES` omitted it, so Read, Grep, Write,
+  and Edit operated on it freely — a tool-side escape hatch. Adding `.envrc` to
+  the shared list closes it across both guards; `.envrc.example` stays allowed
+  (the safe-template check runs first), and `direnv allow .envrc` is untouched.
 
 ## [0.28.0] - 2026-06-10
 

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -538,6 +538,25 @@ mod tests {
     }
 
     #[test]
+    fn read_envrc_blocked() {
+        // #119: tool-side parity with the Bash-side .envrc block.
+        let result = SecretLeaksGuard.run(&make_read_input("/project/.envrc"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn grep_envrc_blocked() {
+        let result = SecretLeaksGuard.run(&make_grep_input("/project/.envrc"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn read_envrc_example_allowed() {
+        let result = SecretLeaksGuard.run(&make_read_input("/project/.envrc.example"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
     fn read_p12_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/etc/ssl/cert.p12"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -361,6 +361,25 @@ mod tests {
     }
 
     #[test]
+    fn write_envrc_blocked() {
+        // #119: tool-side parity — Write/Edit on .envrc were wide open.
+        let result = SecretWritesGuard.run(&make_write_input("/project/.envrc"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn edit_envrc_blocked() {
+        let result = SecretWritesGuard.run(&make_edit_input("/project/.envrc", "old", "new"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn write_envrc_example_allowed() {
+        let result = SecretWritesGuard.run(&make_write_input("/project/.envrc.example"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
     fn private_pem_suffix_blocked() {
         assert!(is_blocked(
             "server.private.pem",

--- a/crates/cadence/src/secret_patterns.rs
+++ b/crates/cadence/src/secret_patterns.rs
@@ -17,6 +17,7 @@ pub const SAFE_SUFFIXES: &[&str] = &[
 /// Files that must never be read or written by Claude Code.
 pub const BLOCKED_FILENAMES: &[&str] = &[
     ".env",
+    ".envrc",
     ".env.local",
     ".env.production",
     ".env.staging",
@@ -185,6 +186,16 @@ mod tests {
     fn case_insensitive() {
         assert!(is_blocked(".ENV", "/project/.ENV"));
         assert!(is_safe_template(".ENV.EXAMPLE"));
+    }
+
+    #[test]
+    fn envrc_blocked_on_tool_side() {
+        // #119: .envrc is dangerous on the Bash side but was wide open to
+        // Read/Grep/Write/Edit — the tool-side block needs the filename listed.
+        assert!(is_blocked(".envrc", "/project/.envrc"));
+        // Safe-template check runs first in the guards, so .envrc.example is
+        // still allowed.
+        assert!(is_safe_template(".envrc.example"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Wave 3 — `.envrc` was treated as dangerous on the Bash side by both secret guards (`cat .envrc` blocks, `echo x > .envrc` blocks), but `secret_patterns::BLOCKED_FILENAMES` omitted it, so the Read, Grep, Write, and Edit tools operated on it freely (#119). A blocked Bash write effectively advertised the tool-side workaround. One-line fix: add `.envrc` to the shared list.

- Both guards' tool paths inherit: Read/Grep block in prevent-secret-leaks; Write/Edit block in prevent-secret-writes.
- `.envrc.example` and friends stay allowed — `is_safe_template` runs before `is_blocked` in both guards.
- `direnv allow .envrc` is untouched (Bash path, `direnv` is metadata-safe).

## Verification

- TDD: 6 behavioral tests (Read/Grep/Write/Edit blocks + a secret_patterns unit + `.envrc.example`/Write-example allows), block-side watched failing on the v0.28.0 base, now green. cadence crate: 591 passed.
- `make ci` green (clippy `-D warnings` on stable 1.96) apart from the two documented sibling-checkout audit failures GitHub CI skips.
- Live pre/post repro (`pre` = installed 0.28.0, `post` = this branch; exit codes):

| Case | pre | post |
|---|---|---|
| Read `.envrc` | 0 | 2 |
| Grep `.envrc` | 0 | 2 |
| Write `.envrc` | 0 | 2 |
| Read `.envrc.example` | — | 0 |
| Bash `direnv allow .envrc` | — | 0 |

Closes cameronsjo/claude-configurations#119

🤖 Generated with [Claude Code](https://claude.com/claude-code)
