### PR TITLE
fix(guardrails): warn-main-branch — carve out docs/plans/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **warn-main-branch: carve out `docs/plans/`** (#226 on claude-configurations).
+  The on-main editing nudge fires once per session, and a plan-document write to
+  `docs/plans/` — which cadence mandates on the default branch — consumed that
+  one-shot warning, letting later real product edits on `main` escape unwarned.
+  Plan-doc directories are now exempt alongside the existing `.claude/` carve-out
+  (consecutive `docs`→`plans` path components; a bare `plans/` or a look-alike
+  such as `mydocs/plans` still warns). Nudge-only; the fail-open contract is
+  unchanged.
+
 ## [0.40.0] - 2026-06-23
 
 ### Fixed

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -13,8 +13,9 @@
 //!
 //! Edits inside any `.claude/` directory are exempt automatically — worktrees
 //! under `.claude/worktrees/` (always on an intentional feature branch) and the
-//! user's `~/.claude/` config and memory tree. That work is never the
-//! branch-worthy product change the warning targets.
+//! user's `~/.claude/` config and memory tree. Plan documents under `docs/plans/`
+//! are exempt too: cadence mandates copying approved plans there on the default
+//! branch. That work is never the branch-worthy product change the warning targets.
 
 use crate::dismiss_main_branch_warn;
 use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
@@ -76,6 +77,22 @@ fn git_dir_for_input(input: &HookInput) -> PathBuf {
 /// `.claude-old` or `myclaude` are not exempt.
 fn is_claude_managed_dir(dir: &Path) -> bool {
     dir.components().any(|c| c.as_os_str() == ".claude")
+}
+
+/// Returns true if `dir` is a cadence plan-document directory (`docs/plans`).
+///
+/// Approved plans are copied to `docs/plans/` on the default branch by design —
+/// cadence's plan-execution rule mandates it — so authoring a plan there is not
+/// the branch-worthy product change this warning targets. Without the carve-out
+/// the once-per-session warning is *consumed* by that first plan-doc write, so
+/// later real product edits on `main` then escape unwarned (issue #226).
+///
+/// Matches consecutive `docs` → `plans` path components anywhere in the path, so
+/// a bare `plans/`, a non-adjacent `docs/foo/plans`, or a look-alike like
+/// `mydocs/plans` is not exempt.
+fn is_plan_doc_dir(dir: &Path) -> bool {
+    let comps: Vec<_> = dir.components().map(|c| c.as_os_str()).collect();
+    comps.windows(2).any(|w| w[0] == "docs" && w[1] == "plans")
 }
 
 /// Returns true if the branch name is a default branch (`main` or `master`).
@@ -156,9 +173,10 @@ impl Check for WarnMainBranch {
         let dir = git_dir_for_input(input);
 
         // Edits inside a `.claude/` directory are tooling, config, or worktree
-        // work — never branch-worthy product changes. Skip the warning (and the
-        // git spawns below) entirely. (issues #33, #35)
-        if is_claude_managed_dir(&dir) {
+        // work, and plan docs under `docs/plans/` are mandated on the default
+        // branch — never the branch-worthy product change this warns about. Skip
+        // the warning (and the git spawns below) entirely. (issues #33, #35, #226)
+        if is_claude_managed_dir(&dir) || is_plan_doc_dir(&dir) {
             return CheckResult::allow();
         }
 
@@ -597,5 +615,53 @@ mod tests {
     fn relative_dot_dir_is_not_managed() {
         // The Bash fallback resolves to ".", which has no `.claude` component.
         assert!(!is_claude_managed_dir(Path::new(".")));
+    }
+
+    // --- docs/plans carve-out (#226) ---
+    // Approved plans are copied to docs/plans/ on the default branch by design
+    // (cadence's plan-execution rule mandates it), so plan-doc authoring there
+    // is not the branch-worthy product change this warning targets.
+
+    #[test]
+    fn docs_plans_dir_is_plan_doc() {
+        assert!(is_plan_doc_dir(Path::new("/Users/x/repo/docs/plans")));
+    }
+
+    #[test]
+    fn nested_under_docs_plans_is_plan_doc() {
+        // A subdirectory beneath docs/plans/ (e.g. an archive folder) still counts.
+        assert!(is_plan_doc_dir(Path::new(
+            "/Users/x/repo/docs/plans/2026/q2"
+        )));
+    }
+
+    #[test]
+    fn plan_doc_dir_requires_docs_parent() {
+        // A bare `plans/` without an immediate `docs/` parent is not exempt —
+        // a product `plans/` dir must still warn on main.
+        assert!(!is_plan_doc_dir(Path::new("/Users/x/repo/plans")));
+        assert!(!is_plan_doc_dir(Path::new("/Users/x/repo/src/plans")));
+    }
+
+    #[test]
+    fn docs_without_plans_is_not_plan_doc() {
+        // Other docs subdirs (adr, architecture) are process/product docs that
+        // should still warn on main.
+        assert!(!is_plan_doc_dir(Path::new("/Users/x/repo/docs")));
+        assert!(!is_plan_doc_dir(Path::new("/Users/x/repo/docs/adr")));
+    }
+
+    #[test]
+    fn plan_doc_lookalike_dirs_are_not_exempt() {
+        // Exact-component match: `mydocs/plans` or `docs-old/plans` are not the
+        // canonical docs/plans path.
+        assert!(!is_plan_doc_dir(Path::new("/Users/x/repo/mydocs/plans")));
+        assert!(!is_plan_doc_dir(Path::new("/Users/x/repo/docs-old/plans")));
+    }
+
+    #[test]
+    fn plan_doc_dir_components_must_be_consecutive() {
+        // `docs/` then a different dir then `plans/` is not the canonical path.
+        assert!(!is_plan_doc_dir(Path::new("/Users/x/repo/docs/foo/plans")));
     }
 }


### PR DESCRIPTION
## Problem

`warn-main-branch` nudges once per session when you edit on `main`/`master`. But a plan-document write to `docs/plans/` — which cadence's plan-execution rule mandates copying to the default branch — trips it, and because the warning is once-per-session, that first plan-doc write **consumes** it. Later real product edits on `main` in the same session then escape unwarned. So this is a correctness gap, not just noise.

Reported on cameronsjo/claude-configurations#226 (guard #1 of three). The other two were validated and routed: the idle-return nudge's earn-its-keep review moved to #228, and the subagent-from-main warning is working-as-designed (no read-only signal in the dispatch payload).

## Fix

Exempt plan-document directories alongside the existing `.claude/` carve-out. `is_plan_doc_dir` matches **consecutive** `docs` → `plans` path components anywhere in the path:

- `docs/plans/`, `docs/plans/2026/...` → exempt
- a bare `plans/`, `src/plans/`, a non-adjacent `docs/foo/plans`, or a look-alike like `mydocs/plans` → still warns

The carve-out returns before the git spawns, mirroring `is_claude_managed_dir`. Nudge-only; the fail-open contract (ADR-0001) is unchanged.

## Tests

- 7 new pure-predicate tests: exempt cases, requires-`docs`-parent, non-adjacent components, exact-component look-alikes.
- `make ci` green — 2149 tests pass, clippy `-D warnings` clean.
- End-to-end against the built binary: a `docs/plans/` write on `main` now allows; a `crates/.../src` write on `main` still nudges.

Part of cameronsjo/claude-configurations#226


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Fixed the main-branch warning nudge to no longer trigger when writing plan documents under `docs/plans/`. This directory is now properly exempted alongside `.claude/`, while the nudge still activates for similar-looking paths like `mydocs/plans` or `docs-old/plans`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->