### PR TITLE
fix(metrics): atomic subagent writes, current model prices, tail-bounded scan (#94, #95, #96)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,15 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   one per `edits[]` element — that the guards fold over; terminology preserves
   its introduced-vs-existing diff (#63) per edit. Write/single-Edit behavior is
   unchanged.
+- **metrics: atomic subagent log writes, current model prices, tail-bounded
+  transcript scan** (#94, #95, #96 on claude-configurations). `log-subagent`
+  built its JSONL line with `writeln!` (many small writes that tear under
+  concurrent appends) — now one `write_all`, matching the sibling loggers.
+  `prices.json` gained `claude-opus-4-8` and `claude-fable-5` (commit cost was
+  silently `$0` for the current default models), plus an `unpricedModels` record
+  field so an unknown model is loud rather than a silent zero. `scan-tokens`
+  parsed the entire transcript on every commit; it now byte-scans past the
+  marker and only JSON-parses the tail, bounding the per-commit hot-path cost.
 
 ## [0.29.0] - 2026-06-10
 

--- a/crates/metrics/prices.json
+++ b/crates/metrics/prices.json
@@ -1,10 +1,22 @@
 {
   "_meta": {
-    "lastVerified": "2026-05-16",
+    "lastVerified": "2026-06-17",
     "source": "https://www.anthropic.com/pricing",
-    "notes": "All prices in USD per million tokens. Update lastVerified when bumping rates."
+    "notes": "All prices in USD per million tokens. input/output for opus-4-8 and fable-5 from the claude-api skill (cached 2026-06-04); cache tiers derived input*1.25 / input*0.10 per the table convention. opus-4-7/4-6 pending reconciliation (claude-configurations#127). Update lastVerified when bumping rates."
   },
   "models": {
+    "claude-opus-4-8": {
+      "inputPerMTok": 5.00,
+      "outputPerMTok": 25.00,
+      "cacheWritePerMTok": 6.25,
+      "cacheReadPerMTok": 0.50
+    },
+    "claude-fable-5": {
+      "inputPerMTok": 10.00,
+      "outputPerMTok": 50.00,
+      "cacheWritePerMTok": 12.50,
+      "cacheReadPerMTok": 1.00
+    },
     "claude-opus-4-7": {
       "inputPerMTok": 15.00,
       "outputPerMTok": 75.00,

--- a/crates/metrics/src/compute_cost.rs
+++ b/crates/metrics/src/compute_cost.rs
@@ -57,6 +57,13 @@ mod tests {
     }
 
     #[test]
+    fn one_million_input_tokens_opus_4_8() {
+        // #95: opus-4-8 is now priced ($5/MTok input), not silently $0.
+        let cost = compute_cost(&opus_tokens(), "claude-opus-4-8", &Prices::embedded());
+        assert_eq!(cost, 5.0);
+    }
+
+    #[test]
     fn mixed_tokens_sum_correctly() {
         let tokens = Tokens {
             input: 1_000_000,

--- a/crates/metrics/src/log_commit.rs
+++ b/crates/metrics/src/log_commit.rs
@@ -165,6 +165,17 @@ fn build_commit_record(
         })
         .collect();
 
+    // Models absent from the price table compute to $0 silently (#95). Record
+    // them so an unknown/unpriced model is loud in the data — a non-empty array
+    // means costUsd is understated and a reprocessing pass can recompute once
+    // the table is patched. Empty in the normal (all-priced) case.
+    let unpriced: Vec<&str> = scan
+        .by_model
+        .iter()
+        .filter(|(model, _)| prices.get(model).is_none())
+        .map(|(model, _)| model.as_str())
+        .collect();
+
     json!({
         "ts": ts,
         "sessionId": input.session_id,
@@ -182,6 +193,7 @@ fn build_commit_record(
         },
         "costUsd": cost,
         "byModel": by_model,
+        "unpricedModels": unpriced,
         "messagesScanned": scan.messages_scanned,
         "lastMessageId": scan.last_message_id,
         "sinceMarker": since_marker,
@@ -380,5 +392,61 @@ mod tests {
             .sum();
         let total = record["costUsd"].as_f64().unwrap();
         assert!((total - bucket_sum).abs() < 1e-9);
+    }
+
+    #[test]
+    fn commit_record_flags_unpriced_models() {
+        // #95: a model absent from the price table is recorded in unpricedModels
+        // so the silent $0 cost is greppable.
+        let prices = Prices::embedded();
+        let scan = ScanResult {
+            tokens: Tokens {
+                input: 100,
+                ..Default::default()
+            },
+            last_message_id: "m9".into(),
+            messages_scanned: 1,
+            model: "gpt-9".into(),
+            by_model: vec![(
+                "gpt-9".into(),
+                Tokens {
+                    input: 100,
+                    ..Default::default()
+                },
+            )],
+        };
+        let rec = build_commit_record(
+            "ts",
+            &sample_input(),
+            "a",
+            "b",
+            "main",
+            "r",
+            &scan,
+            0.0,
+            "m0",
+            &prices,
+        );
+        let unpriced = rec["unpricedModels"].as_array().unwrap();
+        assert_eq!(unpriced.len(), 1);
+        assert_eq!(unpriced[0], "gpt-9");
+    }
+
+    #[test]
+    fn commit_record_no_unpriced_for_known_model() {
+        // sample_scan() uses claude-opus-4-7, which is priced → empty array.
+        let rec = build_commit_record(
+            "ts",
+            &sample_input(),
+            "a",
+            "b",
+            "main",
+            "r",
+            &sample_scan(),
+            0.001,
+            "m1",
+            &Prices::embedded(),
+        );
+        assert!(rec["unpricedModels"].as_array().unwrap().is_empty());
     }
 }

--- a/crates/metrics/src/log_subagent.rs
+++ b/crates/metrics/src/log_subagent.rs
@@ -40,7 +40,13 @@ impl Logger for LogSubagent {
             .append(true)
             .open(dir.join("subagents.jsonl"))
         {
-            let _ = writeln!(file, "{record}");
+            // Build the whole line (record + newline) and write it in one
+            // write_all, matching log_commit.rs — a single O_APPEND write is
+            // atomic, so concurrent appends from parallel subagents can't
+            // interleave a record with its trailing newline (#94).
+            let mut line = record.to_string();
+            line.push('\n');
+            let _ = file.write_all(line.as_bytes());
         }
     }
 }
@@ -116,5 +122,13 @@ mod tests {
             ..Default::default()
         };
         LogSubagent.run(&input);
+    }
+
+    #[test]
+    fn record_serializes_to_single_line() {
+        // #94: the single-write_all fix is only atomic-per-record if the record
+        // has no embedded newline. Compact JSON guarantees this; lock it down.
+        let line = build_subagent_record(&stop_event(), "2026-05-19T00:00:00Z", true).to_string();
+        assert!(!line.contains('\n'), "record must be one line: {line}");
     }
 }

--- a/crates/metrics/src/prices.rs
+++ b/crates/metrics/src/prices.rs
@@ -84,6 +84,22 @@ mod tests {
     }
 
     #[test]
+    fn embedded_has_current_opus_and_fable() {
+        // #95: the current default models must be priced, not silently $0.
+        let prices = Prices::embedded();
+        let opus = prices
+            .get("claude-opus-4-8")
+            .expect("opus-4-8 must be priced");
+        assert_eq!(opus.input_per_mtok, 5.0);
+        assert_eq!(opus.output_per_mtok, 25.0);
+        let fable = prices
+            .get("claude-fable-5")
+            .expect("fable-5 must be priced");
+        assert_eq!(fable.input_per_mtok, 10.0);
+        assert_eq!(fable.output_per_mtok, 50.0);
+    }
+
+    #[test]
     fn unknown_model_absent() {
         let prices = Prices::embedded();
         assert!(prices.get("gpt-9").is_none());

--- a/crates/metrics/src/scan_tokens.rs
+++ b/crates/metrics/src/scan_tokens.rs
@@ -65,57 +65,76 @@ struct Usage {
 ///   predates this transcript — skip rather than overcount).
 /// - No assistant messages in range: returns `None`.
 pub fn scan_tokens(transcript: &str, from: Option<&str>) -> Option<ScanResult> {
-    let msgs: Vec<Message> = transcript
-        .lines()
-        .filter_map(|line| serde_json::from_str::<Line>(line).ok())
-        .filter_map(|line| line.message)
-        .filter(|m| m.usage.is_some() && m.id.is_some() && m.role.as_deref() == Some("assistant"))
-        .collect();
+    let marker = from.unwrap_or("");
+    // None/"" → sum from the start; otherwise accumulate only after the marker
+    // message. `started` gates accumulation; `marker_seen` distinguishes
+    // "marker found, nothing after" (→ None) from "marker never found" (→ None).
+    let mut started = marker.is_empty();
+    let mut marker_seen = started;
 
-    let start = match from {
-        None | Some("") => 0,
-        Some(marker) => {
-            let idx = msgs.iter().position(|m| m.id.as_deref() == Some(marker))?;
-            idx + 1
-        }
-    };
-
-    if msgs.len() <= start {
-        return None;
-    }
-
-    let range = &msgs[start..];
     let mut tokens = Tokens::default();
     let mut by_model: BTreeMap<String, Tokens> = BTreeMap::new();
-    for m in range {
-        if let Some(u) = &m.usage {
-            let delta_input = u.input_tokens;
-            let delta_cache_create = u.cache_creation_input_tokens;
-            let delta_cache_read = u.cache_read_input_tokens;
-            let delta_output = u.output_tokens;
+    let mut messages_scanned = 0usize;
+    let mut last_id: Option<String> = None;
+    let mut last_model: Option<String> = None;
 
-            tokens.input += delta_input;
-            tokens.cache_create += delta_cache_create;
-            tokens.cache_read += delta_cache_read;
-            tokens.output += delta_output;
-
-            let model_key = m.model.clone().unwrap_or_else(|| "unknown".to_string());
-            let bucket = by_model.entry(model_key).or_default();
-            bucket.input += delta_input;
-            bucket.cache_create += delta_cache_create;
-            bucket.cache_read += delta_cache_read;
-            bucket.output += delta_output;
+    for line in transcript.lines() {
+        // Cheap byte-scan pre-filter (#96): before the marker, only pay for a
+        // full JSON parse on a line that could BE the marker. This bounds the
+        // O(transcript) parse to the tail past the marker — the hot-path cost
+        // on every commit. A candidate is still fully parsed and accepted only
+        // when it is an assistant message with id == marker, so a content
+        // substring match never false-starts accumulation.
+        if !started && !line.contains(marker) {
+            continue;
         }
+        let Ok(parsed) = serde_json::from_str::<Line>(line) else {
+            continue;
+        };
+        let Some(m) = parsed.message else {
+            continue;
+        };
+        if m.usage.is_none() || m.id.is_none() || m.role.as_deref() != Some("assistant") {
+            continue;
+        }
+        if !started {
+            if m.id.as_deref() == from {
+                started = true;
+                marker_seen = true;
+            }
+            // The marker message itself is excluded from the sum.
+            continue;
+        }
+
+        let u = m.usage.as_ref().unwrap();
+        tokens.input += u.input_tokens;
+        tokens.cache_create += u.cache_creation_input_tokens;
+        tokens.cache_read += u.cache_read_input_tokens;
+        tokens.output += u.output_tokens;
+
+        let model_key = m.model.clone().unwrap_or_else(|| "unknown".to_string());
+        let bucket = by_model.entry(model_key.clone()).or_default();
+        bucket.input += u.input_tokens;
+        bucket.cache_create += u.cache_creation_input_tokens;
+        bucket.cache_read += u.cache_read_input_tokens;
+        bucket.output += u.output_tokens;
+
+        messages_scanned += 1;
+        last_id = m.id.clone();
+        last_model = Some(model_key);
     }
 
-    let last = range.last()?;
-    let by_model_vec: Vec<(String, Tokens)> = by_model.into_iter().collect();
+    if !marker_seen || messages_scanned == 0 {
+        // Marker predated this transcript, or nothing new since it — skip
+        // rather than overcount (mirrors the bash "emit nothing" behavior).
+        return None;
+    }
     Some(ScanResult {
         tokens,
-        last_message_id: last.id.clone()?,
-        messages_scanned: range.len(),
-        model: last.model.clone().unwrap_or_else(|| "unknown".to_string()),
-        by_model: by_model_vec,
+        last_message_id: last_id?,
+        messages_scanned,
+        model: last_model.unwrap_or_else(|| "unknown".to_string()),
+        by_model: by_model.into_iter().collect(),
     })
 }
 
@@ -240,5 +259,25 @@ mod tests {
         let (model, tokens) = &result.by_model[0];
         assert_eq!(model, "unknown");
         assert_eq!(tokens.output, 5);
+    }
+
+    #[test]
+    fn marker_substring_in_earlier_content_does_not_false_start() {
+        // #96: a user line mentions "m1" before the real m1 assistant message.
+        // The contains() pre-filter parses it but must reject it (not an
+        // assistant message with id==m1), so only m2 is summed — not m1+m2.
+        let transcript = [
+            r#"{"type":"user","message":{"role":"user","content":"continue from m1"}}"#,
+            r#"{"message":{"id":"m1","role":"assistant","model":"claude-opus-4-8","usage":{"input_tokens":10,"output_tokens":1}}}"#,
+            r#"{"message":{"id":"m2","role":"assistant","model":"claude-opus-4-8","usage":{"input_tokens":20,"output_tokens":2}}}"#,
+        ]
+        .join("\n");
+        let r = scan_tokens(&transcript, Some("m1")).unwrap();
+        assert_eq!(
+            r.tokens.input, 20,
+            "m2 only; 30 would mean a false start on m1"
+        );
+        assert_eq!(r.messages_scanned, 1);
+        assert_eq!(r.last_message_id, "m2");
     }
 }


### PR DESCRIPTION
## What

Three P2 fixes in the metrics loggers (observability — all fail-open, no enforcement impact).

| Issue | Fix |
|---|---|
| #94 | `log-subagent` built its line with `writeln!` (many small writes → torn lines under concurrent appends); now one `write_all`, matching the sibling loggers |
| #95 | `prices.json` lacked `claude-opus-4-8`/`claude-fable-5` (commit cost silently $0 for the default models); added both + an `unpricedModels` record field so an unknown model is loud, not a silent zero |
| #96 | `scan-tokens` parsed the **whole** transcript every commit (paid on commit latency); now byte-scans past the marker and parses only the tail |

Verification: 54 metrics tests pass (existing scan_tokens coverage preserved + 6 new, incl. a marker-substring false-start guard); `clippy --workspace -- -D warnings` clean.

**Scope notes:** #95 prices for opus-4-8/fable-5 come from the `claude-api` skill (input/output); cache tiers are convention-derived (`×1.25`/`×0.10`) — flagged in `_meta`. The existing opus-4-7/4-6 entries ($15/$75) disagree 3× with the skill ($5/$25) and may be logging costs ~3× high — tracked separately as #127 (reinterprets historical data; needs an authoritative price confirmation).

> The CHANGELOG `[Unreleased]` entry will conflict trivially with PR #102 (both append bullets); resolution is union-of-bullets.

Closes cameronsjo/claude-configurations#94
Closes cameronsjo/claude-configurations#95
Closes cameronsjo/claude-configurations#96

🤖 Generated with [Claude Code](https://claude.com/claude-code)