### PR TITLE
feat(metrics): log-polish-nudge telemetry for #151 efficacy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **metrics: `log-polish-nudge` — deterministic telemetry for polish-nudge
+  efficacy** (#151 on claude-configurations). A new PostToolUse metrics Logger
+  fires on `gh pr create` — the same `is_gh_pr_create` predicate that drives
+  `nudge-polish-before-pr`, so the recorded set is exactly the PRs that got
+  nudged (the denominator). Each row appends to `polish_nudges.jsonl` with
+  `{ts, sessionId, transcriptPath, branch, repo, polished}`, where `polished`
+  is a best-effort transcript scan for a `cadence-forge:polish` Skill
+  invocation earlier in the session; a `polished: false` row is a deterministic
+  *skip candidate*. (A line merely mentioning `/polish` in prose does not count
+  — only an actual Skill `tool_use` does.) Distinguishing a *rationalized* skip
+  from a legitimate one stays a transcript/prose judgment, but the rate is now
+  queryable without re-mining every transcript. `is_gh_pr_create` moved to
+  `cadence_hooks_core::shell` so the nudge and the logger share one definition.
+  (Wiring this logger into the cadence-metrics plugin's `hooks.json` is the
+  companion step.)
+
 ### Fixed
 
 - **session: the heartbeat now sweeps stale peer lanes** (#155 on

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -11,6 +11,7 @@
 //! code-review precede polish, they don't replace it. A skip must be stated and
 //! justified, never silent.
 
+use cadence_hooks_core::shell::is_gh_pr_create;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Nudges to run `/polish` (cadence-forge:polish) before opening a PR.
@@ -43,17 +44,6 @@ impl Check for NudgePolishBeforePr {
                 .to_string(),
         )
     }
-}
-
-/// Returns true if `command` contains a `gh pr create` token sequence.
-///
-/// Token-based to avoid substring false positives (e.g. branch names
-/// containing the literal string `gh-pr-create`).
-fn is_gh_pr_create(command: &str) -> bool {
-    let tokens: Vec<&str> = command.split_whitespace().collect();
-    tokens
-        .windows(3)
-        .any(|w| w[0] == "gh" && w[1] == "pr" && w[2] == "create")
 }
 
 #[cfg(test)]

--- a/crates/core/src/shell.rs
+++ b/crates/core/src/shell.rs
@@ -84,6 +84,20 @@ pub fn tokenize(command: &str) -> Vec<String> {
     tokens
 }
 
+/// Returns true if `command` contains a `gh pr create` token sequence.
+///
+/// Whitespace-token based to avoid substring false positives — a branch named
+/// `gh-pr-create-experiments`, or the literal text inside a quoted arg, must not
+/// match. Shared by the `nudge-polish-before-pr` Check (the nudge) and the
+/// `log-polish-nudge` metrics Logger, so the logged denominator is exactly the
+/// set of PRs that fired the nudge.
+pub fn is_gh_pr_create(command: &str) -> bool {
+    let tokens: Vec<&str> = command.split_whitespace().collect();
+    tokens
+        .windows(3)
+        .any(|w| w[0] == "gh" && w[1] == "pr" && w[2] == "create")
+}
+
 /// Extract `(host, "owner/repo")` from any git remote URL format.
 ///
 /// Handles:
@@ -675,6 +689,23 @@ pub static LOOP_PATTERN: LazyLock<Regex> = LazyLock::new(|| {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn is_gh_pr_create_matches_the_command() {
+        assert!(is_gh_pr_create("gh pr create --title test"));
+        assert!(is_gh_pr_create("cd repo && gh pr create --fill"));
+    }
+
+    #[test]
+    fn is_gh_pr_create_rejects_other_gh_and_substrings() {
+        assert!(!is_gh_pr_create("gh pr list"));
+        assert!(!is_gh_pr_create("gh pr view 123"));
+        assert!(!is_gh_pr_create("gh issue create --title x"));
+        // A branch name containing the literal substring must not match.
+        assert!(!is_gh_pr_create("git checkout gh-pr-create-experiments"));
+        // Quoted as a single commit-message arg → tokens don't line up.
+        assert!(!is_gh_pr_create("git commit -m 'gh pr create'"));
+    }
 
     // --- strip_quotes ---
 

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -12,6 +12,8 @@ mod common;
 pub mod compute_cost;
 /// Append cost-per-commit records to `commits.jsonl`.
 pub mod log_commit;
+/// Append polish-nudge (`gh pr create`) records to `polish_nudges.jsonl`.
+pub mod log_polish_nudge;
 /// Append subagent lifecycle records to `subagents.jsonl`.
 pub mod log_subagent;
 /// Embedded + overridable model price table.
@@ -22,5 +24,6 @@ pub mod scan_tokens;
 pub mod snapshot;
 
 pub use log_commit::LogCommit;
+pub use log_polish_nudge::LogPolishNudge;
 pub use log_subagent::LogSubagent;
 pub use snapshot::Snapshot;

--- a/crates/metrics/src/log_polish_nudge.rs
+++ b/crates/metrics/src/log_polish_nudge.rs
@@ -1,0 +1,241 @@
+//! `PostToolUse:Bash` — when `gh pr create` runs, append one line to
+//! `<metrics_dir>/polish_nudges.jsonl` recording the nudge-fire and whether
+//! `/polish` ran earlier this session.
+//!
+//! This is the deterministic denominator for the polish-nudge efficacy
+//! measurement (claude-configurations#151): every `gh pr create` *is* a nudged
+//! PR (it fires `nudge-polish-before-pr`), so the same [`is_gh_pr_create`]
+//! predicate gates both. `polished` is a best-effort transcript scan for a
+//! `cadence-forge:polish` Skill invocation earlier in the session — a row with
+//! `polished: false` is a deterministic *skip candidate*. Distinguishing a
+//! rationalized skip from a legitimate one stays a transcript/prose judgment;
+//! this logger only makes the rate queryable without re-mining every transcript.
+//!
+//! Silent no-op on any failure — never blocks (it is a [`Logger`]).
+
+use crate::common;
+use cadence_hooks_core::shell::is_gh_pr_create;
+use cadence_hooks_core::{Logger, MetricsInput};
+use serde_json::{Value, json};
+use std::io::Write;
+
+/// Appends a nudge-fire line to `polish_nudges.jsonl`.
+pub struct LogPolishNudge;
+
+impl Logger for LogPolishNudge {
+    fn name(&self) -> &str {
+        "log-polish-nudge"
+    }
+
+    fn run(&self, input: &MetricsInput) {
+        let Some(command) = input.command() else {
+            return;
+        };
+        // The denominator is defined as "every PR that fired the nudge", so the
+        // gate MUST be the same predicate the nudge uses.
+        if !is_gh_pr_create(command) {
+            return;
+        }
+        // Skip malformed payloads (mirrors the other loggers); session_id is
+        // recorded as a JSON value, never used in a path, so this is hygiene.
+        if !input
+            .session_id
+            .as_deref()
+            .is_some_and(common::is_safe_session_id)
+        {
+            return;
+        }
+
+        // Did `/polish` run earlier this session? Best-effort — a missing or
+        // unreadable transcript yields `false` (an honest "no evidence of
+        // polish"), never a panic.
+        let polished = input
+            .transcript_path
+            .as_deref()
+            .filter(|p| std::path::Path::new(p).is_file())
+            .and_then(|p| std::fs::read_to_string(p).ok())
+            .map(|t| transcript_has_polish_run(&t))
+            .unwrap_or(false);
+
+        let dir = common::metrics_dir();
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let path = dir.join("polish_nudges.jsonl");
+
+        let record = build_polish_nudge_record(
+            &common::utc_timestamp(),
+            input,
+            &common::branch(input.cwd.as_deref()),
+            &common::repo_basename(input.cwd.as_deref()),
+            polished,
+        );
+
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            // Single `write_all` of record + newline so concurrent appends from
+            // other sessions can't interleave (mirrors log_commit).
+            let mut line = record.to_string();
+            line.push('\n');
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+/// True when the session transcript contains a `cadence-forge:polish` Skill
+/// invocation. Pure — operates on the transcript text, no I/O.
+///
+/// Matches a `tool_use` block whose tool is `Skill` and whose `skill` argument
+/// contains `polish`; prose that merely mentions `/polish` (a `text` block) does
+/// NOT match — only an actual Skill invocation counts.
+fn transcript_has_polish_run(transcript: &str) -> bool {
+    transcript.lines().any(line_is_polish_skill_use)
+}
+
+/// True when one transcript line is an assistant message containing a `Skill`
+/// `tool_use` whose `skill` argument names a polish skill. A line that fails to
+/// parse, carries no `message.content` array, or holds only `text`/non-Skill
+/// blocks yields `false` — so prose mentioning `/polish` never counts.
+fn line_is_polish_skill_use(line: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        return false;
+    };
+    let Some(content) = value
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    content.iter().any(|block| {
+        block.get("type").and_then(Value::as_str) == Some("tool_use")
+            && block.get("name").and_then(Value::as_str) == Some("Skill")
+            && block
+                .get("input")
+                .and_then(|i| i.get("skill"))
+                .and_then(Value::as_str)
+                .is_some_and(|skill| skill.to_ascii_lowercase().contains("polish"))
+    })
+}
+
+/// Build the `polish_nudges.jsonl` record. Pure — no I/O.
+fn build_polish_nudge_record(
+    ts: &str,
+    input: &MetricsInput,
+    branch: &str,
+    repo: &str,
+    polished: bool,
+) -> Value {
+    json!({
+        "ts": ts,
+        "sessionId": input.session_id,
+        "transcriptPath": input.transcript_path,
+        "branch": branch,
+        "repo": repo,
+        "polished": polished,
+        "agentId": input.agent_id,
+        "parentSessionId": input.parent_session_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_log_polish_nudge() {
+        assert_eq!(LogPolishNudge.name(), "log-polish-nudge");
+    }
+
+    fn assistant_line(content: &str) -> String {
+        format!(r#"{{"type":"assistant","message":{{"role":"assistant","content":[{content}]}}}}"#)
+    }
+
+    #[test]
+    fn transcript_with_polish_skill_use_is_detected() {
+        let line = assistant_line(
+            r#"{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:polish"}}"#,
+        );
+        assert!(
+            transcript_has_polish_run(&line),
+            "a cadence-forge:polish Skill invocation must be detected"
+        );
+    }
+
+    #[test]
+    fn transcript_with_slash_polish_skill_use_is_detected() {
+        // The bare `/polish` form still surfaces as a Skill tool_use whose skill
+        // argument contains "polish".
+        let line =
+            assistant_line(r#"{"type":"tool_use","name":"Skill","input":{"skill":"polish"}}"#);
+        assert!(transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn transcript_without_polish_is_not_detected() {
+        // A gh pr create Bash call but no polish anywhere → skip candidate.
+        let line = assistant_line(
+            r#"{"type":"tool_use","name":"Bash","input":{"command":"gh pr create --fill"}}"#,
+        );
+        assert!(!transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn prose_mentioning_polish_is_not_a_run() {
+        // Text that merely talks about /polish is NOT a polish run — only an
+        // actual Skill invocation counts. This is the false-positive guard.
+        let line = assistant_line(r#"{"type":"text","text":"I will skip /polish here"}"#);
+        assert!(!transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn other_skill_is_not_polish() {
+        let line = assistant_line(
+            r#"{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:ship"}}"#,
+        );
+        assert!(!transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn corrupt_transcript_line_is_skipped() {
+        assert!(!transcript_has_polish_run("not json {{\n"));
+    }
+
+    fn sample_input() -> MetricsInput {
+        MetricsInput {
+            session_id: Some("s1".into()),
+            transcript_path: Some("/tmp/t.jsonl".into()),
+            agent_id: Some("a1".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn record_has_full_schema() {
+        let rec = build_polish_nudge_record(
+            "2026-06-21T00:00:00Z",
+            &sample_input(),
+            "feat/x",
+            "myrepo",
+            false,
+        );
+        assert_eq!(rec["ts"], "2026-06-21T00:00:00Z");
+        assert_eq!(rec["sessionId"], "s1");
+        assert_eq!(rec["transcriptPath"], "/tmp/t.jsonl");
+        assert_eq!(rec["branch"], "feat/x");
+        assert_eq!(rec["repo"], "myrepo");
+        assert_eq!(rec["polished"], false);
+        assert_eq!(rec["agentId"], "a1");
+        // Main-thread field absent → null, not omitted.
+        assert!(rec["parentSessionId"].is_null());
+    }
+
+    #[test]
+    fn record_marks_polished_true() {
+        let rec = build_polish_nudge_record("ts", &sample_input(), "feat/x", "myrepo", true);
+        assert_eq!(rec["polished"], true);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -227,6 +227,8 @@ enum MetricsCommands {
     },
     /// Log subagent lifecycle (SubagentStart / SubagentStop)
     LogSubagent,
+    /// Log polish-nudge skips: `gh pr create` + whether /polish ran (PostToolUse)
+    LogPolishNudge,
 }
 
 #[derive(Subcommand)]
@@ -328,6 +330,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::Snapshot => "snapshot",
             MetricsCommands::LogCommit { .. } => "log-commit",
             MetricsCommands::LogSubagent => "log-subagent",
+            MetricsCommands::LogPolishNudge => "log-polish-nudge",
         }),
         Commands::Lab(l) => Some(match l {
             LabCommands::PersonaNudge => "persona-nudge",
@@ -738,6 +741,10 @@ fn main() {
             MetricsCommands::LogSubagent => run_logger_from_stdin(
                 &cadence_hooks_metrics::LogSubagent,
                 registry::sample_for("metrics", "log-subagent"),
+            ),
+            MetricsCommands::LogPolishNudge => run_logger_from_stdin(
+                &cadence_hooks_metrics::LogPolishNudge,
+                registry::sample_for("metrics", "log-polish-nudge"),
             ),
         },
         Commands::Lab(cmd) => match cmd {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -272,6 +272,12 @@ pub const HOOKS: &[HookEntry] = &[
         plugin: "metrics",
         event: None,
     },
+    HookEntry {
+        name: "log-polish-nudge",
+        description: "Log polish-nudge skips: gh pr create + whether /polish ran (PostToolUse)",
+        plugin: "metrics",
+        event: None,
+    },
     // lab
     HookEntry {
         name: "persona-nudge",
@@ -361,6 +367,10 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         // log-subagent only reacts to SubagentStart / SubagentStop
         ("metrics", "log-subagent") => Some(
             r#"{"session_id":"test","hook_event_name":"SubagentStop","agent_id":"agent-1","agent_type":"Explore","duration_ms":1234}"#,
+        ),
+        // log-polish-nudge gates on a `gh pr create` command (the nudge denominator)
+        ("metrics", "log-polish-nudge") => Some(
+            r#"{"session_id":"test","hook_event_name":"PostToolUse","tool_input":{"command":"gh pr create --title test"},"transcript_path":"/tmp/transcript.jsonl"}"#,
         ),
         // warn-branch-drift early-exits unless the command is a git commit —
         // the generic PreToolUse sample (`git status`) would never reach the
@@ -496,6 +506,7 @@ mod tests {
             "snapshot",
             "log-commit",
             "log-subagent",
+            "log-polish-nudge",
             "heartbeat",
             "end",
             "backstop-record",


### PR DESCRIPTION
## What

Deterministic telemetry for the polish-nudge efficacy measurement (#151). Today there is **no** hook-layer event for the nudge firing or for a `/polish` run, so a clean skip-rate is impossible without re-mining every transcript. This adds the one signal that makes it queryable.

## How

A new PostToolUse metrics Logger, `log-polish-nudge`, fires on `gh pr create` — gated by the **same** `is_gh_pr_create` predicate that drives `nudge-polish-before-pr`, so the recorded set is *exactly* the PRs that got nudged (the denominator). Each fire appends one line to `polish_nudges.jsonl`:

```json
{"ts":"…","sessionId":"…","transcriptPath":"…","branch":"…","repo":"…","polished":false}
```

`polished` is a best-effort scan of the session transcript for a `cadence-forge:polish` Skill invocation earlier in the session. A `polished: false` row is a deterministic **skip candidate** → `skip_rate = count(polished=false) / count(*)`.

Crucially, prose that merely mentions `/polish` does **not** count — only an actual Skill `tool_use` does. That's the false-positive guard the Tier-1 transcript grep lacked.

### Design note — one richer event, not two

The #151 plan sketched two event streams (nudge-fire + polish-run) joined offline. This consolidates them into a single event at `gh pr create` that *also* carries `polished`, computed via a transcript scan. It delivers the identical deterministic skip-rate with no offline join and no fragile Skill-PostToolUse matcher — and `MetricsInput` carries no `tool_name`, so a clean Skill-matched logger wasn't available anyway.

`is_gh_pr_create` moved to `cadence_hooks_core::shell` so the nudge and the logger share one definition — the denominator is then *definitionally* the nudge trigger, not a copy that can drift.

## Tests

- Built test-first: the transcript detector's positive cases were RED against a stub before the parse logic landed.
- Pure-function unit tests: detection (Skill polish use), the false-positive guards (prose, other skills, corrupt lines), and the record schema.
- Functional smoke test (isolated `CLAUDE_CONFIG_DIR`): `polished:true` after a polish run, `polished:false` without, and **no row** for `gh pr list`.
- `make ci` green — fmt + clippy `-D warnings` + the registration audits (`registry_matches_clap_dispatch`, `only_loggers_have_no_event`, `all_binary_subcommands_are_registered`).

## Companion step (not in this PR)

For the logger to fire in production, the **cadence-metrics** plugin's `hooks.json` needs a PostToolUse entry dispatching `metrics log-polish-nudge`. That wiring must follow the binary release of this subcommand, so it is a separate change.

Refs #151. Version bump **held** — no `Cargo.toml` change, so the merge doesn't auto-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a metrics logger that records polish-nudge events triggered during pull request creation, capturing session data and whether the polish refinement was applied earlier in the session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->