### PR TITLE
fix(cadence): block .env.<x> family on tool path (#64)

### DIFF
--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -530,6 +530,21 @@ mod tests {
     }
 
     #[test]
+    fn read_env_prod_blocked() {
+        // #64: .env.prod is not in BLOCKED_FILENAMES — the Bash path blocked
+        // `cat .env.prod` while Read let it through. Now both block.
+        let result = SecretLeaksGuard.run(&make_read_input("/project/.env.prod"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn grep_env_dev_blocked() {
+        // #64: tool-path parity for another family member missing from the list.
+        let result = SecretLeaksGuard.run(&make_grep_input("/project/.env.dev"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
     fn read_secrets_json_blocked() {
         let result = SecretLeaksGuard.run(&make_read_input("/project/secrets.json"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
@@ -769,10 +784,14 @@ mod tests {
 
     #[test]
     fn null_byte_injection_blocked() {
+        // After null-byte removal the path is "/project/.env.txt". Under the
+        // unified #64 predicate that is `.env.<x>` (x = "txt", not a safe
+        // suffix), so it blocks on the tool path exactly as `cat .env.txt`
+        // already blocked on the Bash path — the null byte cannot smuggle an
+        // .env-family file past. (Pre-#64 this returned Allow, encoding the
+        // tool-vs-Bash divergence this fix removes.)
         let result = SecretLeaksGuard.run(&make_read_input("/project/.env\0.txt"));
-        // After null byte removal: "/project/.env.txt" - not a blocked name
-        // But the key is that \0 doesn't help bypass — ".env" files still blocked
-        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -464,6 +464,24 @@ mod tests {
     }
 
     #[test]
+    fn write_env_prod_blocked() {
+        // #64: .env.prod is not in BLOCKED_FILENAMES — Write let it through
+        // while the Bash path blocked the same family. Now both block.
+        let result = SecretWritesGuard.run(&make_write_input("/project/.env.prod"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn edit_env_development_local_blocked() {
+        let result = SecretWritesGuard.run(&make_edit_input(
+            "/project/.env.development.local",
+            "old",
+            "new",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
     fn write_env_example_allowed() {
         let result = SecretWritesGuard.run(&make_write_input("/project/.env.example"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);

--- a/crates/cadence/src/secret_patterns.rs
+++ b/crates/cadence/src/secret_patterns.rs
@@ -57,6 +57,12 @@ pub fn is_safe_template(filename: &str) -> bool {
 pub fn is_blocked(filename: &str, path: &str) -> bool {
     let lower = filename.to_lowercase();
 
+    // The whole `.env` family — not just the handful in BLOCKED_FILENAMES — so
+    // the tool path agrees with the Bash path's predicate (#64).
+    if is_env_family_secret(&lower) {
+        return true;
+    }
+
     if BLOCKED_FILENAMES.iter().any(|&p| lower == p) {
         return true;
     }
@@ -90,20 +96,17 @@ pub fn is_ambiguous(filename: &str) -> bool {
     false
 }
 
-/// True if a shell token resolves to a dangerous `.env`-family file.
+/// True if a lowercased path component is a dangerous `.env`-family secret:
+/// `.env`, `.envrc`, or `.env.<x>` where `<x>` is non-empty and the component
+/// does not end in a [`SAFE_SUFFIXES`] template suffix (`.env.example`, etc.).
 ///
-/// Component-matched, not substring: the token's final path component must
-/// be `.env`, `.envrc`, or `.env.<something>` — minus [`SAFE_SUFFIXES`] — so
-/// `settings.environment`, `.environment`, and `my.envelope.txt` stay clean
-/// (closes the #86 substring false-block class for both secret guards).
-/// Strips one leading `@` (the curl/httpie upload-operand idiom `@.env`) and
-/// trailing `)` (subshell close) before classifying.
-pub fn is_dangerous_env_token(token: &str) -> bool {
-    let lower = token.to_lowercase();
-    let trimmed = lower.strip_prefix('@').unwrap_or(&lower);
-    let trimmed = trimmed.trim_end_matches(')');
-    let component = trimmed.rsplit('/').next().unwrap_or(trimmed);
-
+/// Shared by [`is_blocked`] (the Read/Grep/Write/Edit tool paths) and
+/// [`is_dangerous_env_token`] (the Bash path) so the tool and shell guards
+/// classify the whole family by one predicate instead of `is_blocked`'s exact
+/// `BLOCKED_FILENAMES` membership — which missed `.env.prod`, `.env.dev`,
+/// `.env.development.local`, … and let the tools read what the shell blocked
+/// (#64). Callers pass an already-lowercased basename/component.
+pub(crate) fn is_env_family_secret(component: &str) -> bool {
     if component == ".env" || component == ".envrc" {
         return true;
     }
@@ -112,6 +115,23 @@ pub fn is_dangerous_env_token(token: &str) -> bool {
         Some(rest) if !rest.is_empty() => !SAFE_SUFFIXES.iter().any(|s| component.ends_with(s)),
         _ => false,
     }
+}
+
+/// True if a shell token resolves to a dangerous `.env`-family file.
+///
+/// Component-matched, not substring: the token's final path component must
+/// be `.env`, `.envrc`, or `.env.<something>` — minus [`SAFE_SUFFIXES`] — so
+/// `settings.environment`, `.environment`, and `my.envelope.txt` stay clean
+/// (closes the #86 substring false-block class for both secret guards).
+/// Strips one leading `@` (the curl/httpie upload-operand idiom `@.env`) and
+/// trailing `)` (subshell close) before classifying via [`is_env_family_secret`].
+pub fn is_dangerous_env_token(token: &str) -> bool {
+    let lower = token.to_lowercase();
+    let trimmed = lower.strip_prefix('@').unwrap_or(&lower);
+    let trimmed = trimmed.trim_end_matches(')');
+    let component = trimmed.rsplit('/').next().unwrap_or(trimmed);
+
+    is_env_family_secret(component)
 }
 
 #[cfg(test)]
@@ -132,6 +152,39 @@ mod tests {
         assert!(is_blocked(".env.local", "/project/.env.local"));
         assert!(is_blocked("credentials.json", "/project/credentials.json"));
         assert!(is_blocked("id_rsa", "/home/user/.ssh/id_rsa"));
+    }
+
+    #[test]
+    fn env_family_secret_detected() {
+        // Bare members.
+        assert!(is_env_family_secret(".env"));
+        assert!(is_env_family_secret(".envrc"));
+        // #64: family members absent from BLOCKED_FILENAMES.
+        assert!(is_env_family_secret(".env.prod"));
+        assert!(is_env_family_secret(".env.dev"));
+        assert!(is_env_family_secret(".env.development.local"));
+        assert!(is_env_family_secret(".env.docker"));
+        // Safe template suffixes stay allowed.
+        assert!(!is_env_family_secret(".env.example"));
+        assert!(!is_env_family_secret(".env.test"));
+        // Lookalikes that aren't the family.
+        assert!(!is_env_family_secret(".environment"));
+        assert!(!is_env_family_secret("settings.environment"));
+    }
+
+    #[test]
+    fn blocked_env_family_gap_closed() {
+        // #64: these are NOT in BLOCKED_FILENAMES but the Bash path already
+        // blocked them via is_dangerous_env_token — is_blocked now agrees.
+        assert!(is_blocked(".env.prod", "/project/.env.prod"));
+        assert!(is_blocked(".env.dev", "/project/.env.dev"));
+        assert!(is_blocked(
+            ".env.development.local",
+            "/project/.env.development.local"
+        ));
+        // Safe templates still allowed through is_blocked.
+        assert!(!is_blocked(".env.example", "/project/.env.example"));
+        assert!(!is_blocked(".env.test", "/project/.env.test"));
     }
 
     #[test]


### PR DESCRIPTION
## What

The secret guards classified the `.env` family two different ways:

- **Bash path** — `is_dangerous_env_token()` (a component-matched, substring-minus-safe-suffix predicate: any `.env.<x>` where `<x>` is non-empty and not a safe template suffix).
- **Read/Grep/Write/Edit tool path** — `is_blocked()` matched the family by *exact* membership against `BLOCKED_FILENAMES`, which lists `.env.production`/`.env.development`/`.envrc` but **not** `.env.prod`, `.env.dev`, `.env.development.local`, `.env.docker`, …

Result (the P0): `Read .env.prod` → allow while `cat .env.prod` → block. The most-used ingestion tools were the weakest check.

## Fix (DRY)

Extracted the `.env`-family logic into one shared helper in `secret_patterns.rs`:

```rust
pub(crate) fn is_env_family_secret(component: &str) -> bool
```

It is now the single source of truth, called from **both** `is_blocked()` (before the `BLOCKED_FILENAMES` exact-match) and `is_dangerous_env_token()` (which keeps its token preprocessing — `@`/`)` stripping, path-component extraction — then delegates). The four tool handlers and the Bash path now agree on one predicate that cannot drift apart. The Bash path's semantics are byte-for-byte preserved (regression-safe); the tool path widens to match it.

## Tests

- `secret_patterns.rs`: `env_family_secret_detected`, `blocked_env_family_gap_closed` (`.env.prod`/`.env.dev`/`.env.development.local` block; `.env.example`/`.env.test` allowed).
- `prevent_secret_leaks.rs`: `read_env_prod_blocked`, `grep_env_dev_blocked`.
- `prevent_secret_writes.rs`: `write_env_prod_blocked`, `edit_env_development_local_blocked`.

`make ci` green (610 cadence tests + workspace). Acceptance via the real hook path: `Read .env.prod` → exit 2 (block); `Read .env.example` → exit 0 (allow).

## Note: one existing test flipped (intended convergence)

`null_byte_injection_blocked` fed `/project/.env\0.txt`; after null-byte stripping the basename is `.env.txt`, which the **Bash path already blocked** (`.env.<x>`, x=`txt`). The pre-fix tool path allowed it — exactly the divergence this PR removes. Updated that test to assert `Block`; its security intent (a null byte cannot smuggle an `.env`-family file past) is strengthened, not weakened. This widening applies to any `.env.<x>` (minus safe suffixes), not just the four issue examples — by design, since the goal is tool/shell parity.

Closes cameronsjo/claude-configurations#64

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved detection and blocking of environment files (`.env` variants including `.env.prod`, `.env.dev`, and `.env.development.local`)
  * Enhanced protection against null-byte injection attempts on sensitive files

* **Tests**
  * Expanded test coverage for environment file blocking behavior and secret write prevention

<!-- end of auto-generated comment: release notes by coderabbit.ai -->