### PR TITLE
chore: release 0.40.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.40.0] - 2026-06-23
+
 ### Fixed
 
 - **doctor: honest version-skew advisory + clearer bare invocation** (#223 on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -207,7 +207,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -219,7 +219,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -229,7 +229,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -240,7 +240,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -251,7 +251,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -259,7 +259,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -269,7 +269,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.39.0"
+version = "0.40.0"
 dependencies = [
  "cadence-hooks-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.39.0"
+version = "0.40.0"
 edition = "2024"
 license = "BSL-1.1"
 authors = ["Cameron Sjo"]


### PR DESCRIPTION
Cuts 0.40.0 — ships #115 (honest version-skew advisory + clearer bare invocation). Squash-merging this changes Cargo.toml on main, which triggers auto-tag → release.yml → tap bump. Refs cameronsjo/claude-configurations#223