### PR TITLE
docs(session): record #136 resume-after-exit investigation

### DIFF
--- a/crates/session/src/end.rs
+++ b/crates/session/src/end.rs
@@ -56,12 +56,25 @@ impl Logger for End {
 /// phantom, and the successor session registers fresh under its own id. #69's
 /// same-session_id re-registration path is therefore the *resume* path
 /// (`--resume`/`--continue` reusing an id after an exit), not the `/clear` path.
-/// We do NOT gate on the `reason` field: the only id-reusing case is resume, and
-/// there the lost `intent`/`touching` are best-effort and self-heal on the next
-/// heartbeat (`touch_own` rebuilds the record) — a bounded, transient
-/// degradation, not the lane loss #69 fixed. (Compaction uses the separate
-/// `PreCompact` hook, not SessionEnd, so a live session never self-deregisters
-/// mid-work.) Revisiting the resume case is tracked as claude-configurations#136.
+/// We do NOT gate on the `reason` field. This was investigated and ruled out
+/// under claude-configurations#136 (resolved 2026-06-19): there is no exit-time
+/// signal that a *later* cold `--resume` is coming. A clean exit fires reason
+/// `other` / `prompt_input_exit` whether or not the id is ever resumed, and the
+/// SessionEnd `reason: "resume"` value covers only in-the-moment resumption, not
+/// a cold `claude --resume <id>` minutes or hours later — so a `reason` allowlist
+/// could not catch the very case #136 is about, while still adding staleness-prone
+/// state to maintain.
+///
+/// The residual is accepted as a bounded degradation. On resume,
+/// `--resume`/`--continue` reuses the id and fires SessionStart (`source=resume`),
+/// so [`crate::start`]'s re-registration runs — but finds no record (this fn
+/// removed it) and rebuilds a *minimal* lane: liveness, `branch`, and the
+/// `declared_branch` baseline re-seed immediately, while `intent`/`touching` are
+/// best-effort metadata the session re-declares via `session declare` (they are
+/// not auto-restored). The only fix that would carry `intent`/`touching` across a
+/// resume is a tombstone / soft-delete, deliberately deferred (P3) until the loss
+/// proves to matter in practice. (Compaction uses the separate `PreCompact` hook,
+/// not SessionEnd, so a live session never self-deregisters mid-work.)
 pub fn run_end(hook_event_name: Option<&str>, dir: &std::path::Path, session_id: &str) {
     if hook_event_name != Some("SessionEnd") {
         return;


### PR DESCRIPTION
## What

Resolve the `claude-configurations#136` revisit that was tracked inline in the
`run_end` doc comment (`crates/session/src/end.rs`). This is a decision-record
change — comment-only, no behavior change.

## Why

#136 asked whether `session end`'s unconditional deregistration should be gated
on the SessionEnd `reason` field to preserve a lane across a later
`claude --resume`. Investigation (Phase 1, verified 2026-06-19) ruled that out:

- **No exit-time signal exists** that a *later* cold `--resume` is coming. A
  clean exit fires `reason: other` / `prompt_input_exit` whether or not the id
  is ever resumed; the `reason: "resume"` value covers only in-the-moment
  resumption, not a cold `claude --resume <id>` minutes/hours later. So a
  `reason` allowlist could not catch the very case #136 is about, and would add
  staleness-prone state.
- The residual is an accepted **bounded degradation**: on resume, SessionStart
  re-registration (#69 path) rebuilds a *minimal* lane (liveness, `branch`,
  `declared_branch` baseline); `intent`/`touching` are re-declared via
  `session declare`, not auto-restored. The only fix that carries them across a
  resume is a tombstone/soft-delete, deliberately deferred (P3).

## Change

- Rewrites the `reason`-gating paragraph to record the finding and the
  reason-gating-impossible conclusion.
- Corrects the imprecise "self-heal on the next heartbeat (`touch_own`
  rebuilds)" line — it is the SessionStart re-registration that rebuilds a
  *minimal* lane, not a heartbeat, and `intent`/`touching` are re-declared, not
  auto-restored.

## Verification

`cargo test -p cadence-hooks-session` — 125 passed, 0 failed (comment-only, so
behavior is unchanged).

Closes cameronsjo/claude-configurations#136
