### PR TITLE
fix(guards): close P2 guard-correctness bugs (#84, #87, #89, #91, #92, #93)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,39 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   one per `edits[]` element — that the guards fold over; terminology preserves
   its introduced-vs-existing diff (#63) per edit. Write/single-Edit behavior is
   unchanged.
+- **git-safety: block history-rewrite and remote-mirror destruction** (#84 on
+  claude-configurations). `git filter-branch`/`filter-repo` (mass history
+  rewrite), `git update-ref` deleting or repointing a protected branch, and
+  `git push --mirror` (overwrites/deletes all remote refs) fell through to
+  Allow. Now blocked; a non-protected `update-ref -d` nudges.
+- **guard-gh-write: cover release upload, secret/variable set, label clone**
+  (#87 on claude-configurations). These write GitHub state and accept `-R`, but
+  the noun/verb table missed them, so ownership was never checked. Added via a
+  separate anchored pattern so `clone` can't make `gh repo clone` (a local read)
+  look like a write. (`gh ruleset` is read-only — written via `gh api`, already
+  covered; account-level `ssh-key`/`gpg-key` and `--owner` `project` excluded.)
+- **dispatch: protect security guards from silent `CADENCE_DISABLE`** (#89 on
+  claude-configurations). Disabling a guard by name exited 0 with no trace, and
+  nothing exempted the enforcement guards — `CADENCE_DISABLE=git-safety` silently
+  neutered it. Now every disable emits a one-line stderr notice, and a protected
+  set (secret/git/gh/vault/browser/trash guards) refuses to disable and still
+  runs. Use the loud, per-session `CADENCE_BYPASS` for maintenance.
+- **terminology: anchor the source-exemption to path components** (#91 on
+  claude-configurations). The `cadence-hooks/`/`.claude/hooks|rules`/`claude.md`
+  exemptions were unanchored substrings, so a sibling `legacy-cadence-hooks/`, a
+  spoofed `x.claude/hooks/`, or `evilclaude.md` got a free pass. Now matched on
+  `/`-split components.
+- **memory-guard: measure the resulting file and anchor to the auto-memory
+  root** (#92, #93 on claude-configurations). The 200-line cap counted the Edit
+  *fragment* (`content()`), so an Edit appending to a near-limit MEMORY.md was
+  allowed while the file grew past the cap — now uses `effective_content()`. And
+  the `/memory/` path test over-matched any project file with a `memory/` dir —
+  now scoped to `<config>/projects/…/memory/`.
+- **prevent-secret-leaks: lowercase the echo-secret nudge keywords** (#85 on
+  claude-configurations, partial). The exfil nudge matched uppercase `KEY`/
+  `SECRET`/… against the original-case command, so `echo $database_password`
+  (lowercase) was missed. (The secret-value content scanner — the rest of #85 —
+  ships separately.)
 
 ## [0.29.0] - 2026-06-10
 

--- a/crates/cadence/src/git_safety.rs
+++ b/crates/cadence/src/git_safety.rs
@@ -320,12 +320,30 @@ impl GitSafetyGuard {
     }
 
     fn check_update_ref_blocked(&self, args: &[&str]) -> Option<String> {
+        // `--stdin` batch mode reads the ref commands from stdin, which the guard
+        // cannot see — the block path can't judge it, so check_warned nudges.
+        if args.contains(&"--stdin") {
+            return None;
+        }
         let has_delete = args.iter().any(|a| *a == "-d" || *a == "--delete");
-        // The ref operand is the first non-flag token; `--stdin` (operates on
-        // stdin, no operand) is out of scope.
-        let targets_protected = args
-            .iter()
-            .find(|a| !a.starts_with('-'))
+        // The ref operand is the first non-flag token — but `-m`/`--message`
+        // takes a reflog-reason value that is itself a non-flag token, so a naive
+        // first-non-flag scan picks the reason and the protected-ref check never
+        // fires (review H1). Skip the value of `-m`/`--message`; every other
+        // update-ref flag is boolean.
+        let mut skip_next = false;
+        let ref_operand = args.iter().find(|a| {
+            if skip_next {
+                skip_next = false;
+                return false;
+            }
+            if **a == "-m" || **a == "--message" {
+                skip_next = true;
+                return false;
+            }
+            !a.starts_with('-')
+        });
+        let targets_protected = ref_operand
             .map(|r| is_protected_branch(push_target_branch(r)))
             .unwrap_or(false);
 
@@ -511,6 +529,14 @@ impl GitSafetyGuard {
                 // check_update_ref_blocked) has no safety net — nudge (#84).
                 if args.iter().any(|a| *a == "-d" || *a == "--delete") {
                     return Some("git update-ref -d (deletes a ref with no safety net)".into());
+                }
+                // `--stdin` batch edits carry their refs on stdin (invisible to
+                // the guard, and a protected delete/repoint could hide there) —
+                // surface it rather than silently allow (review M1).
+                if args.contains(&"--stdin") {
+                    return Some(
+                        "git update-ref --stdin (batch ref edits; refs not verifiable here)".into(),
+                    );
                 }
                 None
             }
@@ -1783,5 +1809,41 @@ mod tests {
         // Regression: a normal push without --mirror is unaffected.
         let result = GitSafetyGuard.run(&make_bash_input("git push origin feature"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn update_ref_reflog_message_then_protected_repoint_blocked() {
+        // Review H1: `-m <reason>` carries a non-flag value; the operand scan
+        // must skip it and still find the protected ref.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git update-ref -m cleanup refs/heads/main abc1234",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn update_ref_message_then_protected_delete_blocked() {
+        // Review H1: the `-m … -d` form must not downgrade Block → Nudge.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git update-ref -m cleanup -d refs/heads/main",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn update_ref_message_then_feature_allowed() {
+        // Review H1 regression: the reason string must not be mistaken for the
+        // ref — a non-protected ref stays allowed.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git update-ref -m reason refs/heads/feature abc1234",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn update_ref_stdin_warned() {
+        // Review M1: batch refs are invisible — surface, don't silently allow.
+        let result = GitSafetyGuard.run(&make_bash_input("git update-ref --stdin"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
     }
 }

--- a/crates/cadence/src/git_safety.rs
+++ b/crates/cadence/src/git_safety.rs
@@ -242,11 +242,23 @@ impl GitSafetyGuard {
             "gc" => self.check_gc_blocked(normalized),
             "branch" => self.check_branch_blocked(args),
             "rebase" => self.check_rebase_blocked(args),
+            sub @ ("filter-branch" | "filter-repo") => {
+                // Mass history rewrite — no benign form; same family as the
+                // reflog-expire / gc --prune blocks (#84).
+                Some(format!("git {sub} (mass history rewrite)"))
+            }
+            "update-ref" => self.check_update_ref_blocked(args),
             _ => None,
         }
     }
 
     fn check_push_blocked(&self, args: &[&str], current_branch: Option<&str>) -> Option<String> {
+        // `--mirror` overwrites EVERY remote ref and deletes remote refs absent
+        // locally — protected branches included, no per-branch targeting (#84).
+        if args.contains(&"--mirror") {
+            return Some("Mirror push (overwrites/deletes all remote refs)".into());
+        }
+
         let has_force = args.iter().any(|a| is_force_flag(a));
         let has_delete = args.iter().any(|a| *a == "--delete" || *a == "-d");
 
@@ -304,6 +316,28 @@ impl GitSafetyGuard {
             return Some("Force push via refspec to protected branch".into());
         }
 
+        None
+    }
+
+    fn check_update_ref_blocked(&self, args: &[&str]) -> Option<String> {
+        let has_delete = args.iter().any(|a| *a == "-d" || *a == "--delete");
+        // The ref operand is the first non-flag token; `--stdin` (operates on
+        // stdin, no operand) is out of scope.
+        let targets_protected = args
+            .iter()
+            .find(|a| !a.starts_with('-'))
+            .map(|r| is_protected_branch(push_target_branch(r)))
+            .unwrap_or(false);
+
+        if targets_protected {
+            return Some(if has_delete {
+                "Delete of protected branch via update-ref".into()
+            } else {
+                // Repointing a protected ref to an arbitrary commit can silently
+                // drop commits (no merge check) — as destructive as force-push.
+                "Repoint of protected branch via update-ref".into()
+            });
+        }
         None
     }
 
@@ -469,6 +503,14 @@ impl GitSafetyGuard {
             "remote" => {
                 if args.contains(&"remove") || args.contains(&"rm") {
                     return Some("git remote remove".into());
+                }
+                None
+            }
+            "update-ref" => {
+                // A non-protected ref delete (protected deletes already block in
+                // check_update_ref_blocked) has no safety net — nudge (#84).
+                if args.iter().any(|a| *a == "-d" || *a == "--delete") {
+                    return Some("git update-ref -d (deletes a ref with no safety net)".into());
                 }
                 None
             }
@@ -1661,6 +1703,85 @@ mod tests {
     fn checkout_dashdash_nothing_after_allowed() {
         // `--` with no pathspec following is not a discard — out of scope.
         let result = GitSafetyGuard.run(&make_bash_input("git checkout --"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // ---------------------------------------------------------------
+    // #84: history-rewrite + remote-destructive subcommands/flags
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn filter_branch_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git filter-branch --tree-filter 'rm -f secrets.txt' HEAD",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn filter_repo_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git filter-repo --path secrets --invert-paths",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn filter_branch_in_chain_blocked() {
+        // Per-segment: a benign first command must not shield the rewrite.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git status && git filter-branch --force --all",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn update_ref_delete_main_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input("git update-ref -d refs/heads/main"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn update_ref_delete_long_form_master_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git update-ref --delete refs/heads/master",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn update_ref_repoint_main_blocked() {
+        // Repointing a protected ref can silently drop commits (no merge check).
+        let result = GitSafetyGuard.run(&make_bash_input("git update-ref refs/heads/main abc1234"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn push_mirror_blocked() {
+        let result = GitSafetyGuard.run(&make_bash_input("git push --mirror origin"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn update_ref_delete_feature_warned() {
+        // Non-protected ref delete: no merge safety net → nudge.
+        let result = GitSafetyGuard.run(&make_bash_input("git update-ref -d refs/heads/feature"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+    }
+
+    #[test]
+    fn update_ref_repoint_feature_allowed() {
+        // Benign plumbing on a non-protected ref is unaffected.
+        let result = GitSafetyGuard.run(&make_bash_input(
+            "git update-ref refs/heads/feature abc1234",
+        ));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn push_without_mirror_allowed() {
+        // Regression: a normal push without --mirror is unaffected.
+        let result = GitSafetyGuard.run(&make_bash_input("git push origin feature"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/cadence/src/git_safety.rs
+++ b/crates/cadence/src/git_safety.rs
@@ -525,18 +525,20 @@ impl GitSafetyGuard {
                 None
             }
             "update-ref" => {
-                // A non-protected ref delete (protected deletes already block in
-                // check_update_ref_blocked) has no safety net — nudge (#84).
-                if args.iter().any(|a| *a == "-d" || *a == "--delete") {
-                    return Some("git update-ref -d (deletes a ref with no safety net)".into());
-                }
                 // `--stdin` batch edits carry their refs on stdin (invisible to
                 // the guard, and a protected delete/repoint could hide there) —
-                // surface it rather than silently allow (review M1).
+                // surface it rather than silently allow (review M1). Checked
+                // before `-d` so the more-informative "refs not verifiable"
+                // message wins when both are present (`update-ref -d --stdin`).
                 if args.contains(&"--stdin") {
                     return Some(
                         "git update-ref --stdin (batch ref edits; refs not verifiable here)".into(),
                     );
+                }
+                // A non-protected ref delete (protected deletes already block in
+                // check_update_ref_blocked) has no safety net — nudge (#84).
+                if args.iter().any(|a| *a == "-d" || *a == "--delete") {
+                    return Some("git update-ref -d (deletes a ref with no safety net)".into());
                 }
                 None
             }

--- a/crates/cadence/src/memory_guard.rs
+++ b/crates/cadence/src/memory_guard.rs
@@ -13,8 +13,28 @@ const TOPIC_SOFT_LIMIT: usize = 300;
 pub struct MemoryGuard;
 
 impl MemoryGuard {
+    /// True when `path` is an auto-memory file: under the resolved Claude
+    /// config dir's `projects/<slug>/memory/` tree.
+    ///
+    /// Anchoring here keeps the guard off unrelated project files that merely
+    /// have a `memory/` directory (`docs/memory/`, `assets/memory/`) — #93.
     fn is_memory_path(path: &str) -> bool {
-        path.contains("/memory/")
+        let config_dir = cadence_hooks_core::paths::claude_config_dir();
+        Self::is_memory_path_under(path, &config_dir.to_string_lossy())
+    }
+
+    /// Pure form of [`Self::is_memory_path`], env-free for unit testing.
+    ///
+    /// Matches a `memory/` segment rooted at an auto-memory tree — either under
+    /// the resolved `<config_dir>/projects/` (honoring a relocated
+    /// `CLAUDE_CONFIG_DIR`) or under a default `.claude/projects/` tree. A bare
+    /// `…/memory/…` no longer matches.
+    fn is_memory_path_under(path: &str, config_dir: &str) -> bool {
+        if !path.contains("/memory/") {
+            return false;
+        }
+        let projects_root = format!("{}/projects/", config_dir.trim_end_matches('/'));
+        path.starts_with(&projects_root) || path.contains("/.claude/projects/")
     }
 
     fn is_memory_md(path: &str) -> bool {
@@ -36,9 +56,13 @@ impl Check for MemoryGuard {
             return CheckResult::allow();
         }
 
-        // Try to get content from the write operation, fall back to reading the file
-        let content = match input.content() {
-            Some(c) => c.to_string(),
+        // Measure the *resulting* document, not the edit fragment (#92).
+        // effective_content() simulates Edit/MultiEdit against the on-disk file;
+        // for Write it's the content as-is. Fall back to the current on-disk
+        // file when the payload carries no editable text, and fail open (allow)
+        // when neither is available (ADR-0001).
+        let content = match input.effective_content() {
+            Some(c) => c,
             None => match std::fs::read_to_string(&path) {
                 Ok(c) => c,
                 Err(_) => return CheckResult::allow(),
@@ -251,5 +275,119 @@ mod tests {
         let input = make_input("/home/user/.claude/projects/foo/memory/debugging.md", 1000);
         let result = MemoryGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+    }
+
+    // --- #93: path anchored to the auto-memory root (pure, env-free) ---
+
+    #[test]
+    fn auto_memory_under_default_claude_matches() {
+        assert!(MemoryGuard::is_memory_path_under(
+            "/home/user/.claude/projects/foo/memory/MEMORY.md",
+            "/home/user/.claude"
+        ));
+    }
+
+    #[test]
+    fn auto_memory_under_relocated_config_dir_matches() {
+        // CLAUDE_CONFIG_DIR relocation: config dir not named ".claude".
+        assert!(MemoryGuard::is_memory_path_under(
+            "/custom/cfg/projects/foo/memory/MEMORY.md",
+            "/custom/cfg"
+        ));
+    }
+
+    #[test]
+    fn project_docs_memory_is_not_auto_memory() {
+        // #93: a real project file in a docs/memory/ dir must NOT be guarded.
+        assert!(!MemoryGuard::is_memory_path_under(
+            "/work/repo/docs/memory/MEMORY.md",
+            "/home/user/.claude"
+        ));
+    }
+
+    #[test]
+    fn project_assets_memory_topic_is_not_auto_memory() {
+        assert!(!MemoryGuard::is_memory_path_under(
+            "/work/repo/assets/memory/notes.md",
+            "/home/user/.claude"
+        ));
+    }
+
+    // --- #92: measure the resulting document, not the edit fragment ---
+
+    fn on_disk_memory(lines: usize) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let mem_dir = dir.path().join(".claude/projects/foo/memory");
+        std::fs::create_dir_all(&mem_dir).unwrap();
+        let path = mem_dir.join("MEMORY.md");
+        let body: String = (0..lines).map(|i| format!("Line {i}\n")).collect();
+        std::fs::write(&path, &body).unwrap();
+        (dir, path.to_str().unwrap().to_string())
+    }
+
+    #[test]
+    fn edit_pushing_near_limit_file_over_hard_limit_blocks() {
+        // 195-line MEMORY.md + an Edit appending 30 lines = 225 → Block.
+        // Old code measured the 30-line fragment → Allow (the bypass).
+        let (_dir, path) = on_disk_memory(195);
+        let appended: String = (0..30).map(|i| format!("New {i}\n")).collect();
+        let input = HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some(path),
+                old_string: Some("Line 194\n".into()),
+                new_string: Some(format!("Line 194\n{appended}")),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            MemoryGuard.run(&input).outcome,
+            cadence_hooks_core::Outcome::Block
+        );
+    }
+
+    #[test]
+    fn small_edit_to_small_memory_file_allowed() {
+        let (_dir, path) = on_disk_memory(50);
+        let input = HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some(path),
+                old_string: Some("Line 0\n".into()),
+                new_string: Some("Line 0 edited\n".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            MemoryGuard.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn multi_edit_pushing_file_over_hard_limit_blocks() {
+        // content() is None for MultiEdit → old code measured the PRE-edit file
+        // (195 → Allow). effective_content() simulates edits[] → Block.
+        let (_dir, path) = on_disk_memory(195);
+        let grown: String = (0..35).map(|i| format!("Grown {i}\n")).collect();
+        let input = HookInput {
+            tool_name: Some("MultiEdit".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some(path),
+                edits: Some(vec![cadence_hooks_core::EditOperation {
+                    old_string: Some("Line 100\n".into()),
+                    new_string: Some(grown),
+                    replace_all: None,
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            MemoryGuard.run(&input).outcome,
+            cadence_hooks_core::Outcome::Block
+        );
     }
 }

--- a/crates/cadence/src/memory_guard.rs
+++ b/crates/cadence/src/memory_guard.rs
@@ -32,12 +32,28 @@ impl MemoryGuard {
     /// `…/memory/…`, or a `memory/` nested deeper in the slug's subtree
     /// (`projects/<slug>/docs/memory/…`), no longer matches (#93).
     fn is_memory_path_under(path: &str, config_dir: &str) -> bool {
-        let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
-        let config_components: Vec<&str> = config_dir
-            .trim_end_matches('/')
-            .split('/')
-            .filter(|c| !c.is_empty())
-            .collect();
+        // Normalize before component matching: resolve `.`/`..` and `\` so a
+        // traversal-addressed path (`projects/foo/docs/../memory/MEMORY.md`,
+        // which resolves to `projects/foo/memory/MEMORY.md`) can't slip past the
+        // anchor by presenting `docs` where `memory` should be. The prior loose
+        // `contains("/memory/")` matched such paths incidentally; the anchor
+        // must not regress that coverage.
+        fn normalized_components(raw: &str) -> Vec<String> {
+            let mut out: Vec<String> = Vec::new();
+            for component in raw.replace('\\', "/").split('/') {
+                match component {
+                    "" | "." => {}
+                    ".." if out.last().is_some_and(|last| last != "..") => {
+                        out.pop();
+                    }
+                    value => out.push(value.to_owned()),
+                }
+            }
+            out
+        }
+
+        let components = normalized_components(path);
+        let config_components = normalized_components(config_dir);
 
         // Rooted at <config_dir>/projects/<slug>/memory/<file> — honors a
         // relocated CLAUDE_CONFIG_DIR whose dir isn't named ".claude".
@@ -343,6 +359,17 @@ mod tests {
         ));
         assert!(!MemoryGuard::is_memory_path_under(
             "/home/user/.claude/projects/foo/docs/memory/MEMORY.md",
+            "/home/user/.claude"
+        ));
+    }
+
+    #[test]
+    fn auto_memory_with_dot_dot_components_still_matches() {
+        // A traversal-addressed auto-memory path resolves back to
+        // projects/<slug>/memory/ and must still be guarded — the anchor must
+        // not let `..` smuggle the real MEMORY.md past the hard limit.
+        assert!(MemoryGuard::is_memory_path_under(
+            "/home/user/.claude/projects/foo/docs/../memory/MEMORY.md",
             "/home/user/.claude"
         ));
     }

--- a/crates/cadence/src/memory_guard.rs
+++ b/crates/cadence/src/memory_guard.rs
@@ -25,16 +25,35 @@ impl MemoryGuard {
 
     /// Pure form of [`Self::is_memory_path`], env-free for unit testing.
     ///
-    /// Matches a `memory/` segment rooted at an auto-memory tree — either under
-    /// the resolved `<config_dir>/projects/` (honoring a relocated
-    /// `CLAUDE_CONFIG_DIR`) or under a default `.claude/projects/` tree. A bare
-    /// `…/memory/…` no longer matches.
+    /// Auto-memory lives at `<root>/projects/<slug>/memory/<file>`, so `memory`
+    /// must sit *directly* under a single slug under `projects` — rooted at
+    /// either the resolved `<config_dir>/projects/` (honoring a relocated
+    /// `CLAUDE_CONFIG_DIR`) or a default `.claude/projects/` tree. A bare
+    /// `…/memory/…`, or a `memory/` nested deeper in the slug's subtree
+    /// (`projects/<slug>/docs/memory/…`), no longer matches (#93).
     fn is_memory_path_under(path: &str, config_dir: &str) -> bool {
-        if !path.contains("/memory/") {
-            return false;
+        let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
+        let config_components: Vec<&str> = config_dir
+            .trim_end_matches('/')
+            .split('/')
+            .filter(|c| !c.is_empty())
+            .collect();
+
+        // Rooted at <config_dir>/projects/<slug>/memory/<file> — honors a
+        // relocated CLAUDE_CONFIG_DIR whose dir isn't named ".claude".
+        if let Some(rest) = components.strip_prefix(config_components.as_slice())
+            && rest.len() >= 4
+            && rest[0] == "projects"
+            && rest[2] == "memory"
+        {
+            return true;
         }
-        let projects_root = format!("{}/projects/", config_dir.trim_end_matches('/'));
-        path.starts_with(&projects_root) || path.contains("/.claude/projects/")
+
+        // Rooted at a default `.claude/projects/<slug>/memory/` anywhere in the
+        // path: window of [.claude, projects, <slug>, memory].
+        components
+            .windows(4)
+            .any(|w| w[0] == ".claude" && w[1] == "projects" && w[3] == "memory")
     }
 
     fn is_memory_md(path: &str) -> bool {
@@ -309,6 +328,21 @@ mod tests {
     fn project_assets_memory_topic_is_not_auto_memory() {
         assert!(!MemoryGuard::is_memory_path_under(
             "/work/repo/assets/memory/notes.md",
+            "/home/user/.claude"
+        ));
+    }
+
+    #[test]
+    fn memory_nested_under_slug_subtree_is_not_auto_memory() {
+        // #93 (CodeRabbit): a `memory/` nested *inside* the projects tree but
+        // below an extra subdir (docs/, assets/) is NOT auto-memory — `memory`
+        // must sit directly under the slug. Both roots must reject it.
+        assert!(!MemoryGuard::is_memory_path_under(
+            "/custom/cfg/projects/foo/docs/memory/MEMORY.md",
+            "/custom/cfg"
+        ));
+        assert!(!MemoryGuard::is_memory_path_under(
+            "/home/user/.claude/projects/foo/docs/memory/MEMORY.md",
             "/home/user/.claude"
         ));
     }

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -147,7 +147,9 @@ fn bash_leaks_secrets(command: &str) -> Option<CheckResult> {
     // Warn: echo/printf of secret env vars. Compare lowercased on both sides so
     // a lowercase var (`echo $database_password`) nudges too — the prior
     // uppercase-literal match against the original-case command missed it (#85).
-    if (lower.contains("echo") || lower.contains("printf"))
+    // Match echo/printf at command position (not substring) so a benign arg or
+    // path containing "echo"/"printf" (`cat ./echoes.log`) doesn't over-fire.
+    if (is_executed_command(&lower, &["echo"]) || is_executed_command(&lower, &["printf"]))
         && ["key", "secret", "token", "password", "credential", "auth"]
             .iter()
             .any(|s| lower.contains(s))

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -144,11 +144,13 @@ fn bash_leaks_secrets(command: &str) -> Option<CheckResult> {
         }
     }
 
-    // Warn: echo/printf of secret env vars
+    // Warn: echo/printf of secret env vars. Compare lowercased on both sides so
+    // a lowercase var (`echo $database_password`) nudges too — the prior
+    // uppercase-literal match against the original-case command missed it (#85).
     if (lower.contains("echo") || lower.contains("printf"))
-        && ["KEY", "SECRET", "TOKEN", "PASSWORD", "CREDENTIAL", "AUTH"]
+        && ["key", "secret", "token", "password", "credential", "auth"]
             .iter()
-            .any(|s| command.contains(s))
+            .any(|s| lower.contains(s))
     {
         return Some(CheckResult::nudge(
             "⚠️  Command may print a secret environment variable. \
@@ -1341,6 +1343,19 @@ mod tests {
         // No dangerous env token among find's args.
         let result =
             SecretLeaksGuard.run(&make_bash_input("find . -name '*.log' -exec cat {} \\;"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn bash_echo_lowercase_password_warned() {
+        // #85: a lowercase var must nudge too (the old uppercase-literal match missed it).
+        let result = SecretLeaksGuard.run(&make_bash_input("echo $database_password"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+    }
+
+    #[test]
+    fn bash_echo_plain_text_allowed() {
+        let result = SecretLeaksGuard.run(&make_bash_input("echo hello world"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
     }
 }

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -114,13 +114,41 @@ pub fn check_terminology(content: &str) -> TerminologyResult {
     TerminologyResult { blocks, nudges }
 }
 
-/// Paths that legitimately contain prohibited terms (hook source, test fixtures).
+/// Paths that legitimately contain prohibited terms: this repo's own source,
+/// hook scripts, rules files, and CLAUDE.md docs.
+///
+/// Anchored to `/`-split path *components*, not bare substrings. The old
+/// `path.contains("cadence-hooks/")` (and the `.claude/hooks|rules` and
+/// `ends_with("claude.md")` arms) handed a terminology free pass to any path
+/// that merely *contained* the fragment — an unrelated sibling repo
+/// (`legacy-cadence-hooks/`), a scratch dir, or a spoofed segment
+/// (`x.claude/hooks/`, `evilclaude.md`) — trivially self-grantable (#91).
+/// Component matching closes those over-matches. A directory whose component is
+/// exactly `cadence-hooks` is still exempt by design: the exemption is
+/// whole-repo (repro scripts, fixtures, docs all legitimately carry the
+/// literals), and the guard has no ground truth for the real checkout's root.
 fn is_excluded_path(path: &str) -> bool {
-    let lower = path.to_lowercase();
-    lower.ends_with("claude.md")
-        || path.contains("cadence-hooks/")
-        || path.contains(".claude/hooks/")
-        || path.contains(".claude/rules/")
+    let components: Vec<&str> = path.split('/').filter(|c| !c.is_empty()).collect();
+
+    // CLAUDE.md (any case) — basename only, so `evilclaude.md` does not match.
+    if components
+        .last()
+        .is_some_and(|name| name.eq_ignore_ascii_case("claude.md"))
+    {
+        return true;
+    }
+
+    // A directory component named exactly `cadence-hooks` (this repo's source).
+    // `legacy-cadence-hooks` and other decorated names no longer match.
+    if components.contains(&"cadence-hooks") {
+        return true;
+    }
+
+    // Consecutive `.claude` then `hooks`/`rules` components, so `x.claude/hooks`
+    // and `foo.claude/rules` (non-boundary, decorated) do not match.
+    components
+        .windows(2)
+        .any(|w| w[0] == ".claude" && (w[1] == "hooks" || w[1] == "rules"))
 }
 
 /// Remove violations that were already present in pre-existing content.
@@ -342,6 +370,64 @@ mod tests {
             "/home/dev/.claude/hooks/enforcement/foo.sh"
         ));
         assert!(!is_excluded_path("/project/src/main.rs"));
+    }
+
+    // --- #91: component-anchored exclusion (no substring free pass) ---
+
+    #[test]
+    fn sibling_repo_substring_not_excluded() {
+        // `legacy-cadence-hooks` contains the substring but is not a component.
+        assert!(!is_excluded_path("/home/dev/legacy-cadence-hooks/notes.md"));
+    }
+
+    #[test]
+    fn spoofed_claude_hooks_segment_not_excluded() {
+        assert!(!is_excluded_path("/tmp/x.claude/hooks/y.md"));
+        assert!(!is_excluded_path("/tmp/foo.claude/rules/y.md"));
+    }
+
+    #[test]
+    fn evilclaude_basename_not_excluded() {
+        assert!(!is_excluded_path("/tmp/evilclaude.md"));
+    }
+
+    #[test]
+    fn claude_md_basename_still_excluded() {
+        assert!(is_excluded_path("/project/CLAUDE.md"));
+        assert!(is_excluded_path("/project/sub/claude.md")); // case-insensitive
+    }
+
+    #[test]
+    fn this_repo_source_still_excluded() {
+        assert!(is_excluded_path(
+            "/Users/x/Projects/cadence-hooks/crates/cadence/src/foo.rs"
+        ));
+        assert!(is_excluded_path("/home/dev/.claude/hooks/enforcement/x.sh"));
+        assert!(is_excluded_path("/home/dev/.claude/rules/terminology.md"));
+    }
+
+    #[test]
+    fn cadence_hooks_component_still_exempt_by_design() {
+        // Documented residual: a dir named exactly `cadence-hooks` is whole-repo
+        // exempt; closing this needs repo-root resolution (#91).
+        assert!(is_excluded_path("/tmp/cadence-hooks/x.md"));
+    }
+
+    #[test]
+    fn run_blocks_violation_in_sibling_repo() {
+        let input = HookInput {
+            tool_name: Some("Write".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some("/home/dev/legacy-cadence-hooks/notes.md".into()),
+                content: Some(BLOCK_VIOLATIONS[0].0.to_string()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            TerminologyGuard.run(&input).outcome,
+            cadence_hooks_core::Outcome::Block
+        );
     }
 
     #[test]

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -24,6 +24,20 @@ static WRITE_ACTIONS: LazyLock<Regex> = LazyLock::new(|| {
     ).expect("pattern should compile")
 });
 
+/// Write subcommands whose noun is absent from [`WRITE_ACTIONS`]' noun group,
+/// or whose verb is absent from its shared verb group. Kept SEPARATE (with `\b`
+/// anchors) so the new verbs don't leak across the shared alternation — notably
+/// so `clone` here never makes `gh repo clone` (a local read) look like a write
+/// (#87). `gh ruleset` is read-only in gh (rulesets are written via `gh api`,
+/// already covered); account-level `gh ssh-key`/`gpg-key` and `--owner`-scoped
+/// `gh project` are deliberately excluded (no `-R` → would mis-target cwd).
+static WRITE_ACTIONS_EXTRA: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(
+        r"gh\s+(secret|variable)\s+(set|delete)\b|gh\s+release\s+upload\b|gh\s+label\s+clone\b",
+    )
+    .expect("pattern should compile")
+});
+
 static API_WRITE_METHOD: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"gh\s+api.*(-X|--method)\s+(?i)(POST|PUT|PATCH|DELETE)")
         .expect("pattern should compile")
@@ -58,6 +72,7 @@ static REPO_FORK_COMMAND: LazyLock<Regex> =
 
 fn is_write_command(command: &str) -> bool {
     WRITE_ACTIONS.is_match(command)
+        || WRITE_ACTIONS_EXTRA.is_match(command)
         || API_WRITE_METHOD.is_match(command)
         || API_FIELD_FLAGS.is_match(command)
         || API_INPUT_FLAG.is_match(command)
@@ -1156,6 +1171,57 @@ mod tests {
         assert!(is_write_command("gh repo rename new-name"));
     }
 
+    // --- #87: write-verb/noun coverage gap ---
+    #[test]
+    fn release_upload_is_write() {
+        assert!(is_write_command("gh release upload v1.0.0 dist.zip"));
+    }
+    #[test]
+    fn release_delete_asset_is_write() {
+        assert!(is_write_command("gh release delete-asset v1.0.0 dist.zip"));
+    }
+    #[test]
+    fn secret_set_is_write() {
+        assert!(is_write_command("gh secret set TOKEN"));
+    }
+    #[test]
+    fn secret_delete_is_write() {
+        assert!(is_write_command("gh secret delete TOKEN"));
+    }
+    #[test]
+    fn variable_set_is_write() {
+        assert!(is_write_command("gh variable set NAME --body v"));
+    }
+    #[test]
+    fn variable_delete_is_write() {
+        assert!(is_write_command("gh variable delete NAME"));
+    }
+    #[test]
+    fn label_clone_is_write() {
+        assert!(is_write_command("gh label clone source/repo"));
+    }
+    #[test]
+    fn secret_list_is_not_write() {
+        assert!(!is_write_command("gh secret list"));
+    }
+    #[test]
+    fn variable_get_is_not_write() {
+        assert!(!is_write_command("gh variable get NAME"));
+    }
+    #[test]
+    fn variable_list_is_not_write() {
+        assert!(!is_write_command("gh variable list"));
+    }
+    #[test]
+    fn release_download_is_not_write() {
+        assert!(!is_write_command("gh release download v1.0.0"));
+    }
+    #[test]
+    fn repo_clone_is_not_write() {
+        // Regression: shared-verb bleed — `clone` must not flag the local read.
+        assert!(!is_write_command("gh repo clone cameronsjo/cadence-hooks"));
+    }
+
     #[test]
     fn release_delete_is_write() {
         assert!(is_write_command("gh release delete v1.0.0"));
@@ -1975,6 +2041,31 @@ mod tests {
             let result = GhWriteGuard.run(&input);
             let meta = result.block_metadata.expect("structured block");
             assert_eq!(meta.rule_id, "gh-write-api-unverifiable");
+        });
+    }
+
+    #[test]
+    fn release_upload_unowned_target_blocks() {
+        // #87: a newly-covered write to a non-owned repo is now ownership-checked.
+        with_env(&owners_env(), || {
+            let input = input_with("gh release upload v1 x.zip -R evil/unowned", "/tmp");
+            let result = GhWriteGuard.run(&input);
+            assert!(matches!(result.outcome, cadence_hooks_core::Outcome::Block));
+            assert_eq!(
+                result.block_metadata.unwrap().rule_id,
+                "gh-write-unauthorized-target"
+            );
+        });
+    }
+
+    #[test]
+    fn secret_set_owned_target_allows() {
+        with_env(&owners_env(), || {
+            let input = input_with("gh secret set TOKEN -R cameronsjo/x", "/tmp");
+            assert!(matches!(
+                GhWriteGuard.run(&input).outcome,
+                cadence_hooks_core::Outcome::Allow
+            ));
         });
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,6 +23,22 @@ mod registry;
 mod try_hook;
 use registry::{HOOKS, HookEntry};
 
+/// Guards that prevent irreversible harm — secret exposure, data loss,
+/// destructive git/gh/remote/vault operations. `CADENCE_DISABLE` (silent,
+/// persistent, settable in settings.json `env`) must not be able to neuter
+/// these; only the loud, per-session `CADENCE_BYPASS` can (#89).
+const PROTECTED_GUARDS: &[&str] = &[
+    "prevent-secret-leaks",
+    "prevent-secret-writes",
+    "git-safety",
+    "guard-push-remote",
+    "guard-gh-dangerous",
+    "guard-gh-write",
+    "guard-op-vault-scan",
+    "guard-browser-device",
+    "trash-guard",
+];
+
 #[derive(Parser)]
 #[command(
     name = "cadence-hooks",
@@ -346,8 +362,16 @@ fn print_hook_list() {
             current_plugin = hook.plugin;
         }
 
-        let status = if bypassed || disabled.contains(&hook.name) {
+        let status = if bypassed {
             " (disabled)"
+        } else if disabled.contains(&hook.name) {
+            // A protected guard named in CADENCE_DISABLE is refused, not
+            // disabled — don't let the listing claim it's off (#89).
+            if PROTECTED_GUARDS.contains(&hook.name) {
+                " (protected — disable refused)"
+            } else {
+                " (disabled)"
+            }
         } else {
             ""
         };
@@ -465,13 +489,25 @@ fn main() {
     };
 
     // Selective disable — skip specific hooks by name via CADENCE_DISABLE.
-    // Comma-separated list of hook names (e.g., "git-safety,warn-main-branch").
+    // Comma-separated list of hook names (e.g., "warn-main-branch,line-endings").
     // Set per-project in .claude/settings.json `env` block, or ad-hoc in shell.
+    // Emits a one-line stderr notice whenever it disables (or refuses to
+    // disable) a hook, so suppression always leaves a trace (#89).
     if let Ok(disabled) = std::env::var("CADENCE_DISABLE")
         && let Some(name) = hook_name(&cli.command)
         && disabled.split(',').any(|h| h.trim() == name)
     {
-        process::exit(0);
+        if PROTECTED_GUARDS.contains(&name) {
+            // Refuse: the guard still runs (fall through to dispatch).
+            eprintln!(
+                "⚠️  cadence-hooks: refusing to disable protected guard '{name}' \
+                 via CADENCE_DISABLE (it still runs). Use CADENCE_BYPASS=1 for a \
+                 one-session maintenance bypass."
+            );
+        } else {
+            eprintln!("⚠️  cadence-hooks: '{name}' disabled via CADENCE_DISABLE");
+            process::exit(0);
+        }
     }
 
     // Event type aliases for readability at callsites.

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,6 +36,7 @@ const PROTECTED_GUARDS: &[&str] = &[
     "guard-gh-write",
     "guard-op-vault-scan",
     "guard-browser-device",
+    "guard-dotfiles",
     "trash-guard",
 ];
 

--- a/tests/selective_disable.rs
+++ b/tests/selective_disable.rs
@@ -204,13 +204,27 @@ fn guardrails_hook_can_be_disabled() {
 #[test]
 fn obsidian_trash_guard_disable_refused() {
     // trash-guard is a protected (data-loss) guard: CADENCE_DISABLE must NOT
-    // silently neuter it. It still runs, and the refusal is announced on stderr
-    // (#89). (Was `obsidian_hook_can_be_disabled`, asserting silent disable.)
+    // silently neuter it. Feed a vault-targeting `rm` and assert it STILL blocks
+    // (exit 2) despite the disable — proving the guard actually engaged, not
+    // merely that it didn't short-circuit (#89). (An exit-code-1 check on an
+    // empty-stdin invocation can't catch a silent-disable regression: the guard
+    // fails open to exit 0 on EOF per ADR-0001, same code a "disabled" path
+    // would return. A real payload + exit-2 is the unambiguous proof it ran.)
+    // (Was `obsidian_hook_can_be_disabled`, asserting silent disable.)
     let mut cmd = cadence_hooks();
     cmd.args(["obsidian", "trash-guard"]);
     cmd.env("CADENCE_DISABLE", "trash-guard");
-
-    let output = cmd.output().expect("failed to execute binary");
+    cmd.env("OBSIDIAN_VAULT", "/vault");
+    let output = run_with_stdin(
+        cmd,
+        r#"{"tool_name":"Bash","tool_input":{"command":"rm /vault/notes/todo.md"}}"#,
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "protected trash-guard must still block a vault rm despite CADENCE_DISABLE.\nstderr: {}",
+        String::from_utf8_lossy(&output.stderr)
+    );
 
     let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(

--- a/tests/selective_disable.rs
+++ b/tests/selective_disable.rs
@@ -55,10 +55,15 @@ fn disabled_hook_exits_zero() {
 }
 
 #[test]
-fn disabled_hook_produces_no_output() {
+fn disabled_advisory_hook_exits_zero_with_notice() {
+    // An advisory (non-protected) hook disabled via CADENCE_DISABLE exits 0
+    // before reading stdin and produces no stdout — but now leaves a one-line
+    // stderr notice so the suppression is always traceable (#89). (Was
+    // `disabled_hook_produces_no_output`, which asserted silent disable of the
+    // protected git-safety guard — the bug #89 fixes.)
     let mut cmd = cadence_hooks();
-    cmd.args(["cadence", "git-safety"]);
-    cmd.env("CADENCE_DISABLE", "git-safety");
+    cmd.args(["cadence", "line-endings"]);
+    cmd.env("CADENCE_DISABLE", "line-endings");
 
     let output = cmd.output().expect("failed to execute binary");
 
@@ -67,17 +72,19 @@ fn disabled_hook_produces_no_output() {
         output.stdout.is_empty(),
         "disabled hook should produce no stdout"
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
     assert!(
-        output.stderr.is_empty(),
-        "disabled hook should produce no stderr"
+        stderr.contains("disabled via CADENCE_DISABLE"),
+        "disabling an advisory hook must leave a trace: {stderr}"
     );
 }
 
 #[test]
 fn comma_separated_list_disables_multiple() {
+    // line-endings is advisory (not protected), so it actually disables.
     let mut cmd = cadence_hooks();
-    cmd.args(["cadence", "git-safety"]);
-    cmd.env("CADENCE_DISABLE", "terminology,git-safety,line-endings");
+    cmd.args(["cadence", "line-endings"]);
+    cmd.env("CADENCE_DISABLE", "terminology,line-endings,orphaned-todos");
 
     let output = cmd.output().expect("failed to execute binary");
 
@@ -91,8 +98,11 @@ fn comma_separated_list_disables_multiple() {
 #[test]
 fn spaces_around_commas_tolerated() {
     let mut cmd = cadence_hooks();
-    cmd.args(["cadence", "git-safety"]);
-    cmd.env("CADENCE_DISABLE", "terminology , git-safety , line-endings");
+    cmd.args(["cadence", "line-endings"]);
+    cmd.env(
+        "CADENCE_DISABLE",
+        "terminology , line-endings , orphaned-todos",
+    );
 
     let output = cmd.output().expect("failed to execute binary");
 
@@ -192,18 +202,44 @@ fn guardrails_hook_can_be_disabled() {
 }
 
 #[test]
-fn obsidian_hook_can_be_disabled() {
+fn obsidian_trash_guard_disable_refused() {
+    // trash-guard is a protected (data-loss) guard: CADENCE_DISABLE must NOT
+    // silently neuter it. It still runs, and the refusal is announced on stderr
+    // (#89). (Was `obsidian_hook_can_be_disabled`, asserting silent disable.)
     let mut cmd = cadence_hooks();
     cmd.args(["obsidian", "trash-guard"]);
     cmd.env("CADENCE_DISABLE", "trash-guard");
 
     let output = cmd.output().expect("failed to execute binary");
 
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("refusing to disable protected guard"),
+        "protected guard disable must be refused with a notice: {stderr}"
+    );
+    assert!(stderr.contains("trash-guard"));
+}
+
+#[test]
+fn protected_guard_cannot_be_disabled_via_cadence_disable() {
+    // git-safety is protected: naming it in CADENCE_DISABLE must NOT skip it.
+    // Feed the dangerous payload and assert it STILL blocks (exit 2) — proving
+    // the guard actually engaged, not merely that it didn't short-circuit (#89).
+    let mut cmd = cadence_hooks();
+    cmd.args(["cadence", "git-safety"]);
+    cmd.env("CADENCE_DISABLE", "git-safety");
+    let output = run_with_stdin(
+        cmd,
+        r#"{"tool_name":"Bash","tool_input":{"command":"git reset --hard HEAD~3"}}"#,
+    );
     assert_eq!(
         output.status.code(),
-        Some(0),
-        "obsidian hook should be disableable too"
+        Some(2),
+        "protected git-safety must still block despite CADENCE_DISABLE"
     );
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("refusing to disable protected guard"));
+    assert!(stderr.contains("git-safety"));
 }
 
 #[test]
@@ -266,14 +302,25 @@ fn list_shows_disabled_status() {
     let output = cmd.output().expect("failed to execute binary");
     let stdout = String::from_utf8_lossy(&output.stdout);
 
-    // Disabled hooks should be marked
+    // git-safety is protected: the listing must show the refusal, not claim
+    // it's disabled (#89).
     let git_safety_line = stdout.lines().find(|l| l.contains("git-safety")).unwrap();
     assert!(
-        git_safety_line.contains("(disabled)"),
-        "disabled hook should be marked: {git_safety_line}"
+        git_safety_line.contains("(protected — disable refused)"),
+        "protected hook in disable list should show refusal: {git_safety_line}"
     );
 
-    // Non-disabled hooks should not be marked
+    // An advisory hook in the disable list is marked disabled.
+    let warn_line = stdout
+        .lines()
+        .find(|l| l.contains("warn-main-branch"))
+        .unwrap();
+    assert!(
+        warn_line.contains("(disabled)"),
+        "advisory disabled hook should be marked: {warn_line}"
+    );
+
+    // Non-disabled hooks should not be marked.
     let terminology_line = stdout.lines().find(|l| l.contains("terminology")).unwrap();
     assert!(
         !terminology_line.contains("(disabled)"),


### PR DESCRIPTION
## What

Six P2 guard-correctness bugs (plus part of a seventh), each verified to reproduce against current `main` before fixing. Two themes: **coverage gaps** (a dangerous op reached no guard) and **over-match/bypass** (a guard over-fired on benign input or under-fired on its target).

| Issue | Fix |
|---|---|
| #84 | git-safety blocks `filter-branch`/`filter-repo`, `update-ref` delete/repoint of a protected ref, and `push --mirror`; non-protected `update-ref -d` nudges |
| #87 | guard-gh-write covers `release upload`, `secret`/`variable set`, `label clone` via a **separate anchored** regex (so `clone` can't flag the `gh repo clone` read) |
| #89 | `CADENCE_DISABLE` emits a stderr notice on every disable; a **protected floor** of 10 security guards refuses to disable (still runs); the `list` view labels them |
| #91 | terminology source-exemption anchored to `/`-split **path components** (no more `legacy-cadence-hooks/` / `x.claude/hooks/` / `evilclaude.md` free pass) |
| #92, #93 | memory-guard measures the **resulting file** (`effective_content()`, closing the near-limit-Edit bypass) and anchors `/memory/` to the **auto-memory root** (no false-block on `docs/memory/`) |
| #85 *(partial)* | echo-exfil nudge keywords lowercased (catches `echo $database_password`). The secret-**value content scanner** — the rest of #85 — ships in a separate PR. |

Issue-body corrections surfaced by verification: `gh ruleset` is read-only (dropped); account-level `ssh-key`/`gpg-key` excluded (no `-R`); the naive find-first-non-flag operand scan needed `-m`-skip (see review below).

## Verification

- 1971 workspace tests pass; `cargo fmt --check` and `cargo clippy --workspace --all-targets -- -D warnings` clean.
- **Adversarial security review (Opus)** on the diff found one verified bypass + a residual, both fixed in this PR:
  - **H1** — `git update-ref -m <reason> refs/heads/main <sha>` silently repointed a protected branch (the `-m` value is a non-flag token, so the operand scan grabbed the reason). Fixed: skip `-m`/`--message`'s value.
  - **M1** — `update-ref --stdin` (refs invisible) → now nudged, not silently allowed.
  - **L1** — added `guard-dotfiles` to the protected floor.
  - All other changes (#87, #91, #92/#93, #85-nudge, the floor itself) confirmed sound under adversarial inputs.

> Local `make ci` also trips the two cross-sibling audit tests (`no_cross_plugin_hooks`, `all_binary_subcommands_are_registered`, unrelated to this PR). GitHub CI has no siblings and skips them; `registry_matches_clap_dispatch` passes.

Closes cameronsjo/claude-configurations#84
Closes cameronsjo/claude-configurations#87
Closes cameronsjo/claude-configurations#89
Closes cameronsjo/claude-configurations#91
Closes cameronsjo/claude-configurations#92
Closes cameronsjo/claude-configurations#93

(#85 stays open — only its echo-nudge half ships here; the content scanner is a separate PR.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added stricter protections so protected guards cannot be disabled without `CADENCE_BYPASS`.
  * Expanded guard coverage for multi-edit scenarios and improved content edit fragment assessment.

* **Bug Fixes**
  * Hardened Git safety: blocks destructive history rewrites and safeguards protected ref updates, including edge cases for `update-ref` and `git push --mirror`.
  * Improved memory guard matching (anchored, config-aware) and more accurate edit-size enforcement using the resulting document.
  * Strengthened secret-leak nudge detection for lowercase secret keywords and added allow-case coverage.
  * Tightened terminology path exemptions to prevent spoofed segment bypasses.
  * Expanded GitHub `gh` write-command detection and enforcement with new allow/block tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->