### PR TITLE
fix: close six P1 guard-correctness bugs (#74, #77, #79, #80, #82, #83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,51 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **git-safety: `git rebase --onto <protected>` is no longer falsely blocked**
+  (#74 on claude-configurations). `check_rebase_blocked` flagged any rebase
+  whose args contained a bare `main`/`master`, catching `git rebase --onto main
+  <upstream> <branch>` — a documented stacked-PR restack where main is the
+  replay destination and is never rewritten. The token following `--onto` is now
+  exempt; a protected branch named anywhere else (plain `git rebase main`, or as
+  the trailing `<branch>`) still blocks.
+- **secret guards: block `.git-credentials`, `.pgpass`, `.aws/credentials`,
+  `.kube/config`** (#77 on claude-configurations). These plaintext credential
+  stores were in neither deny-list, so Read/Grep/Write/Edit operated on them
+  freely. `.git-credentials`/`.pgpass` (unique basenames) join
+  `BLOCKED_FILENAMES`; `.aws/credentials`/`.kube/config` join
+  `BLOCKED_PATH_FRAGMENTS` as parent-dir-qualified fragments so a bare
+  `config`/`credentials` file elsewhere is not over-blocked. (The Bash arms stay
+  `.env`-family-only, as for `id_rsa`/`.netrc` today.)
+- **session: registry records are written atomically** (#79 on
+  claude-configurations). `write_record` used `fs::write` (truncate-then-write),
+  exposing a window where a concurrent `read_peers` lands on a 0-byte/partial
+  file, fails to parse, and silently drops a live peer — worst case, a peer
+  missing from the one-shot SessionStart disclosure for the whole session.
+  Records now stage to a temp file in the same directory and `rename` over the
+  target, so a reader only ever sees a complete document.
+- **session: the lane guard now assesses MultiEdit** (#80 on
+  claude-configurations). The guard matched only Edit/Write, so a MultiEdit into
+  a peer's declared `touching` lane slipped through unwarned. MultiEdit carries a
+  top-level `file_path`, so matching the arm is sufficient (the hook matcher
+  already routes MultiEdit to the binary).
+- **obsidian trash_guard: quoted vault paths no longer evade the check** (#82 on
+  claude-configurations). When cwd was outside the vault, the in-vault scan used
+  raw `split_whitespace`, so a quoted absolute vault path evaded it — a leading
+  `"` defeated the absolute-path test, and a quoted path with spaces (e.g.
+  `Field Reports/…`) was shredded across tokens. The scan now uses the
+  quote-aware `core::shell::tokenize`, so `rm "/vault/Field Reports/old.md"` is
+  caught; out-of-vault quoted paths stay allowed.
+- **content guards: terminology, orphaned-todos, and line-endings now inspect
+  MultiEdit** (#83 on claude-configurations). All three gated on
+  `input.content()`, which is `None` for a MultiEdit payload (it carries
+  `edits[]`), so every MultiEdit hit the early allow() unchecked. A new
+  `HookInput::edit_fragments()` exposes the introduced/removed fragment pairs —
+  one per `edits[]` element — that the guards fold over; terminology preserves
+  its introduced-vs-existing diff (#63) per edit. Write/single-Edit behavior is
+  unchanged.
+
 ## [0.29.0] - 2026-06-10
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   file, fails to parse, and silently drops a live peer — worst case, a peer
   missing from the one-shot SessionStart disclosure for the whole session.
   Records now stage to a temp file in the same directory and `rename` over the
-  target, so a reader only ever sees a complete document.
+  target, so a reader only ever sees a complete document. The temp is created
+  with `O_EXCL` and the rename replaces the target path itself, so the write is
+  symlink-safe end to end.
 - **session: the lane guard now assesses MultiEdit** (#80 on
   claude-configurations). The guard matched only Edit/Write, so a MultiEdit into
   a peer's declared `touching` lane slipped through unwarned. MultiEdit carries a

--- a/crates/cadence/src/block_orphaned_todos.rs
+++ b/crates/cadence/src/block_orphaned_todos.rs
@@ -82,7 +82,10 @@ impl Check for OrphanedTodoGuard {
     }
 
     fn run(&self, input: &HookInput) -> CheckResult {
-        let Some(content) = input.content() else {
+        // edit_fragments() yields the introduced text for Write/Edit and one
+        // fragment per edits[] element for MultiEdit, which `content()` returned
+        // None for — letting MultiEdit slip past unchecked (#83).
+        let Some(fragments) = input.edit_fragments() else {
             return CheckResult::allow();
         };
 
@@ -92,7 +95,10 @@ impl Check for OrphanedTodoGuard {
             return CheckResult::allow();
         }
 
-        let orphans = find_orphaned(content);
+        let orphans: Vec<(usize, String)> = fragments
+            .iter()
+            .flat_map(|(new_text, _old)| find_orphaned(new_text))
+            .collect();
         if orphans.is_empty() {
             return CheckResult::allow();
         }
@@ -264,6 +270,45 @@ mod tests {
     #[test]
     fn run_allows_clean_code() {
         let input = make_check_input(Some("src/main.rs"), "fn main() {}");
+        let result = OrphanedTodoGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // --- MultiEdit: introduced fragments scanned per edit (#83) ---
+
+    use cadence_hooks_core::test_builders::make_multi_edit;
+
+    #[test]
+    fn multi_edit_introducing_orphan_blocks() {
+        // A MultiEdit whose new_string introduces an unreferenced marker must
+        // block — before #83 it slipped through content()'s None early-allow.
+        let orphan = make_marker("TODO", false); // assembled at runtime — source-safe
+        let input = make_multi_edit(
+            "src/main.rs",
+            &[("fn main() {}", &format!("fn main() {{}} {orphan}"))],
+        );
+        let result = OrphanedTodoGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn multi_edit_referenced_marker_allowed() {
+        // A MultiEdit introducing a properly-referenced marker is fine.
+        let ok = make_marker("TODO", true);
+        let input = make_multi_edit(
+            "src/main.rs",
+            &[("fn main() {}", &format!("fn main() {{}} {ok}"))],
+        );
+        let result = OrphanedTodoGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn multi_edit_clean_edits_allowed() {
+        let input = make_multi_edit(
+            "src/main.rs",
+            &[("let a = 1;", "let a = 2;"), ("let b = 3;", "let b = 4;")],
+        );
         let result = OrphanedTodoGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }

--- a/crates/cadence/src/git_safety.rs
+++ b/crates/cadence/src/git_safety.rs
@@ -377,10 +377,18 @@ impl GitSafetyGuard {
     }
 
     fn check_rebase_blocked(&self, args: &[&str]) -> Option<String> {
-        // Check if any non-flag argument is exactly a protected branch name
+        // `--onto <newbase>` names a rebase DESTINATION, not a ref being
+        // rewritten — replaying commits onto main never modifies main, so the
+        // single token following `--onto` is exempt (#74, a documented
+        // stacked-PR restack workflow). A protected branch named anywhere else
+        // still relocates/rewrites a protected ref and stays blocked: plain
+        // `git rebase main`, or `main`/`master` as the rewritten <branch> in
+        // `git rebase --onto X Y main`.
+        let onto_newbase = args.iter().position(|a| *a == "--onto").map(|i| i + 1);
         let targets_protected = args
             .iter()
-            .any(|a| !a.starts_with('-') && is_protected_branch(a));
+            .enumerate()
+            .any(|(i, a)| Some(i) != onto_newbase && !a.starts_with('-') && is_protected_branch(a));
         if targets_protected {
             return Some("Rebase onto protected branch".into());
         }
@@ -630,6 +638,49 @@ mod tests {
     #[test]
     fn rebase_main_blocked() {
         let result = GitSafetyGuard.run(&make_bash_input("git rebase main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rebase_onto_main_destination_allowed() {
+        // #74: `--onto main` names main as the DESTINATION (never rewritten);
+        // the rewritten ref is `feature`. Must not hard-block (rebase still
+        // nudges as a history-rewriting op).
+        let result =
+            GitSafetyGuard.run(&make_bash_input("git rebase --onto main feature~3 feature"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+    }
+
+    #[test]
+    fn rebase_onto_main_newbase_only_allowed() {
+        // `--onto main` with no upstream/branch rebases the CURRENT branch onto
+        // main — main is still only the destination, so it is not blocked.
+        let result = GitSafetyGuard.run(&make_bash_input("git rebase --onto main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+    }
+
+    #[test]
+    fn rebase_onto_with_main_as_branch_blocked() {
+        // #74 regression: main as the trailing <branch> IS rewritten — stays blocked.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git rebase --onto refactor feature~3 main",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rebase_onto_main_with_master_branch_blocked() {
+        // #74 regression: only the token after --onto is exempt; master as
+        // <branch> is rewritten and stays blocked.
+        let result = GitSafetyGuard.run(&make_bash_input("git rebase --onto main feature master"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rebase_onto_with_main_upstream_blocked() {
+        // #74: main as <upstream> is not rewritten, but the minimal fix keeps
+        // this blocked (a deliberate, documented over-block — not a hole).
+        let result = GitSafetyGuard.run(&make_bash_input("git rebase --onto HEAD~2 main feature"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 

--- a/crates/cadence/src/secret_patterns.rs
+++ b/crates/cadence/src/secret_patterns.rs
@@ -33,6 +33,8 @@ pub const BLOCKED_FILENAMES: &[&str] = &[
     ".npmrc",
     ".pypirc",
     ".netrc",
+    ".git-credentials",
+    ".pgpass",
 ];
 
 /// File extensions that must never be read or written (unambiguous secrets).
@@ -42,7 +44,16 @@ pub const BLOCKED_EXTENSIONS: &[&str] = &["key", "p12", "pfx", "keystore", "jks"
 pub const BLOCKED_SUFFIXES: &[&str] = &["-key.pem", "_key.pem", ".private.pem"];
 
 /// Path fragments indicating secrets.
-pub const BLOCKED_PATH_FRAGMENTS: &[&str] = &[".docker/config.json", "gcloud-credentials.json"];
+///
+/// Parent-dir-qualified so the generic basenames `credentials` and `config`
+/// only block inside their credential directories — a bare `credentials` /
+/// `config` filename would over-block every repo (#77).
+pub const BLOCKED_PATH_FRAGMENTS: &[&str] = &[
+    ".docker/config.json",
+    "gcloud-credentials.json",
+    ".aws/credentials",
+    ".kube/config",
+];
 
 /// Ambiguous patterns (warn, not block).
 pub const WARN_EXTENSIONS: &[&str] = &["pem", "p8"];
@@ -249,6 +260,40 @@ mod tests {
         // Safe-template check runs first in the guards, so .envrc.example is
         // still allowed.
         assert!(is_safe_template(".envrc.example"));
+    }
+
+    #[test]
+    fn aws_kube_credential_stores_blocked_by_fragment() {
+        // #77: high-value plaintext credential stores reachable only by path —
+        // matched as parent-dir-qualified fragments, not bare basenames.
+        assert!(is_blocked("credentials", "/home/user/.aws/credentials"));
+        assert!(is_blocked("config", "/home/user/.kube/config"));
+        // Fragment form also covers adjacent variants in the same dir.
+        assert!(is_blocked(
+            "credentials.bak",
+            "/home/user/.aws/credentials.bak"
+        ));
+    }
+
+    #[test]
+    fn plaintext_credential_dotfiles_blocked() {
+        // #77: exact-filename plaintext credential stores (git token store,
+        // Postgres password file).
+        assert!(is_blocked(
+            ".git-credentials",
+            "/home/user/.git-credentials"
+        ));
+        assert!(is_blocked(".pgpass", "/home/user/.pgpass"));
+    }
+
+    #[test]
+    fn bare_config_and_credentials_not_overblocked() {
+        // #77 guard: the generic basenames are fragments (parent-dir-qualified),
+        // so benign `config`/`credentials` files outside the credential dirs
+        // stay readable — proves no bare filename was added.
+        assert!(!is_blocked("config", "/project/config"));
+        assert!(!is_blocked("config", "/project/src/config"));
+        assert!(!is_blocked("credentials", "/project/credentials"));
     }
 
     #[test]

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -147,7 +147,10 @@ impl Check for TerminologyGuard {
     }
 
     fn run(&self, input: &HookInput) -> CheckResult {
-        let Some(content) = input.content() else {
+        // edit_fragments() yields one (introduced, removed) pair for Write/Edit
+        // and one per edits[] element for MultiEdit — so MultiEdit is inspected
+        // instead of waved through `content()`'s None early-allow (#83).
+        let Some(fragments) = input.edit_fragments() else {
             return CheckResult::allow();
         };
 
@@ -157,23 +160,35 @@ impl Check for TerminologyGuard {
             return CheckResult::allow();
         }
 
-        let mut result = check_terminology(content);
-
-        // Edit tool: only violations *introduced* by this edit count. A term
-        // already present in old_string is pre-existing file content — blocking
-        // on it would prevent edits that don't add anything prohibited (#63).
-        if let Some(old) = input
-            .tool_input
-            .as_ref()
-            .and_then(|ti| ti.old_string.as_deref())
-        {
-            let existing = check_terminology(old);
-            result.blocks = subtract_existing(result.blocks, &existing.blocks);
-            result.nudges = subtract_existing(result.nudges, &existing.nudges);
+        // Per-edit introduced-vs-existing diff, accumulated and deduped. Only
+        // violations *introduced* by this call fire; a term carried through
+        // (present in an edit's old_string) is pre-existing context, not new
+        // content (#63). Folding per-edit — not over a concatenated document —
+        // keeps each edit's subtraction scoped and stops a phrase pattern
+        // matching across an edit boundary.
+        let mut blocks: Vec<(String, String)> = Vec::new();
+        let mut nudges: Vec<(String, String)> = Vec::new();
+        for (new_text, old_text) in &fragments {
+            let mut found = check_terminology(new_text);
+            if !old_text.is_empty() {
+                let existing = check_terminology(old_text);
+                found.blocks = subtract_existing(found.blocks, &existing.blocks);
+                found.nudges = subtract_existing(found.nudges, &existing.nudges);
+            }
+            for b in found.blocks {
+                if !blocks.contains(&b) {
+                    blocks.push(b);
+                }
+            }
+            for n in found.nudges {
+                if !nudges.contains(&n) {
+                    nudges.push(n);
+                }
+            }
         }
 
         // Tier 1: hard block
-        if !result.blocks.is_empty() {
+        if !blocks.is_empty() {
             let mut msg = String::new();
             msg.push_str("🚫 BLOCKED: Inclusive terminology violation detected");
             if let Some(ref path) = input.file_path() {
@@ -181,12 +196,12 @@ impl Check for TerminologyGuard {
             }
             msg.push_str("\n\nFound prohibited terms:\n");
 
-            for (term, _) in &result.blocks {
+            for (term, _) in &blocks {
                 msg.push_str(&format!("  - \"{term}\"\n"));
             }
 
             msg.push_str("\nRequired alternatives:\n");
-            for (term, replacement) in &result.blocks {
+            for (term, replacement) in &blocks {
                 msg.push_str(&format!("  {term} → {replacement}\n"));
             }
 
@@ -194,14 +209,14 @@ impl Check for TerminologyGuard {
         }
 
         // Tier 2: nudge (advisory)
-        if !result.nudges.is_empty() {
+        if !nudges.is_empty() {
             let mut msg = String::new();
             msg.push_str("⚠️  Terminology nudge");
             if let Some(ref path) = input.file_path() {
                 msg.push_str(&format!(" in {path}"));
             }
             msg.push_str(" — consider alternatives if technical context:\n");
-            for (term, replacement) in &result.nudges {
+            for (term, replacement) in &nudges {
                 msg.push_str(&format!("  {term} → {replacement}\n"));
             }
 
@@ -563,7 +578,7 @@ mod tests {
 
     // --- Edit tool: only introduced violations fire (#63) ---
 
-    use cadence_hooks_core::test_builders::make_edit;
+    use cadence_hooks_core::test_builders::{make_edit, make_multi_edit};
 
     #[test]
     fn edit_with_preexisting_term_in_context_allowed() {
@@ -637,5 +652,49 @@ mod tests {
         };
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    // --- MultiEdit: edits[] folded per-edit, same #63 semantics (#83) ---
+
+    #[test]
+    fn multi_edit_introducing_term_blocks() {
+        // A MultiEdit whose new_string introduces a prohibited term must block —
+        // it would silently pass through content()'s None early-allow before #83.
+        let term = BLOCK_VIOLATIONS[0].0;
+        let input = make_multi_edit(
+            "/project/src/config.rs",
+            &[
+                ("fn a() {}", "fn a() { /* tidy */ }"),
+                ("value = 1", &format!("value = 2 // uses the {term}")),
+            ],
+        );
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert!(result.message.unwrap().contains(term));
+    }
+
+    #[test]
+    fn multi_edit_carried_through_term_allowed() {
+        // Term present in BOTH old and new of one edit = pre-existing context
+        // carried through — #63 parity, folded per-edit.
+        let term = BLOCK_VIOLATIONS[0].0;
+        let input = make_multi_edit(
+            "/project/src/config.rs",
+            &[(&format!("{term} setting v1"), &format!("{term} setting v2"))],
+        );
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn multi_edit_removing_term_not_blamed() {
+        // Term only in old_string (the edit REMOVES it) → not falsely blamed.
+        let term = BLOCK_VIOLATIONS[0].0;
+        let input = make_multi_edit(
+            "/project/src/config.rs",
+            &[(&format!("use the {term} here"), "use the allowlist here")],
+        );
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/cadence/src/validate_line_endings.rs
+++ b/crates/cadence/src/validate_line_endings.rs
@@ -25,11 +25,17 @@ impl Check for LineEndingsGuard {
             return CheckResult::allow();
         }
 
-        let Some(content) = input.content() else {
+        // Scan each introduced fragment (new_string). MultiEdit carries one per
+        // edits[] element; `content()` returned None for it, so a CRLF introduced
+        // by a MultiEdit slipped through before #83.
+        let Some(fragments) = input.edit_fragments() else {
             return CheckResult::allow();
         };
 
-        if content.contains('\r') {
+        if fragments
+            .iter()
+            .any(|(new_text, _old)| new_text.contains('\r'))
+        {
             return CheckResult::block(
                 "🚫 BLOCKED: Shell script contains Windows-style CRLF line endings.\n\
                  This causes \"env: bash\\r: No such file or directory\" errors.\n\
@@ -186,6 +192,26 @@ mod tests {
     fn zsh_extension_not_checked() {
         // Only .sh and .bash are checked — .zsh is not
         let input = make_input("script.zsh", "#!/bin/zsh\r\necho hello\r\n");
+        let result = LineEndingsGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // --- MultiEdit: introduced fragments scanned per edit (#83) ---
+
+    use cadence_hooks_core::test_builders::make_multi_edit;
+
+    #[test]
+    fn multi_edit_introducing_crlf_blocked() {
+        // A MultiEdit whose new_string introduces a CRLF into a .sh must block —
+        // before #83 it slipped through content()'s None early-allow.
+        let input = make_multi_edit("script.sh", &[("echo hi", "echo hi\r\necho bye")]);
+        let result = LineEndingsGuard.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn multi_edit_lf_only_allowed() {
+        let input = make_multi_edit("script.sh", &[("echo hi", "echo hi\necho bye")]);
         let result = LineEndingsGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -234,6 +234,46 @@ impl HookInput {
             .and_then(|ti| ti.content.as_deref().or(ti.new_string.as_deref()))
     }
 
+    /// The `(introduced, removed)` text-fragment pairs a tool call carries, so a
+    /// content guard can inspect *what the edit introduces* uniformly across
+    /// Write, Edit, and MultiEdit:
+    ///
+    /// - Write (`content`) → one pair `(content, "")` — no removed fragment.
+    /// - Edit (`new_string`/`old_string`) → one pair.
+    /// - MultiEdit (`edits[]`) → one pair per element.
+    ///
+    /// `None` when the payload carries no editable text (e.g. Read, Bash).
+    ///
+    /// Fragments are kept SEPARATE (not concatenated) so a phrase pattern can't
+    /// match across an edit boundary, and so each edit's removed-context
+    /// subtraction stays scoped to that edit. Use this — not [`Self::content`],
+    /// which is `None` for MultiEdit — for fragment-scanning guards that must
+    /// also see `edits[]` (#83); use [`Self::effective_content`] only when the
+    /// whole resulting document matters.
+    pub fn edit_fragments(&self) -> Option<Vec<(String, String)>> {
+        let ti = self.tool_input.as_ref()?;
+
+        if let Some(new) = ti.content.as_deref().or(ti.new_string.as_deref()) {
+            let old = ti.old_string.as_deref().unwrap_or_default().to_string();
+            return Some(vec![(new.to_string(), old)]);
+        }
+
+        if let Some(edits) = ti.edits.as_ref() {
+            let pairs: Vec<(String, String)> = edits
+                .iter()
+                .map(|e| {
+                    (
+                        e.new_string.as_deref().unwrap_or_default().to_string(),
+                        e.old_string.as_deref().unwrap_or_default().to_string(),
+                    )
+                })
+                .collect();
+            return (!pairs.is_empty()).then_some(pairs);
+        }
+
+        None
+    }
+
     /// The full document the tool call will produce.
     ///
     /// - Write (`content` present) → the content as-is.
@@ -1001,6 +1041,75 @@ mod tests {
     fn content_none_when_both_absent() {
         let input = make_input(None, None, None, None, None, None);
         assert_eq!(input.content(), None);
+    }
+
+    // --- edit_fragments (#83) ---
+
+    #[test]
+    fn edit_fragments_write_single_pair_no_old() {
+        let input = make_input(Some("Write"), Some("/a.rs"), None, None, Some("doc"), None);
+        assert_eq!(
+            input.edit_fragments(),
+            Some(vec![("doc".to_string(), String::new())])
+        );
+    }
+
+    #[test]
+    fn edit_fragments_edit_pairs_new_and_old() {
+        let input = HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(ToolInput {
+                file_path: Some("/a.rs".into()),
+                new_string: Some("new".into()),
+                old_string: Some("old".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            input.edit_fragments(),
+            Some(vec![("new".to_string(), "old".to_string())])
+        );
+    }
+
+    #[test]
+    fn edit_fragments_multi_edit_one_pair_per_edit() {
+        // The MultiEdit case content() returns None for — one (new, old) pair
+        // per edits[] element, in order.
+        let input = HookInput {
+            tool_name: Some("MultiEdit".into()),
+            tool_input: Some(ToolInput {
+                file_path: Some("/a.rs".into()),
+                edits: Some(vec![
+                    EditOperation {
+                        old_string: Some("o1".into()),
+                        new_string: Some("n1".into()),
+                        replace_all: None,
+                    },
+                    EditOperation {
+                        old_string: Some("o2".into()),
+                        new_string: Some("n2".into()),
+                        replace_all: None,
+                    },
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(input.content(), None, "content() is blind to MultiEdit");
+        assert_eq!(
+            input.edit_fragments(),
+            Some(vec![
+                ("n1".to_string(), "o1".to_string()),
+                ("n2".to_string(), "o2".to_string()),
+            ])
+        );
+    }
+
+    #[test]
+    fn edit_fragments_none_for_bash() {
+        let input = make_input(Some("Bash"), None, None, Some("ls"), None, None);
+        assert_eq!(input.edit_fragments(), None);
     }
 
     // --- effective_content ---

--- a/crates/obsidian/src/trash_guard.rs
+++ b/crates/obsidian/src/trash_guard.rs
@@ -4,6 +4,7 @@
 //! `rm` bypasses it and loses recoverability. This guard blocks `rm` inside
 //! the vault directory and suggests `mv` to `.trash/` instead.
 
+use cadence_hooks_core::shell::tokenize;
 use cadence_hooks_core::{Check, CheckResult, HookInput, normalize_path};
 
 /// True when a normalized path is absolute — POSIX (`/foo`) or a Windows
@@ -35,8 +36,13 @@ fn check_rm_in_vault(command: &str, cwd: &str, vault: &str) -> CheckResult {
     let mut in_vault = cwd == vault || cwd.starts_with(&vault_prefix);
 
     if !in_vault {
-        for part in command.split_whitespace() {
-            let part = normalize_path(part);
+        // Quote-aware tokenize (not split_whitespace): a vault path with spaces
+        // must be quoted (`"…/Field Reports/old.md"`), and split_whitespace both
+        // shreds it across tokens and leaves a leading `"` that defeats
+        // `looks_absolute`. tokenize keeps a quoted path in one token and strips
+        // the quotes, so the absolute/in-vault test sees the real path (#82).
+        for part in tokenize(command) {
+            let part = normalize_path(&part);
             if looks_absolute(&part) && (part == vault || part.starts_with(&vault_prefix)) {
                 in_vault = true;
                 break;
@@ -105,6 +111,51 @@ mod tests {
     fn rm_with_explicit_vault_path_blocked() {
         let result = check_rm_in_vault("rm /vault/notes/todo.md", "/home/user", "/vault");
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rm_double_quoted_vault_path_blocked() {
+        // #82: a leading `"` must not defeat looks_absolute.
+        let result = check_rm_in_vault("rm \"/vault/notes/todo.md\"", "/home/user", "/vault");
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rm_single_quoted_vault_path_blocked() {
+        let result = check_rm_in_vault("rm '/vault/notes/todo.md'", "/home/user", "/vault");
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rm_double_quoted_vault_path_with_spaces_blocked() {
+        // #82 headline repro: a spaced vault path must be quoted; split_whitespace
+        // shredded it across tokens and the guard never saw the absolute path.
+        let result =
+            check_rm_in_vault("rm \"/vault/Field Reports/old.md\"", "/home/user", "/vault");
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rm_single_quoted_vault_path_with_spaces_blocked() {
+        let result = check_rm_in_vault("rm '/vault/Field Reports/old.md'", "/home/user", "/vault");
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn rm_quoted_out_of_vault_path_with_spaces_allowed() {
+        // Regression: a genuinely out-of-vault quoted spaced path stays Allow.
+        let result = check_rm_in_vault(
+            "rm \"/home/user/Field Reports/old.md\"",
+            "/home/user",
+            "/vault",
+        );
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn rm_quoted_out_of_vault_path_allowed() {
+        let result = check_rm_in_vault("rm '/other/note.md'", "/home/user", "/vault");
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 
     #[test]

--- a/crates/session/src/guard.rs
+++ b/crates/session/src/guard.rs
@@ -80,7 +80,12 @@ pub fn run_guard(input: &HookInput, peers: &[Peer]) -> CheckResult {
             }
             CheckResult::allow()
         }
-        Some("Edit") | Some("Write") => {
+        Some("Edit") | Some("MultiEdit") | Some("Write") => {
+            // MultiEdit carries a top-level file_path like Edit, but was never
+            // matched here, so a MultiEdit into a peer's declared lane slipped
+            // through unwarned (#80). The hook matcher (`Edit|Write`) already
+            // routes MultiEdit to the binary — unanchored regex substring-matches
+            // it — so only this arm needed the fix.
             let Some(path) = input.file_path() else {
                 return CheckResult::allow();
             };
@@ -280,7 +285,7 @@ mod tests {
     use super::*;
     use crate::identity::SessionRecord;
     use cadence_hooks_core::Outcome;
-    use cadence_hooks_core::test_builders::{make_bash, make_edit};
+    use cadence_hooks_core::test_builders::{make_bash, make_edit, make_multi_edit};
 
     fn peer(name: &str, touching: &[&str]) -> Peer {
         Peer {
@@ -437,6 +442,22 @@ mod tests {
             "/Users/dev/cadence-hooks/crates/guardrails/src/lib.rs",
             "old",
             "new",
+        ));
+        let r = run_guard(&input, &peers);
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let msg = r.message.unwrap();
+        assert!(msg.contains("quiet-loom"));
+        assert!(msg.contains("crates/guardrails/"));
+    }
+
+    #[test]
+    fn multi_edit_inside_peer_lane_warns() {
+        // MultiEdit carries a top-level file_path like Edit; a MultiEdit into a
+        // peer's declared lane must nudge, not slip through (#80).
+        let peers = vec![peer("quiet-loom", &["crates/guardrails/"])];
+        let input = with_session(make_multi_edit(
+            "/Users/dev/cadence-hooks/crates/guardrails/src/lib.rs",
+            &[("old", "new"), ("foo", "bar")],
         ));
         let r = run_guard(&input, &peers);
         assert_eq!(r.outcome, Outcome::Nudge);

--- a/crates/session/src/registry.rs
+++ b/crates/session/src/registry.rs
@@ -118,13 +118,44 @@ pub fn find_own(dir: &Path, session_id: &str) -> Option<PathBuf> {
     })
 }
 
+/// Write `contents` to `path` atomically: stage to a uniquely-named temp file
+/// in the SAME directory, then `rename` it over `path`. A concurrent reader
+/// sees either the old complete file or the new complete file — never a
+/// truncated or half-written document.
+///
+/// Plain `fs::write` does `open(O_TRUNC)` then `write_all`, exposing a window
+/// where a peer's `read_peers` lands on a 0-byte/partial file, fails to parse,
+/// and silently skips the session (#79). The one-shot SessionStart disclosure
+/// then misses a live peer for the whole session.
+///
+/// The temp name carries the target filename AND the writer's PID: separate
+/// hook invocations are separate processes (distinct PIDs), and within one
+/// process distinct records have distinct filenames — so two concurrent writers
+/// never collide on the same temp path. `rename` is atomic only within one
+/// filesystem, so the temp MUST share `path`'s parent directory.
+fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "record".to_string());
+    let tmp = dir.join(format!(".{file_name}.{}.tmp", std::process::id()));
+    fs::write(&tmp, contents)?;
+    if let Err(e) = fs::rename(&tmp, path) {
+        // Don't leak a staging file when the rename fails (e.g. read-only fs).
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
 /// Write (or overwrite) a record's file in the registry. Creates the
 /// directory if needed. Writing refreshes mtime — this *is* the heartbeat.
 pub fn write_record(dir: &Path, record: &SessionRecord) -> std::io::Result<()> {
     fs::create_dir_all(dir)?;
     let path = dir.join(identity::filename(&record.name, &record.session_id));
     let json = serde_json::to_string_pretty(record).unwrap_or_else(|_| "{}".to_string());
-    fs::write(path, json + "\n")
+    atomic_write(&path, (json + "\n").as_bytes())
 }
 
 /// Read a session's own record, if registered.
@@ -294,6 +325,67 @@ mod tests {
     fn find_own_none_when_unregistered() {
         let tmp = TempDir::new().unwrap();
         assert!(find_own(tmp.path(), "nobody").is_none());
+    }
+
+    // --- atomic write (#79) ---
+
+    #[test]
+    fn atomic_write_round_trips() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("doc.json");
+        atomic_write(&path, b"hello\n").unwrap();
+        assert_eq!(fs::read_to_string(&path).unwrap(), "hello\n");
+    }
+
+    #[test]
+    fn write_record_leaves_no_temp_file() {
+        // The rename staging file must not survive a successful write — only the
+        // .json record remains, never a stray .tmp.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        write_record(&dir, &record("quiet-loom", "e4739a12-full")).unwrap();
+        let names: Vec<String> = fs::read_dir(&dir)
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["quiet-loom.e4739a12.json".to_string()]);
+    }
+
+    #[test]
+    fn read_peers_skips_empty_file() {
+        // A 0-byte .json is exactly what a torn (non-atomic) fs::write left
+        // mid-flight. The reader must fail open and still surface the valid
+        // peer — and the atomic writer guarantees new writers never create this.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        fs::write(dir.join("torn.deadbeef.json"), "").unwrap();
+        write_record(&dir, &record("forge-anvil", "peer-session")).unwrap();
+        let peers = read_peers(&dir, "self", 600);
+        assert_eq!(peers.len(), 1, "empty file skipped, valid peer found");
+    }
+
+    #[test]
+    fn concurrent_writes_to_distinct_files_all_persist() {
+        // 16 threads share one PID, so this fails under pid-only temp naming
+        // (temp collision corrupts records) and passes once the temp name also
+        // carries the target filename. Guards the uniqueness design.
+        use std::sync::Arc;
+        let tmp = TempDir::new().unwrap();
+        let dir = Arc::new(tmp.path().to_path_buf());
+        let handles: Vec<_> = (0..16)
+            .map(|i| {
+                let dir = Arc::clone(&dir);
+                std::thread::spawn(move || {
+                    let sid = format!("session-{i:02}");
+                    write_record(&dir, &record(&format!("peer-{i:02}"), &sid)).unwrap();
+                })
+            })
+            .collect();
+        for h in handles {
+            h.join().unwrap();
+        }
+        assert_eq!(read_peers(&dir, "none", 600).len(), 16);
     }
 
     // --- peer discovery ---

--- a/crates/session/src/registry.rs
+++ b/crates/session/src/registry.rs
@@ -140,7 +140,31 @@ fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
         .map(|n| n.to_string_lossy().into_owned())
         .unwrap_or_else(|| "record".to_string());
     let tmp = dir.join(format!(".{file_name}.{}.tmp", std::process::id()));
-    fs::write(&tmp, contents)?;
+    // create_new (O_EXCL) refuses to follow or overwrite an existing path, so a
+    // pre-planted symlink at the predictable temp name is rejected rather than
+    // clobbered (the registry dir is user-owned in normal use, but defense in
+    // depth is cheap here). A stale temp from a crashed same-PID process is the
+    // only benign collision — remove it and retry once. `rename` then replaces
+    // `path` itself (never follows a symlink at the target), so the whole write
+    // is symlink-safe end to end.
+    use std::io::Write;
+    let mut file = match fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp)
+    {
+        Ok(f) => f,
+        Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+            fs::remove_file(&tmp)?;
+            fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp)?
+        }
+        Err(e) => return Err(e),
+    };
+    file.write_all(contents)?;
+    drop(file);
     if let Err(e) = fs::rename(&tmp, path) {
         // Don't leak a staging file when the rename fails (e.g. read-only fs).
         let _ = fs::remove_file(&tmp);
@@ -386,6 +410,36 @@ mod tests {
             h.join().unwrap();
         }
         assert_eq!(read_peers(&dir, "none", 600).len(), 16);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn atomic_write_does_not_clobber_preplanted_symlink_at_temp() {
+        // A co-tenant pre-plants a symlink at the predictable temp path; the
+        // O_EXCL create_new must reject/replace it without writing through to
+        // the victim, and the record must still land.
+        use std::os::unix::fs::symlink;
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        fs::create_dir_all(&dir).unwrap();
+        let victim = tmp.path().join("victim.txt");
+        fs::write(&victim, "precious\n").unwrap();
+
+        let rec = record("quiet-loom", "e4739a12-full");
+        let target_name = identity::filename(&rec.name, &rec.session_id);
+        let temp_path = dir.join(format!(".{target_name}.{}.tmp", std::process::id()));
+        symlink(&victim, &temp_path).unwrap();
+
+        write_record(&dir, &rec).unwrap();
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "precious\n",
+            "victim file must not be clobbered through the symlink"
+        );
+        assert!(
+            read_own(&dir, "e4739a12-full").is_some(),
+            "record still landed"
+        );
     }
 
     // --- peer discovery ---

--- a/crates/session/src/registry.rs
+++ b/crates/session/src/registry.rs
@@ -163,7 +163,13 @@ fn atomic_write(path: &Path, contents: &[u8]) -> std::io::Result<()> {
         }
         Err(e) => return Err(e),
     };
-    file.write_all(contents)?;
+    if let Err(e) = file.write_all(contents) {
+        // A failed write (e.g. disk full) must not leave an orphan .tmp —
+        // sweep_stale only reaps .json files, so it would accumulate.
+        drop(file);
+        let _ = fs::remove_file(&tmp);
+        return Err(e);
+    }
     drop(file);
     if let Err(e) = fs::rename(&tmp, path) {
         // Don't leak a staging file when the rename fails (e.g. read-only fs).


### PR DESCRIPTION
## What

Six P1 guard-correctness bugs from the cadence-hooks bug-hunt, each verified to reproduce against current `0.30.0` source before fixing (most empirically, by piping payloads to the installed binary).

| Issue | Fix | Crate |
|---|---|---|
| #74 | `git rebase --onto <protected>` no longer falsely blocked — the token after `--onto` is the replay *destination*, never rewritten | `cadence/git_safety` |
| #77 | `.git-credentials`, `.pgpass`, `.aws/credentials`, `.kube/config` added to the secret deny-set | `cadence/secret_patterns` |
| #79 | registry records written atomically (temp + `O_EXCL` + rename) — closes the torn-read window that dropped a live peer from the SessionStart disclosure | `session/registry` |
| #80 | lane guard now assesses `MultiEdit` against peer `touching` lanes | `session/guard` |
| #82 | trash_guard uses quote-aware `core::shell::tokenize` — quoted/space-bearing vault paths no longer evade the `rm` block | `obsidian/trash_guard` |
| #83 | terminology, orphaned-todos, line-endings now inspect `MultiEdit` (they gated on `content()`, which is `None` for `edits[]`) | `cadence/*` + `core` |

## Notable scoping (verification surfaced these)

- **#77**: `.envrc` was already covered (PR #119) — the issue's claim was stale; not re-added. The fix closes the Read/Grep/Write/Edit path; the Bash arms stay `.env`-family-only (as for `id_rsa`/`.netrc` today).
- **#80**: the hooks.json change the issue proposed is unnecessary — the unanchored `Edit|Write` matcher already substring-routes `MultiEdit` to the binary (cf. `warn_overshare.rs`). One-line arm change; **no cadence-canon edit**.
- **#82**: the issue's `normalize_path` quote-strip is redundant — `tokenize` strips quotes itself. Localized swap, no shared-core churn.
- **#83**: implemented as a shared `HookInput::edit_fragments()` helper + **fragment-fold** (scan introduced text per edit), not `effective_content()`. This adds MultiEdit coverage with *zero* behavior change for existing Write/Edit and no catch-22 on pre-existing violations elsewhere; terminology preserves its introduced-vs-existing diff (#63) per edit.

## Verification

- 27 new tests (per-fix block/allow + regressions); full workspace suite green.
- `cargo fmt --all --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- **Adversarial security review (Opus)** on the full diff: clean — no Critical/High/Medium. Framed as "find inputs where a dangerous op slips through unseen." Confirmed #74's exemption is index-precise (`--onto X Y main` still blocks), #82 introduces no new miss, #83 is byte-for-byte unchanged for Write/single-Edit and term-laundering is impossible. Its one Low finding (predictable temp name + symlink-follow in #79) is fixed here via `O_EXCL`.

> Local `make ci` also trips `no_cross_plugin_hooks` and `all_binary_subcommands_are_registered` — the cross-sibling audit checks (naming `inject-gh-context` / `warn-overshare`, unrelated to this PR). GitHub CI has no sibling checkouts and skips them; `registry_matches_clap_dispatch` (the real-bug canary) passes.

Closes cameronsjo/claude-configurations#74
Closes cameronsjo/claude-configurations#77
Closes cameronsjo/claude-configurations#79
Closes cameronsjo/claude-configurations#80
Closes cameronsjo/claude-configurations#82
Closes cameronsjo/claude-configurations#83

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Refined git rebase protection to correctly handle `--onto` destinations while still blocking dangerous rebase operations
  * Enhanced secret credential file detection to block `.git-credentials` and `.pgpass`, with improved path matching
  * Improved vault trash handling by correctly parsing quoted `rm` vault paths
  * Strengthened safety checks for multi-edit operations across terminology, orphaned todos, and line-ending validation (including peer-lane nudging)
* **New Features**
  * Added atomic session registry writes to prevent partial records during concurrent access
<!-- end of auto-generated comment: release notes by coderabbit.ai -->