### PR TITLE
feat(session): deregister on SessionEnd so ended sessions stop lingering as peers (#97)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,19 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `.env.example` is still caught. JWTs and generic high-entropy strings are
   deliberately not matched (unbounded false positives); only this repo's own
   source is exempt (its test fixtures carry secret-shaped literals).
+- **session: deregister on SessionEnd so ended sessions stop lingering as
+  phantom peers** (#97 on claude-configurations). Liveness was mtime-only with
+  no deregistration ceremony, so an ended session (`/clear`, exit, logout)
+  lingered in `.claude/sessions/` until the next `session start` swept it by age
+  (up to 30 min) — and the next session's SessionStart disclosure listed the
+  dead session as a live peer. A new `session end` fire-and-forget Logger
+  (wired to the SessionEnd event in cadence-canon) removes the session's own
+  registry file via `registry::remove_own`. It gates strictly on
+  `hook_event_name == "SessionEnd"` (a delete must never fire on another event)
+  and removes only the record whose stored `session_id` matches exactly
+  (content-verified via the #90-hardened `find_own`), so it can never delete a
+  peer's lane. `HookEvent` has no `SessionEnd` variant, so it is modelled as a
+  Logger (`event: None`) like `heartbeat` — no enum change.
 
 ### Fixed
 

--- a/crates/session/src/end.rs
+++ b/crates/session/src/end.rs
@@ -1,0 +1,124 @@
+//! `session end` — SessionEnd logger.
+//!
+//! Deregisters this session from the repo registry when it ends (`/clear`,
+//! exit, logout), so it stops appearing as a live peer immediately rather than
+//! lingering until the next `session start` sweeps it by age (#97). Liveness
+//! is otherwise mtime-only, so without this an ended session is disclosed as a
+//! phantom peer for up to the staleness window.
+//!
+//! `HookEvent` has no `SessionEnd` variant, so this is modelled as a
+//! fire-and-forget [`Logger`] (like `heartbeat`) that reacts to
+//! `hook_event_name` in the payload. Never blocks, never errors (ADR-0001).
+
+use crate::identity;
+use crate::registry;
+use cadence_hooks_core::{Logger, MetricsInput};
+
+/// Remove this session's registry file on SessionEnd.
+pub struct End;
+
+impl Logger for End {
+    fn name(&self) -> &str {
+        "end"
+    }
+
+    fn run(&self, input: &MetricsInput) {
+        let Some(sid) = input
+            .session_id
+            .as_deref()
+            .filter(|s| identity::is_safe_session_id(s))
+        else {
+            return;
+        };
+        let Some(cwd) = input.cwd.as_deref() else {
+            return;
+        };
+        let Some(dir) = registry::sessions_dir(cwd) else {
+            return;
+        };
+        run_end(input.hook_event_name.as_deref(), &dir, sid);
+    }
+}
+
+/// Testable core: deregister `session_id` from `dir`, but ONLY on SessionEnd.
+/// The registry path is injected so tests can target a tempdir without a git
+/// repository.
+///
+/// The event gate lives here, not just in the hooks.json wiring, because this
+/// DELETES the session's lane: a misrouted wiring on any other event must never
+/// reach `remove_own`, or a live session would erase its own record on, say,
+/// its first PostToolUse.
+///
+/// Deregistering on *every* SessionEnd reason is deliberate, and reconciles with
+/// the #69 re-registration-preserves-lane fix in [`crate::start`]: empirically
+/// (verified 2026-06-17), `/clear` and `/compact` mint a NEW session_id and fire
+/// SessionEnd for the *old* id — so deregistering the old id removes a genuine
+/// phantom, and the successor session registers fresh under its own id. #69's
+/// same-session_id re-registration path is therefore the *resume* path
+/// (`--resume`/`--continue` reusing an id after an exit), not the `/clear` path.
+/// We do NOT gate on the `reason` field: the only id-reusing case is resume, and
+/// there the lost `intent`/`touching` are best-effort and self-heal on the next
+/// heartbeat (`touch_own` rebuilds the record) — a bounded, transient
+/// degradation, not the lane loss #69 fixed. (Compaction uses the separate
+/// `PreCompact` hook, not SessionEnd, so a live session never self-deregisters
+/// mid-work.) Revisiting the resume case is tracked as claude-configurations#136.
+pub fn run_end(hook_event_name: Option<&str>, dir: &std::path::Path, session_id: &str) {
+    if hook_event_name != Some("SessionEnd") {
+        return;
+    }
+    let _ = registry::remove_own(dir, session_id);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::identity::SessionRecord;
+    use tempfile::TempDir;
+
+    fn record(name: &str, session_id: &str) -> SessionRecord {
+        SessionRecord {
+            name: name.into(),
+            session_id: session_id.into(),
+            branch: Some("main".into()),
+            declared_branch: Some("main".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn run_end_on_session_end_removes_lane() {
+        let tmp = TempDir::new().unwrap();
+        registry::write_record(tmp.path(), &record("quiet-loom", "self-session")).unwrap();
+        run_end(Some("SessionEnd"), tmp.path(), "self-session");
+        assert!(
+            registry::find_own(tmp.path(), "self-session").is_none(),
+            "SessionEnd deregisters the session's lane"
+        );
+    }
+
+    #[test]
+    fn run_end_ignores_non_session_end_event() {
+        // The gate is the whole point: this logger DELETES the lane, so a
+        // misrouted wiring on any other event (here PostToolUse) must NOT
+        // reach remove_own — else a live session erases its own record on its
+        // first tool call.
+        let tmp = TempDir::new().unwrap();
+        registry::write_record(tmp.path(), &record("quiet-loom", "self-session")).unwrap();
+        run_end(Some("PostToolUse"), tmp.path(), "self-session");
+        assert!(
+            registry::find_own(tmp.path(), "self-session").is_some(),
+            "a non-SessionEnd event must NOT deregister the live session"
+        );
+    }
+
+    #[test]
+    fn run_end_ignores_missing_event() {
+        let tmp = TempDir::new().unwrap();
+        registry::write_record(tmp.path(), &record("quiet-loom", "self-session")).unwrap();
+        run_end(None, tmp.path(), "self-session");
+        assert!(
+            registry::find_own(tmp.path(), "self-session").is_some(),
+            "an absent hook_event_name must NOT deregister the session"
+        );
+    }
+}

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -25,11 +25,14 @@
 //! | `warn-branch-drift` | PreToolUse   | [`branch_drift`]|
 //! | `declare`           | CLI action   | [`cli`]         |
 //! | `status`            | CLI action   | [`cli`]         |
+//! | `end`               | SessionEnd   | [`end`]         |
 
 /// PreToolUse commit-time branch-drift warning — never blocks.
 pub mod branch_drift;
 /// CLI actions: `declare` (lane declaration) and `status` (registry listing).
 pub mod cli;
+/// SessionEnd logger: deregister this session's registry file (#97).
+pub mod end;
 /// PreToolUse lane warnings — never blocks.
 pub mod guard;
 /// PostToolUse heartbeat — touches the session's own registry file.

--- a/crates/session/src/registry.rs
+++ b/crates/session/src/registry.rs
@@ -144,6 +144,26 @@ pub fn find_own(dir: &Path, session_id: &str) -> Option<PathBuf> {
     Some(first)
 }
 
+/// Deregister a session: remove its own registry file so it stops appearing as
+/// a live peer the moment it ends, instead of lingering until the next `session
+/// start` sweeps it by age (#97). Resolves the file the same content-verified
+/// way [`find_own`] does, so only the record whose stored `session_id` matches
+/// exactly is removed — never a peer's lane (#90). A clean no-op (`Ok`) when the
+/// session has no registered file: a SessionEnd that fires before `session
+/// start` ever ran has nothing to remove.
+///
+/// Assumes `session_id` was validated by the caller (`End::run` filters through
+/// [`identity::is_safe_session_id`]). Even an unvalidated id cannot traverse:
+/// `find_own` uses it only for content equality and as a filename-suffix string
+/// match against `read_dir` entries, never as a path component — so the deleted
+/// path is always one already inside `dir`.
+pub fn remove_own(dir: &Path, session_id: &str) -> std::io::Result<()> {
+    match find_own(dir, session_id) {
+        Some(path) => fs::remove_file(path),
+        None => Ok(()),
+    }
+}
+
 /// Write `contents` to `path` atomically: stage to a uniquely-named temp file
 /// in the SAME directory, then `rename` it over `path`. A concurrent reader
 /// sees either the old complete file or the new complete file — never a
@@ -694,6 +714,73 @@ mod tests {
     #[test]
     fn sweep_missing_directory_is_noop() {
         sweep_stale(Path::new("/nonexistent/sessions"), 0, "");
+    }
+
+    // --- deregister (remove_own, #97) ---
+
+    #[test]
+    fn remove_own_deletes_the_session_file() {
+        // SessionEnd deregister: an ended session removes its own lane so it
+        // stops appearing as a live peer immediately, instead of lingering
+        // until the next `session start` sweeps it by age (#97).
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        write_record(&dir, &record("quiet-loom", "self-session")).unwrap();
+        remove_own(&dir, "self-session").unwrap();
+        assert!(
+            find_own(&dir, "self-session").is_none(),
+            "own lane removed on deregister"
+        );
+    }
+
+    #[test]
+    fn remove_own_leaves_peers_untouched() {
+        // Deregister removes only the caller's own lane — a concurrent peer's
+        // record must survive.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        write_record(&dir, &record("quiet-loom", "self-session")).unwrap();
+        write_record(&dir, &record("forge-anvil", "peer-session")).unwrap();
+        remove_own(&dir, "self-session").unwrap();
+        assert!(find_own(&dir, "self-session").is_none(), "own lane removed");
+        assert!(
+            find_own(&dir, "peer-session").is_some(),
+            "peer lane untouched"
+        );
+    }
+
+    #[test]
+    fn remove_own_removes_only_matching_colliding_short_id() {
+        // Content-targeted delete (#90-hardened find_own): two sessions sharing
+        // the 8-char prefix ("session-") must not cross-delete. Deregistering
+        // session-1 leaves session-2's lane intact.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        write_record(&dir, &record("alpha-loom", "session-1")).unwrap();
+        write_record(&dir, &record("beta-anvil", "session-2")).unwrap();
+        remove_own(&dir, "session-1").unwrap();
+        assert!(
+            !dir.join("alpha-loom.session-.json").exists(),
+            "session-1 lane removed"
+        );
+        assert!(
+            dir.join("beta-anvil.session-.json").exists(),
+            "colliding session-2 lane NOT cross-deleted"
+        );
+    }
+
+    #[test]
+    fn remove_own_noop_when_unregistered() {
+        // Deregistering a session with no registered file is a clean no-op,
+        // never an error — a SessionEnd before `session start` ever ran.
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().to_path_buf();
+        write_record(&dir, &record("forge-anvil", "peer-session")).unwrap();
+        remove_own(&dir, "never-registered").unwrap();
+        assert!(
+            find_own(&dir, "peer-session").is_some(),
+            "unrelated lane untouched by a no-op deregister"
+        );
     }
 
     // --- git exclude ---

--- a/crates/session/src/start.rs
+++ b/crates/session/src/start.rs
@@ -51,12 +51,18 @@ pub fn run_start(
         return CheckResult::allow();
     };
 
-    // Register (or re-register on resume/clear/compact — preserves any
-    // declared intent/touching from earlier in the session). This runs
-    // *before* the sweep: writing the record refreshes our own mtime to ~now,
-    // so a session that went quiet (a read/think phase) and re-enters via
-    // /clear or compaction can never sweep its own aged file and then rebuild
-    // a minimal record stripped of its intent/touching lanes (#69).
+    // Register (or re-register on resume — preserves any declared
+    // intent/touching from earlier in the session). This runs *before* the
+    // sweep: writing the record refreshes our own mtime to ~now, so a session
+    // that went quiet (a read/think phase) and re-enters with the SAME
+    // session_id can never sweep its own aged file and then rebuild a minimal
+    // record stripped of its intent/touching lanes (#69).
+    //
+    // The same-session_id case is the *resume* path (`--resume`/`--continue`).
+    // `/clear` and `/compact`, by contrast, mint a NEW session_id (verified
+    // 2026-06-17) and fire SessionEnd for the old one — which `session end`
+    // (#97) deregisters — so a post-/clear session arrives here with a fresh id
+    // and no prior record to preserve. The two fixes do not collide on /clear.
     let record = match registry::read_own(dir, sid) {
         Some(mut existing) => {
             if branch.is_some() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,8 @@ enum SessionCommands {
     Guard,
     /// Warn when HEAD drifted from the session's recorded branch at git commit (PreToolUse)
     WarnBranchDrift,
+    /// Deregister this session's registry file when it ends (SessionEnd logger)
+    End,
     /// Declare what this session is working on, so peers can assess collision risk
     Declare {
         /// What this session is working on (e.g. "cadence-hooks#54")
@@ -326,6 +328,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             SessionCommands::Heartbeat => "heartbeat",
             SessionCommands::Guard => "guard",
             SessionCommands::WarnBranchDrift => "warn-branch-drift",
+            SessionCommands::End => "end",
             // declare and status are CLI actions, not hooks — no hooks.json
             // wiring and not subject to CADENCE_DISABLE (same treatment as
             // dismiss-main-branch-warn).
@@ -739,6 +742,10 @@ fn main() {
             SessionCommands::WarnBranchDrift => {
                 run_check_from_stdin(&cadence_hooks_session::branch_drift::WarnBranchDrift, pre)
             }
+            SessionCommands::End => run_logger_from_stdin(
+                &cadence_hooks_session::end::End,
+                registry::sample_for("session", "end"),
+            ),
             SessionCommands::Declare {
                 intent,
                 touching,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -298,6 +298,12 @@ pub const HOOKS: &[HookEntry] = &[
         plugin: "session",
         event: Some(HookEvent::PreToolUse),
     },
+    HookEntry {
+        name: "end",
+        description: "Deregister this session's registry file when it ends (SessionEnd)",
+        plugin: "session",
+        event: None,
+    },
 ];
 
 /// The registry entry for `<namespace> <subcommand>`, if one exists.
@@ -338,6 +344,11 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         ("session", "warn-branch-drift") => Some(
             r#"{"session_id":"test","tool_name":"Bash","tool_input":{"command":"git commit -m test"}}"#,
         ),
+        // end gates on hook_event_name == "SessionEnd"; the generic logger
+        // sample carries a different event and would no-op before the gate.
+        ("session", "end") => {
+            Some(r#"{"session_id":"test","hook_event_name":"SessionEnd","cwd":"/tmp"}"#)
+        }
         _ => None,
     }
 }
@@ -439,7 +450,7 @@ mod tests {
     fn only_loggers_have_no_event() {
         // Fire-and-forget loggers react to `hook_event_name` in the payload
         // rather than a fixed event; everything else must declare one.
-        let loggers = ["snapshot", "log-commit", "log-subagent", "heartbeat"];
+        let loggers = ["snapshot", "log-commit", "log-subagent", "heartbeat", "end"];
         for hook in HOOKS {
             if loggers.contains(&hook.name) {
                 assert!(


### PR DESCRIPTION
## Summary

Session liveness is **mtime-only** with no deregistration ceremony, so an ended
session (`/clear`, exit, logout) lingers in `.claude/sessions/` until the next
`session start` sweeps it by age (up to 30 min). The next session's SessionStart
disclosure then lists the **already-ended** session as a live peer, steering a
fresh session into unwarranted peer-coordination caution against a session that
no longer exists.

(The issue's original "plan-mode → execution as two distinct session_ids" repro
no longer holds — plan→execute is now one session. Re-scoped: the real problem
is any ended session lingering. See the updated issue.)

## Fix

A new `session end` **fire-and-forget Logger** (`crates/session/src/end.rs`),
wired to the **SessionEnd** hook event in cadence-canon (companion PR), removes
the session's own registry file on end via `registry::remove_own`.

- **Gated on `hook_event_name == "SessionEnd"`** in the testable core
  (`run_end`), not just the hooks.json wiring — a delete must never fire on
  another event (a misrouted wiring on PostToolUse would otherwise erase a live
  session's lane on its first tool call).
- **Content-targeted delete:** `remove_own` resolves the file via the
  #90-hardened `find_own` (full `session_id` equality), so it removes only the
  caller's own record — never a peer's lane, even under colliding 8-char
  prefixes. No-op when the session has no registered file.
- `HookEvent` has no `SessionEnd` variant, so this is modelled as a Logger
  (`event: None`) like `heartbeat` — no enum change.

On `/clear`, SessionEnd(old) fires before SessionStart(new), so the deregister
cleans up before the new session discloses peers.

## Tests (TDD — RED first)

- `registry::remove_own_*` (4) — deletes own lane; leaves peers untouched; does
  **not** cross-delete a colliding-short-id peer; clean no-op when unregistered.
- `end::run_end_*` (3) — removes on SessionEnd; **ignores** a non-SessionEnd
  event and an absent event (the gate).

`make ci` green (fmt + clippy `-D warnings` + all tests); `registry_matches_clap_dispatch`,
`only_loggers_have_no_event`, `sample_overrides_parse_as_metrics_input`, and the
hooks-registration audit all pass. No `make bump` — release held to bundle the
P2 batch into 0.31.0.

Closes cameronsjo/claude-configurations#97


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic session cleanup: when a session ends, it is immediately removed from the registry to prevent it from lingering as a phantom peer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->