### PR TITLE
feat(metrics): log-ask-user-question — diagnose AskUserQuestion (Recommended) stance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   Missing/invalid config, unreadable body files, and unrecognized commands all
   fail open silently. Binary subcommand only — the plugin's hooks.json wiring
   (with the `if` filter) lands in a separate PR.
+- **metrics: `log-ask-user-question` — record AskUserQuestion stance + shape on
+  every call** (#210 on claude-configurations). A fire-and-forget PreToolUse
+  logger that appends one line to `<metrics_dir>/askuserquestion.jsonl` per
+  AskUserQuestion call: the call's *stance* — `recommended` when an option label
+  carries `(Recommended)`, `declared_no_rec` when a question text carries the
+  `no clear recommendation` marker, else `silent` — plus its shape
+  (`multiSelect`, `nQuestions`, `nOptions`, `sessionId`, `model`). Stage 1 of
+  making `(Recommended)` reliable: pure observation, zero behavior change — the
+  `silent` rate is the diagnostic denominator for "is Claude omitting a
+  recommendation, or are the options genuinely equivalent?". The shared
+  `stance(...)` classifier (new `Stance` enum in `rules::askuserquestion`) is
+  reused by the `warn-recommended-option` nudge so the two never drift;
+  `MetricsInput` gains a `model` field. The `cadence-metrics` hooks.json wiring
+  ships alongside.
 
 ## [0.37.0] - 2026-06-22
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,6 +243,7 @@ name = "cadence-hooks-metrics"
 version = "0.38.0"
 dependencies = [
  "cadence-hooks-core",
+ "cadence-hooks-rules",
  "regex",
  "serde",
  "serde_json",

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -425,6 +425,10 @@ pub struct MetricsInput {
     pub parent_agent_id: Option<String>,
     pub source_agent_id: Option<String>,
     pub duration_ms: Option<u64>,
+    /// Model id for the session (e.g. `claude-opus-4-8`), when the payload
+    /// carries it (SessionStart and some Pre/PostToolUse payloads). Mirrors
+    /// [`HookInput::model`]; deserializes to `None` when absent.
+    pub model: Option<String>,
     /// Top-level keys present in the raw payload. Populated by [`Self::from_json`],
     /// not deserialized — powers the `CADENCE_METRICS_DEBUG` `_keys` field that
     /// surfaces schema additions across Claude Code releases.

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -7,6 +7,7 @@ description = "Fire-and-forget metrics loggers: cost-per-commit and subagent lif
 
 [dependencies]
 cadence-hooks-core.workspace = true
+cadence-hooks-rules.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -10,6 +10,8 @@ mod common;
 
 /// USD cost from token totals and a model name.
 pub mod compute_cost;
+/// Append AskUserQuestion stance/shape records to `askuserquestion.jsonl`.
+pub mod log_askuserquestion;
 /// Append cost-per-commit records to `commits.jsonl`.
 pub mod log_commit;
 /// Append polish-nudge (`gh pr create`) records to `polish_nudges.jsonl`.
@@ -23,6 +25,7 @@ pub mod scan_tokens;
 /// Snapshot HEAD before a `git commit`.
 pub mod snapshot;
 
+pub use log_askuserquestion::LogAskUserQuestion;
 pub use log_commit::LogCommit;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_subagent::LogSubagent;

--- a/crates/metrics/src/log_askuserquestion.rs
+++ b/crates/metrics/src/log_askuserquestion.rs
@@ -1,0 +1,170 @@
+//! `PreToolUse:AskUserQuestion` — append one line to
+//! `<metrics_dir>/askuserquestion.jsonl` recording the call's *stance*
+//! (recommended / declared-no-rec / silent) and *shape* (multiSelect, question
+//! and option counts).
+//!
+//! This is the diagnostic denominator for claude-configurations#210: it makes
+//! "how often does Claude declare a stance vs. stay silent on an
+//! AskUserQuestion?" queryable without mining transcripts. Stage 1 ships it
+//! pure-observational (no behavior change); the `silent` count — sampled by
+//! hand — settles whether a missing "(Recommended)" is an omission or a
+//! genuinely-equivalent question. The classifier is shared with the
+//! `warn-recommended-option` nudge
+//! ([`cadence_hooks_rules::askuserquestion::stance`]) so logger and nudge
+//! never drift.
+//!
+//! Silent no-op on any failure — never blocks (it is a [`Logger`]).
+
+use crate::common;
+use cadence_hooks_core::{AskQuestion, Logger, MetricsInput};
+use cadence_hooks_rules::askuserquestion::stance;
+use serde_json::{Value, json};
+use std::io::Write;
+
+/// Appends a stance/shape line to `askuserquestion.jsonl`.
+pub struct LogAskUserQuestion;
+
+impl Logger for LogAskUserQuestion {
+    fn name(&self) -> &str {
+        "log-ask-user-question"
+    }
+
+    fn run(&self, input: &MetricsInput) {
+        // Only the PreToolUse AskUserQuestion call carries `questions`; every
+        // other event no-ops before touching the filesystem.
+        let Some(questions) = input
+            .tool_input
+            .as_ref()
+            .and_then(|ti| ti.questions.as_deref())
+        else {
+            return;
+        };
+        if questions.is_empty() {
+            return;
+        }
+
+        let dir = common::metrics_dir();
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let path = dir.join("askuserquestion.jsonl");
+
+        let record = build_record(&common::utc_timestamp(), input, questions);
+
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&path)
+        {
+            // Single `write_all` of record + newline so concurrent appends from
+            // other sessions can't interleave (mirrors log_commit / log_polish_nudge).
+            let mut line = record.to_string();
+            line.push('\n');
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+/// Build the `askuserquestion.jsonl` record. Pure — no I/O.
+///
+/// `multiSelect` is true when *any* question in the call is multi-select;
+/// `nOptions` is the total option count across all questions. `model` and
+/// `sessionId` are recorded verbatim (null when the payload omits them) — they
+/// are JSON values only, never used to build a path, so no sanitizing is needed.
+fn build_record(ts: &str, input: &MetricsInput, questions: &[AskQuestion]) -> Value {
+    let n_options: usize = questions
+        .iter()
+        .map(|q| q.options.as_ref().map_or(0, |o| o.len()))
+        .sum();
+    let multi_select = questions.iter().any(|q| q.multi_select.unwrap_or(false));
+    json!({
+        "ts": ts,
+        "stance": stance(questions).as_str(),
+        "multiSelect": multi_select,
+        "nQuestions": questions.len(),
+        "nOptions": n_options,
+        "sessionId": input.session_id,
+        "model": input.model,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::AskOption;
+
+    fn q(text: &str, labels: &[&str], multi: bool) -> AskQuestion {
+        AskQuestion {
+            question: Some(text.into()),
+            header: Some("H".into()),
+            multi_select: Some(multi),
+            options: Some(
+                labels
+                    .iter()
+                    .map(|l| AskOption {
+                        label: Some((*l).into()),
+                        description: None,
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    fn input_with_model(model: Option<&str>) -> MetricsInput {
+        MetricsInput {
+            session_id: Some("s1".into()),
+            model: model.map(str::to_string),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn name_is_log_ask_user_question() {
+        assert_eq!(LogAskUserQuestion.name(), "log-ask-user-question");
+    }
+
+    #[test]
+    fn record_captures_silent_stance_and_shape() {
+        let qs = vec![q("Which approach?", &["A", "B", "C"], false)];
+        let rec = build_record(
+            "2026-06-22T00:00:00Z",
+            &input_with_model(Some("claude-opus-4-8")),
+            &qs,
+        );
+        assert_eq!(rec["ts"], "2026-06-22T00:00:00Z");
+        assert_eq!(rec["stance"], "silent");
+        assert_eq!(rec["multiSelect"], false);
+        assert_eq!(rec["nQuestions"], 1);
+        assert_eq!(rec["nOptions"], 3);
+        assert_eq!(rec["sessionId"], "s1");
+        assert_eq!(rec["model"], "claude-opus-4-8");
+    }
+
+    #[test]
+    fn record_captures_recommended_stance() {
+        let qs = vec![q("Which?", &["A (Recommended)", "B"], false)];
+        let rec = build_record("ts", &input_with_model(None), &qs);
+        assert_eq!(rec["stance"], "recommended");
+        // Absent model → null, not omitted.
+        assert!(rec["model"].is_null());
+    }
+
+    #[test]
+    fn record_captures_declared_no_rec_stance() {
+        let qs = vec![q("Which? — no clear recommendation", &["A", "B"], false)];
+        let rec = build_record("ts", &input_with_model(None), &qs);
+        assert_eq!(rec["stance"], "declared_no_rec");
+    }
+
+    #[test]
+    fn record_sums_options_and_ors_multiselect_across_questions() {
+        let qs = vec![
+            q("Q1?", &["A", "B"], false),
+            q("Q2?", &["C", "D", "E"], true),
+        ];
+        let rec = build_record("ts", &input_with_model(None), &qs);
+        assert_eq!(rec["nQuestions"], 2);
+        assert_eq!(rec["nOptions"], 5);
+        assert_eq!(rec["multiSelect"], true);
+    }
+}

--- a/crates/rules/src/askuserquestion.rs
+++ b/crates/rules/src/askuserquestion.rs
@@ -11,10 +11,89 @@
 //! "(Recommended)" rule is conditional ("when you have a clear preference"), so
 //! a hard block would over-apply to genuinely-equivalent options.
 
-use cadence_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{AskQuestion, Check, CheckResult, HookInput};
 use std::collections::HashMap;
 
+/// Case-sensitive by design: option labels are machine-emitted, so the exact
+/// `(Recommended)` casing is expected — unlike [`NO_REC_MARKER`], which scans
+/// free-form question prose and so matches case-insensitively.
 const RECOMMENDED_MARKER: &str = "(Recommended)";
+
+/// The phrase that marks a question as deliberately offering no recommendation.
+/// Detected case-insensitively anywhere in the question text (tolerant of the
+/// `— no clear recommendation` framing the rule suggests), so Claude can declare
+/// genuine neutrality instead of staying silent. See [`Stance`].
+const NO_REC_MARKER: &str = "no clear recommendation";
+
+/// Whether an AskUserQuestion call makes Claude's stance on its options legible.
+///
+/// The reader of an AskUserQuestion (often Cameron, later, with no conversation
+/// to anchor it) should always be able to tell *Claude's* stance — a clear pick,
+/// or a deliberate "these are genuine trade-offs" — and never be left guessing
+/// whether Claude simply forgot. The three buckets are mutually exclusive;
+/// [`stance`] resolves them in priority order.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stance {
+    /// At least one option label carries the `(Recommended)` marker.
+    Recommended,
+    /// No recommended option, but a question text declares no clear
+    /// recommendation (the explicit-neutrality marker).
+    DeclaredNoRec,
+    /// Neither signal — Claude said nothing about which option it prefers.
+    Silent,
+}
+
+impl Stance {
+    /// Stable lowercase tag for logging/JSONL
+    /// (`recommended` / `declared_no_rec` / `silent`).
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Stance::Recommended => "recommended",
+            Stance::DeclaredNoRec => "declared_no_rec",
+            Stance::Silent => "silent",
+        }
+    }
+}
+
+/// Classify an AskUserQuestion call's stance from its questions.
+///
+/// Priority: a `(Recommended)` label wins over a no-rec marker (a call that both
+/// recommends and hedges still expresses a preference); `Silent` is the absence
+/// of both. Shared by the [`WarnRecommendedOption`] nudge and the
+/// `log-ask-user-question` metrics logger so the two never drift.
+pub fn stance(questions: &[AskQuestion]) -> Stance {
+    if has_recommended(questions) {
+        Stance::Recommended
+    } else if declares_no_rec(questions) {
+        Stance::DeclaredNoRec
+    } else {
+        Stance::Silent
+    }
+}
+
+/// True when any option label across all questions carries `(Recommended)`.
+fn has_recommended(questions: &[AskQuestion]) -> bool {
+    questions
+        .iter()
+        .flat_map(|q| q.options.iter().flatten())
+        .any(|o| {
+            o.label
+                .as_deref()
+                .is_some_and(|l| l.contains(RECOMMENDED_MARKER))
+        })
+}
+
+/// True when any question text declares no clear recommendation.
+fn declares_no_rec(questions: &[AskQuestion]) -> bool {
+    questions
+        .iter()
+        .any(|q| q.question.as_deref().is_some_and(contains_no_rec_marker))
+}
+
+/// Case-insensitive, prose-tolerant detection of the no-recommendation marker.
+fn contains_no_rec_marker(text: &str) -> bool {
+    text.to_ascii_lowercase().contains(NO_REC_MARKER)
+}
 
 /// PreToolUse nudge: remind Claude to label a recommended AskUserQuestion option.
 pub struct WarnRecommendedOption;
@@ -34,15 +113,10 @@ impl Check for WarnRecommendedOption {
         if questions.is_empty() {
             return CheckResult::allow();
         }
-        let has_recommended = questions
-            .iter()
-            .flat_map(|q| q.options.iter().flatten())
-            .any(|o| {
-                o.label
-                    .as_deref()
-                    .is_some_and(|l| l.contains(RECOMMENDED_MARKER))
-            });
-        if has_recommended {
+        // Stage 1 (diagnose): behavior unchanged — still nudge whenever no option
+        // is labeled "(Recommended)". Stage 2 will gate this on `stance(...) ==
+        // Silent` so a declared "no clear recommendation" stops tripping it.
+        if has_recommended(questions) {
             CheckResult::allow()
         } else {
             CheckResult::nudge(
@@ -225,6 +299,91 @@ mod tests {
             WarnRecommendedOption.run(&input).outcome,
             cadence_hooks_core::Outcome::Allow
         );
+    }
+
+    // --- Stance classifier ---
+
+    fn q(text: &str, labels: &[&str]) -> AskQuestion {
+        AskQuestion {
+            question: Some(text.into()),
+            header: Some("H".into()),
+            multi_select: Some(false),
+            options: Some(
+                labels
+                    .iter()
+                    .map(|l| AskOption {
+                        label: Some((*l).into()),
+                        description: None,
+                    })
+                    .collect(),
+            ),
+        }
+    }
+
+    #[test]
+    fn stance_recommended_when_label_marked() {
+        let qs = vec![q("Which approach?", &["A (Recommended)", "B"])];
+        assert_eq!(stance(&qs), Stance::Recommended);
+    }
+
+    #[test]
+    fn stance_declared_no_rec_when_question_marks_neutral() {
+        let qs = vec![q("Which approach? — no clear recommendation", &["A", "B"])];
+        assert_eq!(stance(&qs), Stance::DeclaredNoRec);
+    }
+
+    #[test]
+    fn stance_silent_when_neither_signal() {
+        let qs = vec![q("Which approach?", &["A", "B"])];
+        assert_eq!(stance(&qs), Stance::Silent);
+    }
+
+    #[test]
+    fn stance_recommended_beats_declared_no_rec() {
+        // A call that both recommends and hedges still expresses a preference.
+        let qs = vec![q(
+            "Which approach? — no clear recommendation",
+            &["A (Recommended)", "B"],
+        )];
+        assert_eq!(stance(&qs), Stance::Recommended);
+    }
+
+    #[test]
+    fn stance_no_rec_marker_in_any_question_counts() {
+        let qs = vec![
+            q("First question?", &["A", "B"]),
+            q("Second? — no clear recommendation", &["C", "D"]),
+        ];
+        assert_eq!(stance(&qs), Stance::DeclaredNoRec);
+    }
+
+    #[test]
+    fn stance_recommended_in_one_question_beats_no_rec_in_another() {
+        // Cross-question priority: a `(Recommended)` label in *any* question
+        // outranks a no-rec marker in a *different* question.
+        let qs = vec![
+            q("First — no clear recommendation", &["A", "B"]),
+            q("Second?", &["C (Recommended)", "D"]),
+        ];
+        assert_eq!(stance(&qs), Stance::Recommended);
+    }
+
+    #[test]
+    fn no_rec_marker_is_case_insensitive_and_prose_tolerant() {
+        assert!(contains_no_rec_marker(
+            "These are genuine trade-offs — No Clear Recommendation."
+        ));
+        assert!(contains_no_rec_marker("no clear recommendation"));
+        // The bare prose "recommend" must not count, nor a near-miss phrase.
+        assert!(!contains_no_rec_marker("I recommend option A clearly"));
+        assert!(!contains_no_rec_marker("no recommendation given"));
+    }
+
+    #[test]
+    fn stance_as_str_tags() {
+        assert_eq!(Stance::Recommended.as_str(), "recommended");
+        assert_eq!(Stance::DeclaredNoRec.as_str(), "declared_no_rec");
+        assert_eq!(Stance::Silent.as_str(), "silent");
     }
 
     // --- WarnEmptyAnswers ---

--- a/src/main.rs
+++ b/src/main.rs
@@ -233,6 +233,8 @@ enum MetricsCommands {
     LogSubagent,
     /// Log polish-nudge skips: `gh pr create` + whether /polish ran (PostToolUse)
     LogPolishNudge,
+    /// Log AskUserQuestion stance + shape on every call (PreToolUse)
+    LogAskUserQuestion,
 }
 
 #[derive(Subcommand)]
@@ -337,6 +339,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::LogCommit { .. } => "log-commit",
             MetricsCommands::LogSubagent => "log-subagent",
             MetricsCommands::LogPolishNudge => "log-polish-nudge",
+            MetricsCommands::LogAskUserQuestion => "log-ask-user-question",
         }),
         Commands::Lab(l) => Some(match l {
             LabCommands::PersonaNudge => "persona-nudge",
@@ -759,6 +762,10 @@ fn main() {
             MetricsCommands::LogPolishNudge => run_logger_from_stdin(
                 &cadence_hooks_metrics::LogPolishNudge,
                 registry::sample_for("metrics", "log-polish-nudge"),
+            ),
+            MetricsCommands::LogAskUserQuestion => run_logger_from_stdin(
+                &cadence_hooks_metrics::LogAskUserQuestion,
+                registry::sample_for("metrics", "log-ask-user-question"),
             ),
         },
         Commands::Lab(cmd) => match cmd {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -290,6 +290,12 @@ pub const HOOKS: &[HookEntry] = &[
         plugin: "metrics",
         event: None,
     },
+    HookEntry {
+        name: "log-ask-user-question",
+        description: "Log AskUserQuestion stance + shape on every call (PreToolUse)",
+        plugin: "metrics",
+        event: None,
+    },
     // lab
     HookEntry {
         name: "persona-nudge",
@@ -383,6 +389,11 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         // log-polish-nudge gates on a `gh pr create` command (the nudge denominator)
         ("metrics", "log-polish-nudge") => Some(
             r#"{"session_id":"test","hook_event_name":"PostToolUse","tool_input":{"command":"gh pr create --title test"},"transcript_path":"/tmp/transcript.jsonl"}"#,
+        ),
+        // log-ask-user-question records every AskUserQuestion call's stance +
+        // shape; the generic logger sample carries no `questions` and would no-op.
+        ("metrics", "log-ask-user-question") => Some(
+            r#"{"session_id":"test","hook_event_name":"PreToolUse","model":"claude-opus-4-8","tool_input":{"questions":[{"question":"Which approach?","header":"Approach","multiSelect":false,"options":[{"label":"Option A","description":"first"},{"label":"Option B","description":"second"}]}]}}"#,
         ),
         // warn-branch-drift early-exits unless the command is a git commit —
         // the generic PreToolUse sample (`git status`) would never reach the
@@ -525,6 +536,7 @@ mod tests {
             "log-commit",
             "log-subagent",
             "log-polish-nudge",
+            "log-ask-user-question",
             "heartbeat",
             "end",
             "backstop-record",


### PR DESCRIPTION
## What

Stage 1 of making `(Recommended)` reliable on `AskUserQuestion` — **diagnose first** (cameronsjo/claude-configurations#210).

Adds a fire-and-forget PreToolUse logger, `metrics log-ask-user-question`, that records every `AskUserQuestion` call's **stance** and **shape** to `<metrics_dir>/askuserquestion.jsonl`. **Zero behavior change** — the existing `warn-recommended-option` nudge is untouched this PR.

## Why

Claude often asks an `AskUserQuestion` without labeling any option `(Recommended)`. It was unanswerable whether that's an *omission* (a real miss) or *genuine equivalence* (where omitting is correct), because two things are true at once:

1. The `warn-recommended-option` nudge fires too late to fix its own call (exit 0 → the tool proceeds; the nudge only lands next turn).
2. Sometimes omitting is correct — the rule is conditional ("when you have a clear preference").

A hook can't *pick* the recommended option or judge "do you have a preference?". So Stage 1 just **measures**: the `silent` rate, sampled by hand, settles omission vs. equivalence before Stage 2 changes any behavior.

## What's in this PR

- New `Stance` classifier in `rules::askuserquestion` — `Recommended` (an option label carries `(Recommended)`), `DeclaredNoRec` (a question text carries the `no clear recommendation` marker), else `Silent`. **Shared** with the Stage 2 nudge so the two never drift. `DeclaredNoRec` stays empty until Stage 2's rule ships — that emptiness is the lift it will later show.
- New `metrics log-ask-user-question` logger → appends `{ts, stance, multiSelect, nQuestions, nOptions, sessionId, model}` per call.
- `MetricsInput` gains a `model` field (mirrors `HookInput::model`).
- Registered per the registry/dispatch invariant (clap variant + `HOOKS` entry `event: None` + sample payload); `registry_matches_clap_dispatch` stays green.

## Note on wiring location

The companion hooks.json wiring is a sibling PR on `cameronsjo/cadence-metrics`. The original plan said wire it into `cadence-rules/hooks.json`, but a `metrics`-namespace subcommand wired in the `rules` plugin dir trips the `no_cross_plugin_hooks` audit — loggers belong in `cadence-metrics` (matches `snapshot` / `log-commit` / `log-subagent`). Same runtime behavior (fires on PreToolUse:AskUserQuestion), audit-clean.

## Verification

- `cargo fmt --all --check` + `clippy -D warnings` clean.
- `registry_matches_clap_dispatch` ✓; rules crate 68 tests, metrics crate 103 tests, 0 failures (incl. 7 new classifier tests + 5 new logger tests).
- Runtime smoke test against the debug binary: `silent` / `recommended` / `declared_no_rec` payloads classify correctly; a non-AskUserQuestion payload writes no line; every exit is 0.
- Pre-existing local `hook_registration_audit` failures (`cadence redact-external-content` + `metrics log-polish-nudge` unwired in sibling checkouts; a cross-plugin `inject-gh-context`) are unrelated and skip on CI (no sibling plugin dirs).

## Not in this PR (Stage 2, after data)

- Rewrite the cadence "AskUserQuestion Discipline" `MUST` as a declare-your-stance pair.
- Gate `warn-recommended-option` on `stance == Silent` only (quiets the false alarms). Stays a nudge — ADR 0020 preserved.

Stage 1 of cameronsjo/claude-configurations#210
