### PR TITLE
feat(cadence): give the polish nudge teeth — transcript-aware conditional block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **nudge-polish-before-pr: transcript-aware conditional block** (#151 on
+  claude-configurations). The pre-PR polish reminder was a soft nudge (allow +
+  warn) on every `gh pr create`, so the model could talk past it — "day 3 of
+  polish not needed." It now scans the session transcript (via
+  `core::transcript::transcript_has_polish_run`, extracted from the metrics
+  logger into a shared module and tightened — exact-leaf match replaces the
+  prior `.contains("polish")`, so the metrics logger's `polished` field no
+  longer counts decoys like `repolish`) for a real `cadence-forge:polish` Skill
+  run and routes a 3-way,
+  fail-open outcome: a transcript **showing** a polish run → silent **allow**
+  (kills the nag-after-polish noise); a readable transcript with **no** polish
+  run → **block** (exit 2, the teeth); no / empty / unreadable / unparsable
+  transcript → the original **nudge** (ADR-0001 — never block on our own missing
+  data). Polish-skill detection is leaf-exact (rejects decoys that merely
+  contain `polish`). The
+  block message reassigns authority — run `/polish`, or surface a believed-
+  legitimate skip to Cameron, who decides; the model may not self-approve — and
+  does not advertise a self-serve bypass. Same subcommand, event, and matcher;
+  `HookInput` gains a `transcript_path` field (a documented common field on
+  every hook event).
+
 ### Fixed
 
 - **warn-main-branch: carve out `docs/plans/`** (#226 on claude-configurations).

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -1,20 +1,32 @@
-//! Nudge to run `/polish` before creating a pull request.
+//! Gate `/polish` before creating a pull request.
 //!
-//! Fires on `gh pr create` and reminds the model that
-//! [cadence-forge:polish](https://github.com/cameronsjo/cadence-forge) runs a
-//! branch-scoped pass over the changes vs `origin/main` — simplify, logging,
-//! tests, docs, security, and code review. Skill, agent, command, and rule
-//! markdown (and CLAUDE.md) are behavior, not documentation, so they are in
-//! scope; literal documentation (prose about the system) routes to
-//! `/polish docs`. Skippable only when the branch is a trivial one-liner or has
-//! already been taken through `/polish` — planning, TDD, attune, and a manual
-//! code-review precede polish, they don't replace it. A skip must be stated and
-//! justified, never silent.
+//! Fires on `gh pr create`. Polish is mandatory before a PR, so this check is
+//! transcript-aware: it scans the session transcript for a real
+//! [cadence-forge:polish](https://github.com/cameronsjo/cadence-forge) Skill
+//! invocation and routes a 3-way, fail-open outcome:
+//!
+//! - transcript **shows** a polish Skill run → **allow** (silent — no nag after
+//!   a real polish run);
+//! - transcript is readable with **no** polish run → **block** (an evidenced
+//!   skip — the teeth);
+//! - no transcript / unreadable / parse error → **nudge** (ADR-0001 fail-open;
+//!   never block on our own missing data).
+//!
+//! `/polish` runs a branch-scoped pass over the changes vs `origin/main` —
+//! simplify, logging, tests, docs, security, and code review. Skill, agent,
+//! command, and rule markdown (and CLAUDE.md) are behavior, not documentation,
+//! so they are in scope; literal documentation (prose about the system) routes
+//! to `/polish docs`. A skip is legitimate only for a trivial one-liner or a
+//! branch already taken through `/polish` — and the model may not self-approve
+//! one: it surfaces the decision to Cameron. (The subcommand id stays
+//! `nudge-polish-before-pr` for wiring stability even though it now can block.)
 
 use cadence_hooks_core::shell::is_gh_pr_create;
+use cadence_hooks_core::transcript::transcript_has_polish_run;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
-/// Nudges to run `/polish` (cadence-forge:polish) before opening a PR.
+/// Gates `/polish` (cadence-forge:polish) before opening a PR — conditional on
+/// transcript evidence of a real polish run.
 pub struct NudgePolishBeforePr;
 
 impl Check for NudgePolishBeforePr {
@@ -26,24 +38,78 @@ impl Check for NudgePolishBeforePr {
         let Some(command) = input.command() else {
             return CheckResult::allow();
         };
-
-        if !is_gh_pr_create(command) {
-            return CheckResult::allow();
-        }
-
-        CheckResult::nudge(
-            "Before opening this PR, consider `/polish` (cadence-forge:polish) \
-             — a branch-scoped pass vs `origin/main`: simplify, logging, tests, \
-             docs, security, code review. Skill / agent / command / rule \
-             markdown and CLAUDE.md are behavior, not documentation — IN scope; \
-             only *literal* docs (prose about the system) route to \
-             `/polish docs`. Skip ONLY if it's a trivial one-liner or already \
-             went through `/polish` — planning, TDD, attune, or a code-review \
-             precede polish, they don't replace it. If you skip, say so and \
-             why — don't skip silently."
-                .to_string(),
-        )
+        // Read the session transcript when the payload names one and it is
+        // readable. A missing path, a non-file, or a read error all collapse to
+        // `None`, and `decide` then fails open to a nudge — we never block on
+        // our own missing data (ADR-0001).
+        let transcript = input
+            .transcript_path()
+            .filter(|p| std::path::Path::new(p).is_file())
+            .and_then(|p| std::fs::read_to_string(p).ok());
+        decide(command, transcript.as_deref())
     }
+}
+
+/// The pure 3-way conditional — no I/O, so the gate logic is unit-tested
+/// without the filesystem. `run()` reads the transcript and hands the content
+/// (or `None`) in.
+///
+/// - non-`gh pr create` → allow.
+/// - `gh pr create` + transcript showing a polish Skill run → allow (silent).
+/// - `gh pr create` + readable, **non-empty** transcript without a polish run → block.
+/// - `gh pr create` + `None` / empty / whitespace-only transcript → nudge (fail-open floor).
+fn decide(command: &str, transcript: Option<&str>) -> CheckResult {
+    if !is_gh_pr_create(command) {
+        return CheckResult::allow();
+    }
+    match transcript {
+        // No transcript — fail open to the soft nudge, never block.
+        None => CheckResult::nudge(nudge_message()),
+        // An empty or whitespace-only readable transcript is "no evidence", not
+        // an evidenced skip — a 0-byte / not-yet-flushed file must fail open too,
+        // never block on our own missing data (ADR-0001).
+        Some(t) if t.trim().is_empty() => CheckResult::nudge(nudge_message()),
+        // Polish actually ran — silent allow. Kills the nag-after-polish noise.
+        Some(t) if transcript_has_polish_run(t) => CheckResult::allow(),
+        // Readable, non-empty transcript with no polish run — an evidenced skip.
+        // The teeth.
+        Some(_) => CheckResult::block(block_message()),
+    }
+}
+
+/// The loophole-closing clauses both the block and the nudge carry, so the
+/// "it's just markdown" and "TDD/attune already covered it" skips can't survive
+/// either path.
+const SCOPE_CLAUSES: &str = "Skill / agent / command / rule markdown and \
+    CLAUDE.md are behavior, not documentation — IN scope; only *literal* docs \
+    (prose about the system) route to `/polish docs`. Planning, TDD, attune, or \
+    a code-review precede polish — they don't replace it.";
+
+/// Today's soft nudge — the fail-open message when there is no transcript
+/// evidence either way. Allow + warn; the model proceeds.
+fn nudge_message() -> String {
+    format!(
+        "Before opening this PR, consider `/polish` (cadence-forge:polish) — a \
+         branch-scoped pass vs `origin/main`: simplify, logging, tests, docs, \
+         security, code review. {SCOPE_CLAUSES} Skip ONLY if it's a trivial \
+         one-liner or already went through `/polish`. If you skip, say so and \
+         why — don't skip silently."
+    )
+}
+
+/// The block message — fires when the transcript proves polish was skipped.
+/// Reassigns authority: the model runs `/polish`, or if it believes the skip is
+/// legitimate it stops and surfaces the decision to Cameron. It deliberately
+/// does not advertise a self-serve bypass token.
+fn block_message() -> String {
+    format!(
+        "Polish was NOT run on this branch — the session transcript shows no \
+         `cadence-forge:polish` Skill invocation, and polish is mandatory before \
+         opening a PR. Run `/polish` now, then retry `gh pr create`. \
+         {SCOPE_CLAUSES} If you believe this skip is legitimate — a trivial \
+         one-liner, or polish performed outside a Skill call — you may NOT \
+         self-approve it: stop and surface the decision to Cameron, who decides."
+    )
 }
 
 #[cfg(test)]
@@ -76,6 +142,111 @@ mod tests {
             msg.contains("don't skip silently"),
             "message should require the model to state why it is skipping"
         );
+    }
+
+    // --- decide(): the pure 3-way conditional (no filesystem) ---
+
+    /// A transcript line carrying a real `cadence-forge:polish` Skill invocation.
+    fn polish_transcript() -> &'static str {
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:polish"}}]}}"#
+    }
+
+    /// A readable transcript with NO polish Skill run — only prose. The evidenced
+    /// skip the block path is meant to catch.
+    fn no_polish_transcript() -> &'static str {
+        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"opening the PR now"}]}}"#
+    }
+
+    #[test]
+    fn decide_pr_create_with_polish_run_allows_silently() {
+        // Polish actually ran → silent allow. This is the noise-kill: today the
+        // nudge fires even after a real polish run.
+        let result = decide("gh pr create --title test", Some(polish_transcript()));
+        assert_eq!(result.outcome, Outcome::Allow);
+        assert!(
+            result.message.is_none(),
+            "a real polish run must allow silently, no nag"
+        );
+    }
+
+    #[test]
+    fn decide_pr_create_without_polish_run_blocks() {
+        // The teeth: a readable transcript with no polish Skill run is an
+        // evidenced skip → hard block.
+        let result = decide("gh pr create --title test", Some(no_polish_transcript()));
+        assert_eq!(result.outcome, Outcome::Block);
+        let msg = result.message.unwrap_or_default();
+        // The block carries the same loophole-closing clauses the nudge does.
+        assert!(
+            msg.contains("behavior, not documentation"),
+            "block must keep the behavioral-markdown clause: {msg}"
+        );
+        assert!(
+            msg.contains("they don't replace it"),
+            "block must deny upstream-process substitution: {msg}"
+        );
+        // It states polish was NOT run...
+        assert!(
+            msg.to_lowercase().contains("not run"),
+            "block must state polish was not run: {msg}"
+        );
+        // ...directs the model to run /polish...
+        assert!(msg.contains("/polish"), "block must name the remedy: {msg}");
+        // ...and reassigns authority: the model may not self-approve a skip, it
+        // surfaces the decision to Cameron.
+        assert!(
+            msg.contains("Cameron"),
+            "block must name Cameron as the decider: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("surface"),
+            "block must tell the model to surface the decision: {msg}"
+        );
+        // The block must NOT advertise a self-serve bypass — that would re-hand
+        // the model a one-line loophole.
+        assert!(
+            !msg.contains("CADENCE_BYPASS"),
+            "block must not promote a self-serve skip token: {msg}"
+        );
+    }
+
+    #[test]
+    fn decide_pr_create_empty_transcript_nudges() {
+        // Fail-open: an empty or whitespace-only readable transcript is "no
+        // evidence", not an evidenced skip — it must nudge, never block. Guards
+        // the 0-byte / not-yet-flushed file case (security review finding 1).
+        assert_eq!(
+            decide("gh pr create --title x", Some("")).outcome,
+            Outcome::Nudge
+        );
+        assert_eq!(
+            decide("gh pr create --title x", Some("   \n\t  ")).outcome,
+            Outcome::Nudge
+        );
+    }
+
+    #[test]
+    fn decide_pr_create_no_transcript_nudges() {
+        // Fail-open floor (ADR-0001): no transcript evidence → today's soft
+        // nudge, never a block. Preserves the pre-teeth behavior exactly.
+        let result = decide("gh pr create --title test", None);
+        assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.unwrap_or_default();
+        assert!(msg.contains("/polish"));
+        assert!(msg.contains("behavior, not documentation"));
+        assert!(msg.contains("they don't replace it"));
+        assert!(msg.contains("don't skip silently"));
+    }
+
+    #[test]
+    fn decide_non_pr_create_allows_regardless_of_transcript() {
+        // The matcher only scopes the process spawn; decide() still guards
+        // against a non-create gh command slipping through.
+        assert_eq!(
+            decide("gh pr list", Some(no_polish_transcript())).outcome,
+            Outcome::Allow
+        );
+        assert_eq!(decide("git commit -m x", None).outcome, Outcome::Allow);
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,6 +14,7 @@ pub mod loop_analysis;
 pub mod paths;
 pub mod shell;
 pub mod time;
+pub mod transcript;
 
 #[cfg(feature = "test-builders")]
 pub mod test_builders;
@@ -147,6 +148,12 @@ pub struct HookInput {
     /// Available in PostToolUse hooks — absent in PreToolUse and SessionStart.
     pub tool_response: Option<ToolResponse>,
     pub cwd: Option<String>,
+    /// Absolute path to the session transcript (`.jsonl`). A documented common
+    /// field present on every hook event — PreToolUse included — so a guard can
+    /// scan what already happened this session (e.g. did `/polish` run before
+    /// this `gh pr create`?). Deserializes to `None` when absent, so existing
+    /// hooks are unaffected.
+    pub transcript_path: Option<String>,
     /// Claude Code session id — present on `SessionStart`.
     pub session_id: Option<String>,
     /// `SessionStart` trigger: `startup` | `resume` | `clear` | `compact`.
@@ -377,6 +384,12 @@ impl HookInput {
     /// The Claude Code session id, if present (SessionStart and some payloads).
     pub fn session_id(&self) -> Option<&str> {
         self.session_id.as_deref()
+    }
+
+    /// The absolute path to the session transcript (`.jsonl`), if present.
+    /// A documented common field on every hook event (PreToolUse included).
+    pub fn transcript_path(&self) -> Option<&str> {
+        self.transcript_path.as_deref()
     }
 
     /// The SessionStart trigger source (startup/resume/clear/compact), if present.
@@ -998,6 +1011,28 @@ mod tests {
         assert_eq!(input.session_id(), None);
         assert_eq!(input.source(), None);
         assert_eq!(input.model(), None);
+    }
+
+    #[test]
+    fn pre_tool_use_payload_carries_transcript_path() {
+        // The real PreToolUse payload shape (per the Claude Code hooks docs):
+        // transcript_path is a common field present on every event. A guard that
+        // scans the session transcript depends on this deserializing.
+        let json = r#"{"session_id":"abc123","transcript_path":"/home/u/.claude/projects/x/t.jsonl","cwd":"/repo","hook_event_name":"PreToolUse","tool_name":"Bash","tool_input":{"command":"gh pr create"}}"#;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            input.transcript_path(),
+            Some("/home/u/.claude/projects/x/t.jsonl")
+        );
+        assert_eq!(input.command(), Some("gh pr create"));
+    }
+
+    #[test]
+    fn transcript_path_absent_is_none() {
+        // Backward compatibility: payloads without the field (older clients, or
+        // synthetic test inputs) deserialize to None, never an error.
+        let input: HookInput = serde_json::from_str(r#"{"tool_name":"Bash"}"#).unwrap();
+        assert_eq!(input.transcript_path(), None);
     }
 
     #[test]

--- a/crates/core/src/transcript.rs
+++ b/crates/core/src/transcript.rs
@@ -1,0 +1,150 @@
+//! Session-transcript scanning shared across hooks.
+//!
+//! Claude Code records each session as an append-only JSONL transcript (one
+//! message per line). Hooks that need to know *what already happened this
+//! session* — e.g. "did `/polish` run before this `gh pr create`?" — scan that
+//! transcript. The detection is deliberately pure (operates on the transcript
+//! text, no I/O) so both the fire-and-forget metrics logger and the PreToolUse
+//! gate that blocks an evidenced polish-skip share one implementation and one
+//! set of tests.
+
+use serde_json::Value;
+
+/// True when the session transcript contains a `cadence-forge:polish` Skill
+/// invocation. Pure — operates on the transcript text, no I/O.
+///
+/// Matches a `tool_use` block whose tool is `Skill` and whose `skill` argument
+/// contains `polish`; prose that merely mentions `/polish` (a `text` block) does
+/// NOT match — only an actual Skill invocation counts. `.any()` short-circuits
+/// on the first match, so a long transcript with an early polish run is cheap.
+pub fn transcript_has_polish_run(transcript: &str) -> bool {
+    transcript.lines().any(line_is_polish_skill_use)
+}
+
+/// True when one transcript line is an assistant message containing a `Skill`
+/// `tool_use` whose `skill` argument names a polish skill. A line that fails to
+/// parse, carries no `message.content` array, or holds only `text`/non-Skill
+/// blocks yields `false` — so prose mentioning `/polish` never counts.
+pub(crate) fn line_is_polish_skill_use(line: &str) -> bool {
+    let Ok(value) = serde_json::from_str::<Value>(line) else {
+        return false;
+    };
+    let Some(content) = value
+        .get("message")
+        .and_then(|m| m.get("content"))
+        .and_then(Value::as_array)
+    else {
+        return false;
+    };
+    content.iter().any(|block| {
+        block.get("type").and_then(Value::as_str) == Some("tool_use")
+            && block.get("name").and_then(Value::as_str) == Some("Skill")
+            && block
+                .get("input")
+                .and_then(|i| i.get("skill"))
+                .and_then(Value::as_str)
+                .is_some_and(is_polish_skill)
+    })
+}
+
+/// True when a skill id names the polish skill: the bare `polish` form or any
+/// `<namespace>:polish` form (e.g. `cadence-forge:polish`), case-insensitive.
+/// Matches the id's leaf — the segment after the last `:` — exactly, so a decoy
+/// like `writing-polish-notes` that merely *contains* `polish` is rejected. The
+/// precision matters now that a spurious match would silently satisfy a gate
+/// that drives a hard block.
+fn is_polish_skill(skill: &str) -> bool {
+    skill
+        .rsplit(':')
+        .next()
+        .is_some_and(|leaf| leaf.eq_ignore_ascii_case("polish"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn assistant_line(content: &str) -> String {
+        format!(r#"{{"type":"assistant","message":{{"role":"assistant","content":[{content}]}}}}"#)
+    }
+
+    #[test]
+    fn transcript_with_polish_skill_use_is_detected() {
+        let line = assistant_line(
+            r#"{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:polish"}}"#,
+        );
+        assert!(
+            transcript_has_polish_run(&line),
+            "a cadence-forge:polish Skill invocation must be detected"
+        );
+    }
+
+    #[test]
+    fn transcript_with_slash_polish_skill_use_is_detected() {
+        // The bare `/polish` form still surfaces as a Skill tool_use whose skill
+        // argument contains "polish".
+        let line =
+            assistant_line(r#"{"type":"tool_use","name":"Skill","input":{"skill":"polish"}}"#);
+        assert!(transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn transcript_without_polish_is_not_detected() {
+        // A gh pr create Bash call but no polish anywhere → skip candidate.
+        let line = assistant_line(
+            r#"{"type":"tool_use","name":"Bash","input":{"command":"gh pr create --fill"}}"#,
+        );
+        assert!(!transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn prose_mentioning_polish_is_not_a_run() {
+        // Text that merely talks about /polish is NOT a polish run — only an
+        // actual Skill invocation counts. This is the false-positive guard.
+        let line = assistant_line(r#"{"type":"text","text":"I will skip /polish here"}"#);
+        assert!(!transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn other_skill_is_not_polish() {
+        let line = assistant_line(
+            r#"{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:ship"}}"#,
+        );
+        assert!(!transcript_has_polish_run(&line));
+    }
+
+    #[test]
+    fn decoy_skill_merely_containing_polish_is_not_a_run() {
+        // A future skill whose id only *contains* "polish" must NOT satisfy the
+        // gate now that detection drives a hard block — only the polish skill's
+        // exact leaf does.
+        for decoy in [
+            "writing-polish-notes",
+            "cadence-forge:polish-helper",
+            "cadence-forge:repolish",
+        ] {
+            let line = assistant_line(&format!(
+                r#"{{"type":"tool_use","name":"Skill","input":{{"skill":"{decoy}"}}}}"#
+            ));
+            assert!(
+                !transcript_has_polish_run(&line),
+                "decoy {decoy:?} must not count as a polish run"
+            );
+        }
+    }
+
+    #[test]
+    fn is_polish_skill_matches_leaf_exactly() {
+        assert!(is_polish_skill("polish"));
+        assert!(is_polish_skill("cadence-forge:polish"));
+        assert!(is_polish_skill("Cadence-Forge:POLISH"));
+        assert!(!is_polish_skill("writing-polish-notes"));
+        assert!(!is_polish_skill("cadence-forge:polish-helper"));
+        assert!(!is_polish_skill("cadence-forge:ship"));
+    }
+
+    #[test]
+    fn corrupt_transcript_line_is_skipped() {
+        assert!(!transcript_has_polish_run("not json {{\n"));
+    }
+}

--- a/crates/metrics/src/log_polish_nudge.rs
+++ b/crates/metrics/src/log_polish_nudge.rs
@@ -15,6 +15,7 @@
 
 use crate::common;
 use cadence_hooks_core::shell::is_gh_pr_create;
+use cadence_hooks_core::transcript::transcript_has_polish_run;
 use cadence_hooks_core::{Logger, MetricsInput};
 use serde_json::{Value, json};
 use std::io::Write;
@@ -85,42 +86,6 @@ impl Logger for LogPolishNudge {
     }
 }
 
-/// True when the session transcript contains a `cadence-forge:polish` Skill
-/// invocation. Pure — operates on the transcript text, no I/O.
-///
-/// Matches a `tool_use` block whose tool is `Skill` and whose `skill` argument
-/// contains `polish`; prose that merely mentions `/polish` (a `text` block) does
-/// NOT match — only an actual Skill invocation counts.
-fn transcript_has_polish_run(transcript: &str) -> bool {
-    transcript.lines().any(line_is_polish_skill_use)
-}
-
-/// True when one transcript line is an assistant message containing a `Skill`
-/// `tool_use` whose `skill` argument names a polish skill. A line that fails to
-/// parse, carries no `message.content` array, or holds only `text`/non-Skill
-/// blocks yields `false` — so prose mentioning `/polish` never counts.
-fn line_is_polish_skill_use(line: &str) -> bool {
-    let Ok(value) = serde_json::from_str::<Value>(line) else {
-        return false;
-    };
-    let Some(content) = value
-        .get("message")
-        .and_then(|m| m.get("content"))
-        .and_then(Value::as_array)
-    else {
-        return false;
-    };
-    content.iter().any(|block| {
-        block.get("type").and_then(Value::as_str) == Some("tool_use")
-            && block.get("name").and_then(Value::as_str) == Some("Skill")
-            && block
-                .get("input")
-                .and_then(|i| i.get("skill"))
-                .and_then(Value::as_str)
-                .is_some_and(|skill| skill.to_ascii_lowercase().contains("polish"))
-    })
-}
-
 /// Build the `polish_nudges.jsonl` record. Pure — no I/O.
 fn build_polish_nudge_record(
     ts: &str,
@@ -148,60 +113,6 @@ mod tests {
     #[test]
     fn name_is_log_polish_nudge() {
         assert_eq!(LogPolishNudge.name(), "log-polish-nudge");
-    }
-
-    fn assistant_line(content: &str) -> String {
-        format!(r#"{{"type":"assistant","message":{{"role":"assistant","content":[{content}]}}}}"#)
-    }
-
-    #[test]
-    fn transcript_with_polish_skill_use_is_detected() {
-        let line = assistant_line(
-            r#"{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:polish"}}"#,
-        );
-        assert!(
-            transcript_has_polish_run(&line),
-            "a cadence-forge:polish Skill invocation must be detected"
-        );
-    }
-
-    #[test]
-    fn transcript_with_slash_polish_skill_use_is_detected() {
-        // The bare `/polish` form still surfaces as a Skill tool_use whose skill
-        // argument contains "polish".
-        let line =
-            assistant_line(r#"{"type":"tool_use","name":"Skill","input":{"skill":"polish"}}"#);
-        assert!(transcript_has_polish_run(&line));
-    }
-
-    #[test]
-    fn transcript_without_polish_is_not_detected() {
-        // A gh pr create Bash call but no polish anywhere → skip candidate.
-        let line = assistant_line(
-            r#"{"type":"tool_use","name":"Bash","input":{"command":"gh pr create --fill"}}"#,
-        );
-        assert!(!transcript_has_polish_run(&line));
-    }
-
-    #[test]
-    fn prose_mentioning_polish_is_not_a_run() {
-        // Text that merely talks about /polish is NOT a polish run — only an
-        // actual Skill invocation counts. This is the false-positive guard.
-        let line = assistant_line(r#"{"type":"text","text":"I will skip /polish here"}"#);
-        assert!(!transcript_has_polish_run(&line));
-    }
-
-    #[test]
-    fn other_skill_is_not_polish() {
-        let line = assistant_line(
-            r#"{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:ship"}}"#,
-        );
-        assert!(!transcript_has_polish_run(&line));
-    }
-
-    #[test]
-    fn corrupt_transcript_line_is_skipped() {
-        assert!(!transcript_has_polish_run("not json {{\n"));
     }
 
     fn sample_input() -> MetricsInput {


### PR DESCRIPTION
## Why

`nudge-polish-before-pr` fired a soft nudge (allow + warn) on every `gh pr create`, reminding the model to run `/polish` first. Because a nudge is allow + warn, the model could talk past it — the "day 3 of polish not needed" report (cameronsjo/claude-configurations#151) is that efficacy verdict arriving early. Polish is mandatory before a PR, and a nudge can't be mandatory by definition. This gives the nudge teeth — precisely, not bluntly.

The enabler already existed: the metrics logger had a deterministic `transcript_has_polish_run()` that scans the session transcript for a real `cadence-forge:polish` Skill `tool_use`. The nudge never used it (its input type didn't even deserialize `transcript_path`). Wiring that detection in turns a dumb always-on warning into a precise, conditional gate.

## What

On a `gh pr create` command, a pure `decide(command, transcript: Option<&str>)` routes a 3-way, fail-open outcome:

| Transcript evidence | Outcome | Rationale |
|---|---|---|
| Readable, **shows** a `cadence-forge:polish` Skill run | **allow** (silent) | Polish happened — kills today's nag-after-polish noise |
| Readable, non-empty, **no** polish run | **block** (exit 2) | The teeth — an evidenced skip |
| No `transcript_path` / empty / unreadable / unparsable | **nudge** (today's soft message) | ADR-0001 fail-open — never block on our own missing data |

Non-`gh pr create` commands → allow (unchanged). Same subcommand, event, and matcher — no `registry.rs` / `main.rs` / `hooks.json` change.

**Authority reassignment (the behavioral lever):** the block message states polish wasn't run and directs the model to run `/polish`, or — if it believes the skip is legitimate (trivial one-liner; polish done outside a Skill call) — to **stop and surface the decision to Cameron, who decides.** The model may not self-approve, and the message advertises no self-serve bypass. The operator escape hatches remain the existing, unadvertised global `CADENCE_BYPASS=1` and per-hook `CADENCE_DISABLE=nudge-polish-before-pr`.

### Changes

- **`core/transcript.rs`** *(new)* — hoists `transcript_has_polish_run` (+ helper) out of the metrics logger into a shared module, and **tightens** detection: exact-leaf match (`:polish`) replaces the prior `.contains("polish")`, so decoys like `repolish` / `writing-polish-notes` no longer count — in the gate or the logger's `polished` field.
- **`core/lib.rs`** — `HookInput` gains a `transcript_path` field + accessor (serde-default, backward-compatible). It's a documented common field on every hook event, PreToolUse included (verified against the Claude Code hooks docs).
- **`metrics/log_polish_nudge.rs`** — deletes the local detector copies; calls the shared one.
- **`cadence/nudge_polish_before_pr.rs`** — `run()` reads the transcript and delegates to the pure `decide()`; shared message body carries the loophole clauses on both the block and nudge paths.

## Verification

- TDD: pure `decide()` tests (allow/block/nudge/empty/non-create) + the moved detection tests.
- `make ci` (fmt-check + clippy `-D warnings` + all tests) green.
- End-to-end against the built binary: block (exit 2, correct message, no bypass leak), allow (silent), nudge, and empty/unreadable transcript → nudge (fail-open).

## Security review (nudge→block transition)

An Opus security review ran on the diff, per the discipline that "when a predicate that previously drove only a NUDGE starts driving a stronger outcome, its false-positive tolerance inverts." Two findings were **fixed**:

1. Empty/whitespace-only readable transcript now fails open to a nudge (was a wrongful-block gap).
2. Leaf-exact polish-skill match (was substring `.contains`, an over-match).

No Critical findings; no panic paths; fail-open holds on every unreadable path; the block message and feedback footer leak no bypass token. A follow-up code review returned only Nits, all applied.

**Accepted residuals (documented, not blockers):**
- *Schema drift* — detection is pinned to Claude Code's transcript JSONL shape (verified current). If that shape changes, every readable transcript reads as "no polish" → blocks. Bounded by the existing operator valves (`CADENCE_BYPASS` / `CADENCE_DISABLE`) and surface-to-Cameron. Candidate follow-up: a schema-sanity guard that only blocks when the known schema is present.
- *Cross-session* — the transcript is per-session, so polish in session A then `gh pr create` in session B (post-`/clear`) blocks. Mitigated by surface-to-Cameron + the valves. Candidate follow-up: a cross-session polish marker.
- *Determined evasion* — an alternate PR-create form (`gh api .../pulls`) sidesteps the shared matcher, and a forged transcript line could satisfy the detector. Both are outside the "talk past the nudge" failure mode this targets; the teeth raise the bar against the rationalized skip, not a determined forger.

## Out of scope / follow-ups

- cameronsjo/claude-configurations#151 — efficacy verdict + decision to close (enforcement moved upstream) handled **post-merge**, not auto-closed here.
- Optional ADR documenting the transcript-aware conditional-block pattern (reusable for other nudges) — separate repo/PR.

---

Generated with [Claude Code](https://claude.com/claude-code) (Opus 4.8)
