### PR TITLE
feat(rules): AskUserQuestion nudges — recommended-option (Pre) + empty-answers (Post)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **AskUserQuestion guidance moves from prose/shell to two Rust nudge hooks**
+  (`rules warn-recommended-option`, `rules warn-empty-answers`).
+  `warn-recommended-option` (PreToolUse) nudges Claude to label a clearly-preferred
+  option "(Recommended)" and list it first when no option across the questions
+  carries the marker — a deterministic call-time reinforcement of the conditional,
+  drift-prone always-loaded rule that the model had quietly stopped applying.
+  `warn-empty-answers` (PostToolUse) ports the retired `guard-askuserquestion.sh`:
+  it re-asks-as-plain-text when the answers dict is empty or every value is garbage
+  (`""`/`.`/`null`/`undefined`), the auto-approve artifact from
+  anthropics/claude-code#29962. Both are nudges, never blocks — the rule is
+  conditional ("when you have a clear preference"), so a block would over-apply to
+  genuinely-equivalent options. New `ToolInput.questions` / `ToolResponse.answers`
+  fields on the hook payload back the checks (previously dropped by serde).
+  Companion `hooks.json` wiring ships in `cadence-rules`. Supersedes ADR 0012's
+  shell implementation (ADR 0020).
+
 ## [0.31.0] - 2026-06-17
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -259,6 +259,7 @@ version = "0.31.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod time;
 pub mod test_builders;
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::io::{IsTerminal, Read};
 use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::process;
@@ -167,6 +168,8 @@ pub struct ToolInput {
     pub replace_all: Option<bool>,
     /// MultiEdit tool: sequence of edit operations applied in order.
     pub edits: Option<Vec<EditOperation>>,
+    /// AskUserQuestion tool: the questions being asked, each with its options.
+    pub questions: Option<Vec<AskQuestion>>,
 }
 
 /// A single edit operation within a MultiEdit tool call.
@@ -175,6 +178,23 @@ pub struct EditOperation {
     pub old_string: Option<String>,
     pub new_string: Option<String>,
     pub replace_all: Option<bool>,
+}
+
+/// A single AskUserQuestion question and its answer options.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AskQuestion {
+    pub question: Option<String>,
+    pub header: Option<String>,
+    pub multi_select: Option<bool>,
+    pub options: Option<Vec<AskOption>>,
+}
+
+/// A single answer option within an AskUserQuestion question.
+#[derive(Debug, Default, Deserialize)]
+pub struct AskOption {
+    pub label: Option<String>,
+    pub description: Option<String>,
 }
 
 /// Apply a single old→new replacement to a document.
@@ -195,6 +215,10 @@ fn apply_edit(doc: &str, old: &str, new: &str, replace_all: bool) -> String {
 pub struct ToolResponse {
     pub stdout: Option<String>,
     pub stderr: Option<String>,
+    /// AskUserQuestion tool: answers keyed by question text. Values are strings
+    /// (multiSelect = comma-joined) or null when unanswered. Present only on the
+    /// PostToolUse payload for AskUserQuestion.
+    pub answers: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl HookInput {
@@ -343,6 +367,13 @@ impl HookInput {
         self.tool_response
             .as_ref()
             .and_then(|tr| tr.stdout.as_deref())
+    }
+
+    /// The AskUserQuestion questions carried by this tool call, if any.
+    pub fn ask_questions(&self) -> Option<&[AskQuestion]> {
+        self.tool_input
+            .as_ref()
+            .and_then(|ti| ti.questions.as_deref())
     }
 }
 
@@ -1555,5 +1586,30 @@ mod tests {
         let msg = interactive_terminal_help("terminology", Some(HookEvent::PreToolUse), None, &[]);
         assert!(msg.contains("cadence-hooks try terminology"));
         assert!(msg.contains("| cadence-hooks terminology"));
+    }
+
+    #[test]
+    fn deserialize_askuserquestion_tool_input() {
+        let json = r#"{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Which approach?","header":"Approach","multiSelect":false,"options":[{"label":"Option A (Recommended)","description":"first"},{"label":"Option B","description":"second"}]}]}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let qs = input.ask_questions().expect("questions present");
+        assert_eq!(qs.len(), 1);
+        assert_eq!(qs[0].multi_select, Some(false));
+        let opts = qs[0].options.as_ref().unwrap();
+        assert_eq!(opts[0].label.as_deref(), Some("Option A (Recommended)"));
+    }
+
+    #[test]
+    fn deserialize_askuserquestion_answers() {
+        let json = r#"{"tool_name":"AskUserQuestion","tool_response":{"answers":{"Which approach?":"Option A"}}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        let answers = input
+            .tool_response
+            .as_ref()
+            .unwrap()
+            .answers
+            .as_ref()
+            .unwrap();
+        assert_eq!(answers.get("Which approach?").unwrap(), "Option A");
     }
 }

--- a/crates/core/src/test_builders.rs
+++ b/crates/core/src/test_builders.rs
@@ -98,7 +98,7 @@ pub fn make_bash_post_tool_use(cmd: &str, stdout: &str) -> HookInput {
         }),
         tool_response: Some(ToolResponse {
             stdout: Some(stdout.into()),
-            stderr: None,
+            ..Default::default()
         }),
         ..Default::default()
     }

--- a/crates/rules/Cargo.toml
+++ b/crates/rules/Cargo.toml
@@ -8,6 +8,7 @@ description = "Rules plugin hooks: skill frontmatter validation, security patter
 [dependencies]
 cadence-hooks-core.workspace = true
 regex.workspace = true
+serde_json.workspace = true
 
 [dev-dependencies]
 cadence-hooks-core = { workspace = true, features = ["test-builders"] }

--- a/crates/rules/src/askuserquestion.rs
+++ b/crates/rules/src/askuserquestion.rs
@@ -1,0 +1,330 @@
+//! AskUserQuestion advisory nudges.
+//!
+//! Two non-blocking checks wired on the `AskUserQuestion` tool:
+//! - PreToolUse [`WarnRecommendedOption`]: reminds Claude to label a recommended
+//!   option "(Recommended)" and list it first when it has a clear preference.
+//! - PostToolUse [`WarnEmptyAnswers`]: detects empty/garbage answers from
+//!   auto-approve modes (anthropics/claude-code#29962) and nudges to re-ask as
+//!   plain text and wait. Ports the retired `guard-askuserquestion.sh`.
+//!
+//! Both are nudges (exit 0, additionalContext), never blocks: the
+//! "(Recommended)" rule is conditional ("when you have a clear preference"), so
+//! a hard block would over-apply to genuinely-equivalent options.
+
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use std::collections::HashMap;
+
+const RECOMMENDED_MARKER: &str = "(Recommended)";
+
+/// PreToolUse nudge: remind Claude to label a recommended AskUserQuestion option.
+pub struct WarnRecommendedOption;
+
+impl Check for WarnRecommendedOption {
+    fn name(&self) -> &str {
+        "warn-recommended-option"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        if input.tool_name() != Some("AskUserQuestion") {
+            return CheckResult::allow();
+        }
+        let Some(questions) = input.ask_questions() else {
+            return CheckResult::allow();
+        };
+        if questions.is_empty() {
+            return CheckResult::allow();
+        }
+        let has_recommended = questions
+            .iter()
+            .flat_map(|q| q.options.iter().flatten())
+            .any(|o| {
+                o.label
+                    .as_deref()
+                    .is_some_and(|l| l.contains(RECOMMENDED_MARKER))
+            });
+        if has_recommended {
+            CheckResult::allow()
+        } else {
+            CheckResult::nudge(
+                "None of these AskUserQuestion options is labeled \"(Recommended)\". \
+                 If one option is your clear recommendation, label it \"(Recommended)\" \
+                 and list it first so the user can decide faster. If the options are \
+                 genuinely equivalent, no change is needed.",
+            )
+        }
+    }
+}
+
+/// PostToolUse nudge: re-ask when AskUserQuestion returns empty/garbage answers.
+pub struct WarnEmptyAnswers;
+
+impl Check for WarnEmptyAnswers {
+    fn name(&self) -> &str {
+        "warn-empty-answers"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        if input.tool_name() != Some("AskUserQuestion") {
+            return CheckResult::allow();
+        }
+        // Only judge once the tool has run (PostToolUse). A PreToolUse
+        // AskUserQuestion payload carries no `tool_response` — not our concern
+        // here; the Pre check owns that path. This `tool_response`-presence gate
+        // keeps the Post check inert if it ever sees a Pre-shaped payload.
+        let Some(response) = input.tool_response.as_ref() else {
+            return CheckResult::allow();
+        };
+        if answers_are_empty_or_garbage(response.answers.as_ref()) {
+            CheckResult::nudge(
+                "AskUserQuestion returned empty/garbage answers — no human responded. \
+                 This is a known auto-approve artifact (anthropics/claude-code#29962). \
+                 Do NOT proceed with defaults. Re-ask the same questions as plain text \
+                 in your response, then WAIT for the user to reply before continuing.",
+            )
+        } else {
+            CheckResult::allow()
+        }
+    }
+}
+
+/// True when the answers dict is missing, empty, or every value is blank /
+/// `.` / `null` / `undefined` (the auto-approve garbage signatures the retired
+/// shell guard flagged).
+fn answers_are_empty_or_garbage(answers: Option<&HashMap<String, serde_json::Value>>) -> bool {
+    match answers {
+        None => true,
+        // `all` over an empty map is vacuously true — an empty answers dict is
+        // itself the garbage signal.
+        Some(map) => map.values().all(is_garbage_value),
+    }
+}
+
+fn is_garbage_value(v: &serde_json::Value) -> bool {
+    match v {
+        serde_json::Value::Null => true,
+        serde_json::Value::String(s) => {
+            let t = s.trim();
+            t.is_empty() || t == "." || t == "null" || t == "undefined"
+        }
+        // A real structured answer (number/bool/array/object) is not garbage.
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::{AskOption, AskQuestion, ToolInput, ToolResponse};
+    use serde_json::json;
+
+    fn pre_input(option_labels: &[&str]) -> HookInput {
+        HookInput {
+            tool_name: Some("AskUserQuestion".into()),
+            tool_input: Some(ToolInput {
+                questions: Some(vec![AskQuestion {
+                    question: Some("Which approach?".into()),
+                    header: Some("Approach".into()),
+                    multi_select: Some(false),
+                    options: Some(
+                        option_labels
+                            .iter()
+                            .map(|l| AskOption {
+                                label: Some((*l).into()),
+                                description: Some("desc".into()),
+                            })
+                            .collect(),
+                    ),
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn post_input(answers: Option<HashMap<String, serde_json::Value>>) -> HookInput {
+        HookInput {
+            tool_name: Some("AskUserQuestion".into()),
+            tool_response: Some(ToolResponse {
+                answers,
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    // --- WarnRecommendedOption ---
+
+    #[test]
+    fn pre_wrong_tool_allows() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            WarnRecommendedOption.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn pre_no_questions_allows() {
+        let input = HookInput {
+            tool_name: Some("AskUserQuestion".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            WarnRecommendedOption.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn pre_with_recommended_allows() {
+        let input = pre_input(&["Option A (Recommended)", "Option B"]);
+        assert_eq!(
+            WarnRecommendedOption.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn pre_without_recommended_nudges() {
+        let input = pre_input(&["Option A", "Option B"]);
+        let result = WarnRecommendedOption.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+        assert!(result.message.unwrap().contains("(Recommended)"));
+    }
+
+    #[test]
+    fn pre_recommended_in_any_question_allows() {
+        // ANY option across ALL questions carrying the marker is enough.
+        let input = HookInput {
+            tool_name: Some("AskUserQuestion".into()),
+            tool_input: Some(ToolInput {
+                questions: Some(vec![
+                    AskQuestion {
+                        options: Some(vec![AskOption {
+                            label: Some("Plain".into()),
+                            description: None,
+                        }]),
+                        ..Default::default()
+                    },
+                    AskQuestion {
+                        options: Some(vec![AskOption {
+                            label: Some("Best (Recommended)".into()),
+                            description: None,
+                        }]),
+                        ..Default::default()
+                    },
+                ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            WarnRecommendedOption.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    // --- WarnEmptyAnswers ---
+
+    #[test]
+    fn post_wrong_tool_allows() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            WarnEmptyAnswers.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn post_no_response_allows() {
+        // A Pre-shaped AskUserQuestion payload (no tool_response) is inert here.
+        let input = HookInput {
+            tool_name: Some("AskUserQuestion".into()),
+            ..Default::default()
+        };
+        assert_eq!(
+            WarnEmptyAnswers.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn post_real_answers_allow() {
+        let mut map = HashMap::new();
+        map.insert("Which approach?".to_string(), json!("Option A"));
+        assert_eq!(
+            WarnEmptyAnswers.run(&post_input(Some(map))).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn post_empty_map_nudges() {
+        assert_eq!(
+            WarnEmptyAnswers
+                .run(&post_input(Some(HashMap::new())))
+                .outcome,
+            cadence_hooks_core::Outcome::Nudge
+        );
+    }
+
+    #[test]
+    fn post_absent_answers_nudges() {
+        assert_eq!(
+            WarnEmptyAnswers.run(&post_input(None)).outcome,
+            cadence_hooks_core::Outcome::Nudge
+        );
+    }
+
+    #[test]
+    fn post_all_garbage_values_nudge() {
+        for garbage in [
+            json!(""),
+            json!("   "),
+            json!("."),
+            json!("null"),
+            json!("undefined"),
+            json!(null),
+        ] {
+            let mut map = HashMap::new();
+            map.insert("Q?".to_string(), garbage.clone());
+            assert_eq!(
+                WarnEmptyAnswers.run(&post_input(Some(map))).outcome,
+                cadence_hooks_core::Outcome::Nudge,
+                "garbage value {garbage:?} should nudge"
+            );
+        }
+    }
+
+    #[test]
+    fn post_one_real_answer_among_garbage_allows() {
+        let mut map = HashMap::new();
+        map.insert("Q1?".to_string(), json!(""));
+        map.insert("Q2?".to_string(), json!("Real answer"));
+        assert_eq!(
+            WarnEmptyAnswers.run(&post_input(Some(map))).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    // --- pure helpers ---
+
+    #[test]
+    fn garbage_value_classification() {
+        assert!(is_garbage_value(&json!("")));
+        assert!(is_garbage_value(&json!("  ")));
+        assert!(is_garbage_value(&json!(".")));
+        assert!(is_garbage_value(&json!("null")));
+        assert!(is_garbage_value(&json!("undefined")));
+        assert!(is_garbage_value(&json!(null)));
+        assert!(!is_garbage_value(&json!("Option A")));
+        assert!(!is_garbage_value(&json!(42)));
+        assert!(!is_garbage_value(&json!(true)));
+    }
+}

--- a/crates/rules/src/lib.rs
+++ b/crates/rules/src/lib.rs
@@ -2,6 +2,8 @@
 //!
 //! Structural validation for plugin files and security-aware code scanning.
 
+/// AskUserQuestion advisory nudges: label a recommended option (Pre) and re-ask on empty auto-approve answers (Post).
+pub mod askuserquestion;
 /// Scan written code for language-specific security anti-patterns.
 pub mod check_security_patterns;
 /// Validate SKILL.md and command file frontmatter (required fields, name format, known fields).

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,10 @@ enum RulesCommands {
     ValidateFrontmatter,
     /// Scan for security anti-patterns
     SecurityPatterns,
+    /// Nudge to label a recommended AskUserQuestion option "(Recommended)"
+    WarnRecommendedOption,
+    /// Nudge to re-ask when AskUserQuestion returns empty auto-approve answers
+    WarnEmptyAnswers,
 }
 
 #[derive(Subcommand)]
@@ -310,6 +314,8 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
         Commands::Rules(r) => Some(match r {
             RulesCommands::ValidateFrontmatter => "validate-frontmatter",
             RulesCommands::SecurityPatterns => "security-patterns",
+            RulesCommands::WarnRecommendedOption => "warn-recommended-option",
+            RulesCommands::WarnEmptyAnswers => "warn-empty-answers",
         }),
         Commands::Obsidian(o) => Some(match o {
             ObsidianCommands::TrashGuard => "trash-guard",
@@ -695,6 +701,14 @@ fn main() {
             ),
             RulesCommands::SecurityPatterns => run_check_from_stdin(
                 &cadence_hooks_rules::check_security_patterns::SecurityPatternScanner,
+                post,
+            ),
+            RulesCommands::WarnRecommendedOption => run_check_from_stdin(
+                &cadence_hooks_rules::askuserquestion::WarnRecommendedOption,
+                pre,
+            ),
+            RulesCommands::WarnEmptyAnswers => run_check_from_stdin(
+                &cadence_hooks_rules::askuserquestion::WarnEmptyAnswers,
                 post,
             ),
         },

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -234,6 +234,18 @@ pub const HOOKS: &[HookEntry] = &[
         plugin: "rules",
         event: Some(HookEvent::PostToolUse),
     },
+    HookEntry {
+        name: "warn-recommended-option",
+        description: "Nudge to label a recommended AskUserQuestion option \"(Recommended)\"",
+        plugin: "rules",
+        event: Some(HookEvent::PreToolUse),
+    },
+    HookEntry {
+        name: "warn-empty-answers",
+        description: "Nudge to re-ask when AskUserQuestion returns empty auto-approve answers",
+        plugin: "rules",
+        event: Some(HookEvent::PostToolUse),
+    },
     // obsidian
     HookEntry {
         name: "trash-guard",
@@ -349,6 +361,14 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         ("session", "end") => {
             Some(r#"{"session_id":"test","hook_event_name":"SessionEnd","cwd":"/tmp"}"#)
         }
+        // warn-recommended-option: a question with no "(Recommended)" option → nudge
+        ("rules", "warn-recommended-option") => Some(
+            r#"{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Which approach?","header":"Approach","multiSelect":false,"options":[{"label":"Option A","description":"first"},{"label":"Option B","description":"second"}]}]}}"#,
+        ),
+        // warn-empty-answers: a PostToolUse response with empty answers → nudge
+        ("rules", "warn-empty-answers") => Some(
+            r#"{"tool_name":"AskUserQuestion","tool_input":{"questions":[{"question":"Which approach?","options":[{"label":"Option A"}]}]},"tool_response":{"answers":{"Which approach?":""}}}"#,
+        ),
         _ => None,
     }
 }


### PR DESCRIPTION
## What

Two non-blocking `AskUserQuestion` nudge checks under the `rules` namespace, replacing a conditional always-loaded prose rule (and the last shell guard) with deterministic, call-time hooks.

- **`warn-recommended-option` (PreToolUse)** — nudges Claude to label a clearly-preferred option `(Recommended)` and list it first when no option across the questions carries the marker. Counters the behavioral drift where the model quietly stopped applying the conditional `~/.claude/rules/cadence/cadence-rules.md` rule. Non-blocking on purpose: the rule is conditional ("when you have a clear preference"), so genuinely-equivalent options legitimately carry no marker — a block would over-apply.
- **`warn-empty-answers` (PostToolUse)** — ports the retired `guard-askuserquestion.sh` faithfully: re-ask as plain text and wait when the answers dict is missing, empty, or every value is garbage (`""`/`.`/`null`/`undefined`) — the auto-approve artifact from anthropics/claude-code#29962.

## Why two checks, not one

The `Check` trait's `run()` never receives the hook event, and each clap subcommand maps to exactly one event (`registry_matches_clap_dispatch` enforces it). One struct branching on payload shape would emit a single, possibly-wrong `hookEventName`. Two single-purpose checks each read one field (`tool_input.questions` vs `tool_response.answers`) and emit the correct event.

## Payload changes

`ToolInput.questions` and `ToolResponse.answers` are new optional fields on the core hook payload (serde silently dropped them before). No file I/O — they ride in the Pre/Post payload, unlike `effective_content()`'s disk simulation for Edits.

## Tests / CI

- 15 new tests (rules crate 81 → 96); `make ci` green (fmt + clippy `-D warnings` + all suites).
- `cadence-hooks try rules warn-recommended-option` → NUDGE; with a `(Recommended)` option → ALLOW; `try rules warn-empty-answers` → NUDGE.

## Follow-ups (separate, not in this PR)

- Companion `hooks.json` wiring in **cadence-rules** (matcher `AskUserQuestion`) — paired PR.
- Retire `~/.claude/hooks/guard-askuserquestion.sh` + its `settings.json` registration, AFTER this ships (so AskUserQuestion is never unguarded).
- ADR 0020 documenting the shell→Rust + Pre+Post consolidation (supersedes ADR 0012's implementation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
