### PR TITLE
ci: pin actions/checkout to commit SHA in reusable gate

### DIFF
--- a/.github/workflows/plugin-hooks-skew.yml
+++ b/.github/workflows/plugin-hooks-skew.yml
@@ -19,7 +19,7 @@ jobs:
   doctor:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Install latest released cadence-hooks
         env:


### PR DESCRIPTION
Pin the unpinned `actions/checkout@v4` to its commit SHA (zizmor unpinned-uses, supply-chain). The plugin callers then pin to this workflow's resulting commit SHA. Refs cameronsjo/claude-configurations#223