### PR TITLE
feat(guardrails): warn-subagent-worktree — nudge subagent dispatch from main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **guardrails: `warn-subagent-worktree` — nudge when dispatching a subagent
+  from main while a sibling worktree exists** (#201 on claude-configurations). A
+  subagent inherits the *spawning session's* working directory, so a session in
+  the main checkout spawns subagents that operate on the main checkout — never a
+  sibling worktree. This PreToolUse check fires once per session (per repo) on an
+  `Agent`/`Task` spawn when the session is in the primary checkout (`.git` is a
+  directory, not a linked-worktree file), a sibling worktree exists
+  (`git worktree list` shows more than the primary), and the spawn doesn't set
+  `isolation: "worktree"`. The nudge names both fixes — dispatch from inside the
+  worktree, or pass `isolation: "worktree"` for a fresh one — and a permanent
+  per-repo opt-out via `CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true`. `ToolInput` gains
+  `subagent_type` / `isolation` (snake_case, matching the Agent payload).
+
 ## [0.36.0] - 2026-06-22
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "cadence-hooks-core",
  "regex",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -170,6 +170,14 @@ pub struct ToolInput {
     pub edits: Option<Vec<EditOperation>>,
     /// AskUserQuestion tool: the questions being asked, each with its options.
     pub questions: Option<Vec<AskQuestion>>,
+    /// Agent/Task tool: which subagent type the dispatch spawns. Absent for a
+    /// fork-yourself dispatch (`subagent_type` omitted). Carried for diagnostics
+    /// only — guards do not branch on the value.
+    pub subagent_type: Option<String>,
+    /// Agent/Task tool: isolation mode for the spawned subagent. `Some("worktree")`
+    /// means the spawn gets a fresh agent-owned worktree; absent means the
+    /// subagent inherits the spawning session's working directory.
+    pub isolation: Option<String>,
 }
 
 /// A single edit operation within a MultiEdit tool call.
@@ -245,6 +253,25 @@ impl HookInput {
         self.tool_input
             .as_ref()
             .and_then(|ti| ti.command.as_deref())
+    }
+
+    /// The subagent isolation mode for an Agent/Task spawn, if set.
+    ///
+    /// `Some("worktree")` means the spawn already gets a fresh agent-owned
+    /// worktree (so it is confined); `None` means the subagent inherits the
+    /// spawning session's working directory.
+    pub fn isolation(&self) -> Option<&str> {
+        self.tool_input
+            .as_ref()
+            .and_then(|ti| ti.isolation.as_deref())
+    }
+
+    /// The subagent type for an Agent/Task spawn, if set (`None` for a
+    /// fork-yourself dispatch). Diagnostics only.
+    pub fn subagent_type(&self) -> Option<&str> {
+        self.tool_input
+            .as_ref()
+            .and_then(|ti| ti.subagent_type.as_deref())
     }
 
     /// The content being written (Write tool) or the replacement text (Edit tool).
@@ -1325,6 +1352,26 @@ mod tests {
         let json = r#"{"tool_name":"Bash","tool_input":{"command":"git status"}}"#;
         let input: HookInput = serde_json::from_str(json).unwrap();
         assert_eq!(input.command(), Some("git status"));
+    }
+
+    #[test]
+    fn deserialize_agent_isolation_and_subagent_type() {
+        // The Agent tool's input carries snake_case `subagent_type` and
+        // `isolation` (confirmed against real session payloads).
+        let json = r#"{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose","isolation":"worktree"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.subagent_type(), Some("general-purpose"));
+        assert_eq!(input.isolation(), Some("worktree"));
+    }
+
+    #[test]
+    fn agent_fields_absent_are_none() {
+        // A fork-yourself / no-isolation dispatch omits both keys; serde maps
+        // the absent fields to None (backward-compatible with every other tool).
+        let json = r#"{"tool_name":"Agent","tool_input":{"description":"do x"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(input.subagent_type(), None);
+        assert_eq!(input.isolation(), None);
     }
 
     // --- Path normalization ---

--- a/crates/core/src/test_builders.rs
+++ b/crates/core/src/test_builders.rs
@@ -104,6 +104,26 @@ pub fn make_bash_post_tool_use(cmd: &str, stdout: &str) -> HookInput {
     }
 }
 
+/// Build a `HookInput` for an `Agent` (subagent dispatch) tool invocation.
+///
+/// `subagent_type` and `isolation` mirror the Agent tool's input keys — pass
+/// `None` to model an omitted field (a fork-yourself dispatch omits
+/// `subagent_type`; a no-isolation dispatch omits `isolation`). `cwd` is the
+/// spawning session's working directory, which `warn-subagent-worktree`
+/// resolves the checkout from.
+pub fn make_agent(subagent_type: Option<&str>, isolation: Option<&str>, cwd: &str) -> HookInput {
+    HookInput {
+        tool_name: Some("Agent".into()),
+        tool_input: Some(ToolInput {
+            subagent_type: subagent_type.map(Into::into),
+            isolation: isolation.map(Into::into),
+            ..Default::default()
+        }),
+        cwd: Some(cwd.into()),
+        ..Default::default()
+    }
+}
+
 /// Build a `HookInput` for a `SessionStart` event with the given session id and
 /// source (`startup` | `resume` | `clear` | `compact`).
 pub fn make_session(session_id: &str, source: &str) -> HookInput {

--- a/crates/guardrails/Cargo.toml
+++ b/crates/guardrails/Cargo.toml
@@ -12,3 +12,4 @@ serde_json.workspace = true
 
 [dev-dependencies]
 cadence-hooks-core = { workspace = true, features = ["test-builders"] }
+tempfile = "3"

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -47,5 +47,7 @@ pub mod warn_issue_tracker;
 pub mod warn_main_branch;
 /// Remind on `gh pr create` when the PR body has no closing keyword linking to an issue.
 pub mod warn_pr_issue_link;
+/// Warn when dispatching a subagent from main while a sibling worktree exists.
+pub mod warn_subagent_worktree;
 /// Warn about untracked files during git commit operations.
 pub mod warn_untracked;

--- a/crates/guardrails/src/warn_subagent_worktree.rs
+++ b/crates/guardrails/src/warn_subagent_worktree.rs
@@ -1,0 +1,399 @@
+//! Warn when dispatching a subagent from the main checkout while a sibling
+//! git worktree exists.
+//!
+//! A subagent inherits the **spawning session's working directory**. A session
+//! in the main checkout spawns subagents that operate on the main checkout —
+//! never a sibling worktree. So when a feature worktree exists and the intent
+//! is to isolate subagent work in it, dispatching from the main checkout lands
+//! the work in main instead. This nudge fires once per session (per repo) on an
+//! `Agent`/`Task` spawn when:
+//!
+//! 1. the spawn does not already set `isolation: "worktree"` (which would give
+//!    it a fresh agent-owned worktree, so it's already confined), and
+//! 2. the spawning session sits in the **primary checkout** (its `.git` is a
+//!    directory — a linked worktree's `.git` is a *file*, meaning the session
+//!    is already inside a worktree and its subagents inherit that isolation), and
+//! 3. a **sibling worktree exists** (`git worktree list` shows more than the
+//!    primary) — the sharpener that keeps the nudge silent unless a worktree is
+//!    actually in play.
+//!
+//! Silence permanently for a repo by setting `CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true`
+//! in `<repo>/.claude/settings.json`'s `env` block (or `~/.claude/settings.json`
+//! for user-global). For repos where dispatching subagents from main is the
+//! intended workflow.
+
+use cadence_hooks_core::shell::git_command;
+use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+
+/// Returns true if `repo_root` is a **primary checkout** — its `.git` is a
+/// directory. A linked worktree's `.git` is a *file* pointing into the primary
+/// repo's `.git/worktrees/`, so a `false` here means the session is already
+/// inside a worktree (and its subagents inherit that worktree). Mirrors the
+/// `.git`-dir primitive in `cadence_hooks_session::registry::ensure_git_excluded`.
+fn is_primary_checkout(repo_root: &str) -> bool {
+    Path::new(repo_root).join(".git").is_dir()
+}
+
+/// Count the worktrees in `git worktree list --porcelain` output.
+///
+/// Each worktree is introduced by a line starting with `worktree `. The primary
+/// checkout is always one entry, so `> 1` means at least one *sibling* worktree.
+fn count_worktrees(porcelain: &str) -> usize {
+    porcelain
+        .lines()
+        .filter(|l| l.starts_with("worktree "))
+        .count()
+}
+
+/// Returns true if `CADENCE_ALLOW_SUBAGENT_FROM_MAIN` is set to a truthy value.
+fn is_subagent_from_main_allowed() -> bool {
+    is_allowed_value(
+        std::env::var("CADENCE_ALLOW_SUBAGENT_FROM_MAIN")
+            .ok()
+            .as_deref(),
+    )
+}
+
+/// Pure: classify a `CADENCE_ALLOW_SUBAGENT_FROM_MAIN` value as truthy or falsy.
+///
+/// Truthy: `"1"`, `"true"`, `"yes"` (case-insensitive, trimmed). Anything else
+/// — unset, empty, `"0"`, `"false"` — is falsy. Mirrors `warn_main_branch`'s
+/// `is_main_allowed_value`.
+fn is_allowed_value(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("1" | "true" | "yes")
+    )
+}
+
+/// The nudge message: names the behavior (cwd inheritance → main, not the
+/// worktree) and both fixes, plus the silence env var.
+fn warn_message() -> String {
+    "You're dispatching a subagent from the main checkout while a sibling git worktree exists. \
+     Subagents inherit the spawning session's working directory, so this work will land in the \
+     main checkout — not the worktree.\n\
+     To isolate it: dispatch from a session already inside the worktree, or pass \
+     isolation: \"worktree\" to give the spawn a fresh agent-owned worktree.\n\
+     To silence for this repo: set CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true in .claude/settings.json"
+        .to_string()
+}
+
+/// Pure decision: should we warn about this subagent dispatch?
+///
+/// Nudge only when the session is in the primary checkout, a sibling worktree
+/// exists, the spawn isn't already worktree-isolated, we haven't warned this
+/// session, and the repo isn't permanently opted out. Any one of those
+/// suppresses the nudge.
+fn assess_spawn(
+    in_main: bool,
+    worktree_exists: bool,
+    isolation_worktree: bool,
+    already_warned: bool,
+    allowed: bool,
+) -> CheckResult {
+    if allowed || already_warned || isolation_worktree || !in_main || !worktree_exists {
+        return CheckResult::allow();
+    }
+    CheckResult::nudge(warn_message())
+}
+
+/// Warns once per session when a subagent is dispatched from the main checkout
+/// while a sibling worktree exists.
+pub struct WarnSubagentWorktree;
+
+impl WarnSubagentWorktree {
+    /// Build the per-session marker path scoped to a specific repo root.
+    ///
+    /// Hashes the repo root so two repos with the same name don't share markers.
+    /// The PPID component ties the marker to the Claude Code session — hooks run
+    /// as separate child processes, so `process::id()` changes every invocation;
+    /// the parent PID (Claude Code) is stable across a session. Mirrors
+    /// `warn_main_branch::marker_path`.
+    fn marker_path(repo_root: &str) -> PathBuf {
+        let mut hasher = DefaultHasher::new();
+        repo_root.hash(&mut hasher);
+        let hash = hasher.finish();
+
+        let ppid = std::env::var("PPID")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or_else(std::process::id);
+
+        cadence_hooks_core::paths::marker_temp_dir()
+            .join(format!(".claude-subagent-worktree-warned-{hash:x}-{ppid}"))
+    }
+}
+
+impl Check for WarnSubagentWorktree {
+    fn name(&self) -> &str {
+        "warn-subagent-worktree"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        // Only subagent dispatches. `Agent` is the current tool name; `Task` is
+        // the pre-2.1.63 name, kept for resilience. Every other tool call exits
+        // here before any git spawn. (In production the hooks.json matcher
+        // already filters to Agent|Task, so this is belt-and-suspenders.)
+        if !matches!(input.tool_name(), Some("Agent" | "Task")) {
+            return CheckResult::allow();
+        }
+
+        // cwd of the spawning session — the directory its subagents inherit.
+        let cwd = input.cwd.as_deref().unwrap_or(".");
+
+        // Not in a git repo → nothing to isolate. Fail open (ADR-0001).
+        let Some(repo_root) = git_command(cwd, &["rev-parse", "--show-toplevel"]) else {
+            return CheckResult::allow();
+        };
+
+        let in_main = is_primary_checkout(&repo_root);
+        let worktree_exists = git_command(cwd, &["worktree", "list", "--porcelain"])
+            .map(|out| count_worktrees(&out) > 1)
+            .unwrap_or(false);
+        let isolation_worktree = input.isolation() == Some("worktree");
+
+        let marker = Self::marker_path(&repo_root);
+        let already_warned = marker.exists();
+        let allowed = is_subagent_from_main_allowed();
+
+        let result = assess_spawn(
+            in_main,
+            worktree_exists,
+            isolation_worktree,
+            already_warned,
+            allowed,
+        );
+
+        if result.outcome == Outcome::Nudge {
+            let _ = std::fs::write(&marker, "");
+        }
+
+        result
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::test_builders::{make_agent, make_bash};
+
+    // --- assess_spawn (pure decision) ---
+
+    #[test]
+    fn all_conditions_met_warns() {
+        let result = assess_spawn(true, true, false, false, false);
+        assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.expect("nudge has a message");
+        assert!(msg.contains("worktree"));
+        assert!(msg.contains("CADENCE_ALLOW_SUBAGENT_FROM_MAIN"));
+    }
+
+    #[test]
+    fn allowed_suppresses() {
+        let result = assess_spawn(true, true, false, false, true);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn already_warned_suppresses() {
+        let result = assess_spawn(true, true, false, true, false);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn isolation_worktree_suppresses() {
+        // The spawn already gets a fresh worktree — nothing to warn about.
+        let result = assess_spawn(true, true, true, false, false);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn inside_worktree_suppresses() {
+        // Session is already inside a worktree (.git is a file) → its subagents
+        // inherit that worktree, so no nudge.
+        let result = assess_spawn(false, true, false, false, false);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn no_sibling_worktree_suppresses() {
+        // In main but no worktree in play — the common case, stays silent.
+        let result = assess_spawn(true, false, false, false, false);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn message_names_both_fixes() {
+        let msg = warn_message();
+        assert!(
+            msg.contains("inside the worktree"),
+            "should name the dispatch-from-inside fix: {msg}"
+        );
+        assert!(
+            msg.contains("isolation: \"worktree\""),
+            "should name the isolation fix: {msg}"
+        );
+    }
+
+    // --- count_worktrees ---
+
+    #[test]
+    fn count_worktrees_single_root() {
+        let porcelain = "worktree /Users/x/repo\nHEAD abc123\nbranch refs/heads/main\n";
+        assert_eq!(count_worktrees(porcelain), 1);
+    }
+
+    #[test]
+    fn count_worktrees_two_roots() {
+        let porcelain = "worktree /Users/x/repo\nHEAD abc\nbranch refs/heads/main\n\
+                         \nworktree /Users/x/repo/.claude/worktrees/feat\nHEAD def\nbranch refs/heads/feat\n";
+        assert_eq!(count_worktrees(porcelain), 2);
+    }
+
+    #[test]
+    fn count_worktrees_empty() {
+        assert_eq!(count_worktrees(""), 0);
+    }
+
+    #[test]
+    fn count_worktrees_ignores_non_worktree_lines() {
+        // A branch named "worktree-x" must not be counted — only lines that
+        // *start* with "worktree " (the porcelain entry marker) count.
+        let porcelain = "worktree /Users/x/repo\nbranch refs/heads/worktree-experiment\n";
+        assert_eq!(count_worktrees(porcelain), 1);
+    }
+
+    // --- is_primary_checkout (.git dir vs file) ---
+
+    #[test]
+    fn primary_checkout_when_git_is_dir() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir(dir.path().join(".git")).unwrap();
+        assert!(is_primary_checkout(dir.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn not_primary_checkout_when_git_is_file() {
+        // A linked worktree's .git is a file ("gitdir: ...").
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::write(
+            dir.path().join(".git"),
+            "gitdir: /repo/.git/worktrees/feat\n",
+        )
+        .unwrap();
+        assert!(!is_primary_checkout(dir.path().to_str().unwrap()));
+    }
+
+    #[test]
+    fn not_primary_checkout_when_git_absent() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!is_primary_checkout(dir.path().to_str().unwrap()));
+    }
+
+    // --- run() early exits ---
+
+    #[test]
+    fn non_agent_tool_allows() {
+        // A Bash call must never trip the warning — it returns before any git
+        // spawn, so no repo is needed.
+        let result = WarnSubagentWorktree.run(&make_bash("git status"));
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn agent_outside_git_repo_allows() {
+        // A temp dir that is not a git repo → rev-parse fails → fail-open allow.
+        let dir = tempfile::tempdir().unwrap();
+        let input = make_agent(Some("general-purpose"), None, dir.path().to_str().unwrap());
+        let result = WarnSubagentWorktree.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- isolation() round-trips via make_agent ---
+
+    #[test]
+    fn make_agent_carries_isolation() {
+        let input = make_agent(Some("general-purpose"), Some("worktree"), "/tmp");
+        assert_eq!(input.isolation(), Some("worktree"));
+        assert_eq!(input.subagent_type(), Some("general-purpose"));
+        assert_eq!(input.tool_name(), Some("Agent"));
+    }
+
+    #[test]
+    fn make_agent_omits_isolation_as_none() {
+        let input = make_agent(None, None, "/tmp");
+        assert_eq!(input.isolation(), None);
+        assert_eq!(input.subagent_type(), None);
+    }
+
+    // --- marker path ---
+
+    #[test]
+    fn marker_path_differs_per_repo() {
+        let a = WarnSubagentWorktree::marker_path("/tmp/repo-a");
+        let b = WarnSubagentWorktree::marker_path("/tmp/repo-b");
+        assert_ne!(a, b, "marker path must include a repo-specific hash");
+    }
+
+    #[test]
+    fn marker_path_stable_for_same_repo() {
+        let a = WarnSubagentWorktree::marker_path("/tmp/repo");
+        let b = WarnSubagentWorktree::marker_path("/tmp/repo");
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn marker_path_is_distinct_from_main_branch_marker() {
+        // The two once-per-session guards must not collide on a marker name, or
+        // one warning would suppress the other.
+        let m = WarnSubagentWorktree::marker_path("/tmp/repo");
+        assert!(
+            m.to_string_lossy().contains("subagent-worktree-warned"),
+            "marker name must be guard-specific: {}",
+            m.display()
+        );
+    }
+
+    // --- is_allowed_value (pure) ---
+
+    #[test]
+    fn allowed_value_unset_is_false() {
+        assert!(!is_allowed_value(None));
+    }
+
+    #[test]
+    fn allowed_value_empty_is_false() {
+        assert!(!is_allowed_value(Some("")));
+        assert!(!is_allowed_value(Some("   ")));
+    }
+
+    #[test]
+    fn allowed_value_falsy_strings() {
+        assert!(!is_allowed_value(Some("0")));
+        assert!(!is_allowed_value(Some("false")));
+        assert!(!is_allowed_value(Some("no")));
+        assert!(!is_allowed_value(Some("off")));
+    }
+
+    #[test]
+    fn allowed_value_truthy_strings() {
+        assert!(is_allowed_value(Some("1")));
+        assert!(is_allowed_value(Some("true")));
+        assert!(is_allowed_value(Some("yes")));
+    }
+
+    #[test]
+    fn allowed_value_case_insensitive() {
+        assert!(is_allowed_value(Some("TRUE")));
+        assert!(is_allowed_value(Some("Yes")));
+    }
+
+    #[test]
+    fn allowed_value_trims_whitespace() {
+        assert!(is_allowed_value(Some("  true  ")));
+        assert!(is_allowed_value(Some("\t1\n")));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -156,6 +156,8 @@ enum GuardrailsCommands {
     GuardGitInit,
     /// Warn when editing on main/master branch
     WarnMainBranch,
+    /// Warn when dispatching a subagent from main while a sibling worktree exists
+    WarnSubagentWorktree,
     /// Nudge after idle periods between edits
     CheckIdleReturn,
     /// Warn when creating a branch from a non-main base
@@ -295,6 +297,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::GuardGhWrite => "guard-gh-write",
             GuardrailsCommands::GuardGitInit => "guard-git-init",
             GuardrailsCommands::WarnMainBranch => "warn-main-branch",
+            GuardrailsCommands::WarnSubagentWorktree => "warn-subagent-worktree",
             GuardrailsCommands::CheckIdleReturn => "check-idle-return",
             GuardrailsCommands::WarnBranchBase => "warn-branch-base",
             GuardrailsCommands::WarnCronDatetime => "warn-cron-datetime",
@@ -633,6 +636,10 @@ fn main() {
             ),
             GuardrailsCommands::WarnMainBranch => run_check_from_stdin(
                 &cadence_hooks_guardrails::warn_main_branch::WarnMainBranch,
+                pre,
+            ),
+            GuardrailsCommands::WarnSubagentWorktree => run_check_from_stdin(
+                &cadence_hooks_guardrails::warn_subagent_worktree::WarnSubagentWorktree,
                 pre,
             ),
             GuardrailsCommands::CheckIdleReturn => run_check_from_stdin(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -126,6 +126,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::PreToolUse),
     },
     HookEntry {
+        name: "warn-subagent-worktree",
+        description: "Warn when dispatching a subagent from main while a sibling worktree exists",
+        plugin: "guardrails",
+        event: Some(HookEvent::PreToolUse),
+    },
+    HookEntry {
         name: "check-idle-return",
         description: "Nudge after idle periods between edits",
         plugin: "guardrails",
@@ -401,6 +407,12 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         ("session", "backstop-warn") => {
             Some(r#"{"session_id":"test","source":"startup","cwd":"/tmp"}"#)
         }
+        // warn-subagent-worktree only engages on an Agent/Task spawn; the generic
+        // Bash PreToolUse sample would no-op. Carry a cwd so the git checks have a
+        // directory to resolve against.
+        ("guardrails", "warn-subagent-worktree") => Some(
+            r#"{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose"},"cwd":"/tmp"}"#,
+        ),
         _ => None,
     }
 }


### PR DESCRIPTION
## What

A new PreToolUse check, `warn-subagent-worktree`. A subagent inherits the **spawning session's** working directory, so a session in the main checkout spawns subagents that operate on the main checkout — never a sibling worktree. The check nudges **once per session (per repo)** on an `Agent`/`Task` spawn when:

1. the session is in the **primary checkout** (`.git` is a directory, not a linked-worktree file — a session already inside a worktree is exempt, since its subagents inherit that worktree);
2. a **sibling worktree exists** (`git worktree list --porcelain` shows more than the primary — the sharpener that keeps it silent unless a worktree is actually in play);
3. the spawn does **not** set `isolation: "worktree"` (which would give it a fresh agent-owned worktree).

The nudge names both fixes — dispatch from inside the worktree, or pass `isolation: "worktree"` for a fresh one — and a permanent per-repo opt-out: `CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true`.

## Changes

- **core:** `ToolInput` gains `subagent_type` + `isolation` (snake_case, confirmed against real Agent payloads); `HookInput::isolation()` / `subagent_type()` accessors; a `make_agent` test builder.
- **guardrails:** `warn_subagent_worktree` with pure `assess_spawn` / `count_worktrees` / `is_primary_checkout` helpers, a once-per-session PPID-scoped marker (mirrors `warn-main-branch`), and the env opt-out. Wired into `main.rs` (clap + dispatch), `registry.rs` (HookEntry + `try` sample). 29 new tests.

## Coordination

Sibling wiring lands in **cadence-guardrails** (`hooks.json` PreToolUse matcher `Agent|Task`). `all_binary_subcommands_are_registered` is green once both land; GitHub CI has no siblings and skips that cross-sibling leg, so the internal `registry_matches_clap_dispatch` invariant is the gate (passing).

## Validation

`subagent_type` / `isolation` keys confirmed empirically from session transcripts (1799 `Agent` dispatches, 51 `isolation:"worktree"`). The B3 live test (dispatch from main with a worktree present → expect the one-time nudge; from inside the worktree → silence) is the end-to-end proof.

Closes cameronsjo/claude-configurations#201