### PR TITLE
ci: reusable plugin-hooks-skew workflow_call gate

### DIFF
--- a/.github/workflows/plugin-hooks-skew.yml
+++ b/.github/workflows/plugin-hooks-skew.yml
@@ -1,0 +1,44 @@
+name: plugin-hooks-skew
+
+# Reusable gate for cadence plugins: a plugin's hooks.json must only reference
+# cadence-hooks subcommands present in the LATEST RELEASED binary. Each plugin
+# calls this from a thin hooks-skew.yml. Enforces "release the binary before the
+# plugin wiring goes live", so a SessionStart `doctor` skew advisory never
+# reaches users on the tap (claude-configurations #223).
+#
+# When called, actions/checkout checks out the CALLER plugin's repo, so
+# `doctor --root .` scans that plugin's hooks.json.
+
+on:
+  workflow_call: {}
+
+permissions:
+  contents: read
+
+jobs:
+  doctor:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install latest released cadence-hooks
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="$(gh release view --repo cameronsjo/cadence-hooks --json tagName --jq .tagName)"
+          echo "Latest released cadence-hooks: $tag"
+          gh release download "$tag" --repo cameronsjo/cadence-hooks \
+            --pattern "*linux-x86_64.tar.gz" --dir /tmp/ch
+          tar -xzf /tmp/ch/*linux-x86_64.tar.gz -C /tmp/ch
+          bin="$(find /tmp/ch -type f -name cadence-hooks | head -n1)"
+          mkdir -p "$HOME/.local/bin"
+          install -m 0755 "$bin" "$HOME/.local/bin/cadence-hooks"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
+          "$HOME/.local/bin/cadence-hooks" --version
+
+      # Verbose doctor exits non-zero on subcommand skew (1) or a shell-expansion
+      # bug (2). NOT --quiet: that suppresses the skew warning's exit code (it's
+      # the non-blocking SessionStart preflight mode).
+      - name: doctor — released binary must support every wired subcommand
+        run: cadence-hooks doctor --root .


### PR DESCRIPTION
## What

A reusable `workflow_call` gate, `plugin-hooks-skew`. It installs the latest **released** cadence-hooks and runs `cadence-hooks doctor --root .` against the **calling** plugin's checkout, failing on subcommand skew. Each cadence plugin that wires cadence-hooks calls it from a thin ~12-line `hooks-skew.yml`, so the gate logic lives in one place.

## Why

Prevention for cameronsjo/claude-configurations#223 — the `metrics log-ask-user-question` hook shipped to the marketplace before a cadence-hooks release carried the subcommand, so the SessionStart `doctor` advisory nagged every session with a `brew upgrade` that was a no-op. This gate enforces "release the binary first, then wire the plugin."

## Rollout (after this merges)

Each qualifying plugin (cadence, cadence-rules, cadence-guardrails, cadence-canon, cadence-lab, cadence-metrics) gets a thin caller:

```yaml
jobs:
  doctor:
    uses: cameronsjo/cadence-hooks/.github/workflows/plugin-hooks-skew.yml@main
```

cadence-metrics PR #6 currently carries the inline version; it converts to the caller once this merges.

## Verified

- The install + `doctor --root .` mechanism already runs green in CI on cadence-metrics PR #6.
- actionlint clean; only `${{ github.token }}` in an `env:` block (no untrusted-input interpolation); checkout pulls the caller repo, so `--root .` scans the caller's hooks.json.

Refs cameronsjo/claude-configurations#223


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated validation workflow for plugin hook configurations to detect compatibility issues with the latest released binary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->