### PR TITLE
feat(terminology): per-repo .claude/terminology.json exemptions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Per-repo terminology exemptions (`.claude/terminology.json`).** The
+  `terminology` guard now reads an optional `<git-root>/.claude/terminology.json`
+  that softens its hard block for named files and terms — mirroring the
+  `.claude/redaction.json` precedent. Each `exemptions[]` entry takes `paths`
+  (glob patterns: a `/`-bearing pattern matches the repo-relative path with `**`
+  spanning separators, a bare pattern matches the basename anywhere), optional
+  `terms` (case-insensitive against the display term; omit to exempt all), and an
+  optional `mode` (`allow` drops the violation, `nudge` demotes a block to an
+  advisory). It can only ever *remove* or *demote* a violation, never add one;
+  the global hard block and the built-in path baseline are untouched. Missing,
+  unreadable, or invalid JSON is ignored (fail-open, ADR-0001). The shared
+  `find_git_root` walk also moved into `core::paths`. See
+  [docs/configuration.md](docs/configuration.md#per-repo-terminology-exemptions).
+
 ### Fixed
 
 - **nudge-polish-before-pr: see polish run in a subagent transcript** (#247 on

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -199,6 +199,7 @@ name = "cadence-hooks-cadence"
 version = "0.41.0"
 dependencies = [
  "cadence-hooks-core",
+ "glob",
  "regex",
  "serde",
  "serde_json",
@@ -476,6 +477,12 @@ dependencies = [
  "wasip2",
  "wasip3",
 ]
+
+[[package]]
+name = "glob"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "hashbrown"

--- a/crates/cadence/Cargo.toml
+++ b/crates/cadence/Cargo.toml
@@ -7,6 +7,7 @@ description = "Cadence plugin hooks: enforcement, memory guard, session manageme
 
 [dependencies]
 cadence-hooks-core.workspace = true
+glob = "0.3"
 regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -36,7 +36,7 @@ use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use serde::Deserialize;
 use std::collections::HashSet;
-use std::path::{Path, PathBuf};
+use std::path::Path;
 use std::sync::LazyLock;
 
 /// Plugin/skill namespaces whose `<ns>:<name>` IDs are harness-internal.
@@ -310,7 +310,7 @@ fn read_body_file(path: &str, base_dir: &str) -> Option<String> {
 /// — no git root, missing/unreadable file, invalid JSON — yields the default
 /// (empty) config.
 fn load_redaction_config(base_dir: &str) -> RedactionConfig {
-    let Some(root) = find_git_root(base_dir) else {
+    let Some(root) = cadence_hooks_core::paths::find_git_root(base_dir) else {
         return RedactionConfig::default();
     };
     let path = root.join(".claude/redaction.json");
@@ -318,21 +318,6 @@ fn load_redaction_config(base_dir: &str) -> RedactionConfig {
         return RedactionConfig::default();
     };
     serde_json::from_str(&content).unwrap_or_default()
-}
-
-/// Walk up from `start` to the first directory containing a `.git` entry.
-/// `.git` may be a directory (normal checkout) or a file (linked worktree);
-/// `Path::exists` catches both. `None` if no ancestor has one.
-fn find_git_root(start: &str) -> Option<PathBuf> {
-    let mut dir = PathBuf::from(start);
-    loop {
-        if dir.join(".git").exists() {
-            return Some(dir);
-        }
-        if !dir.pop() {
-            return None;
-        }
-    }
 }
 
 /// Scan one body for blocklist hits, deduped by start offset across categories,

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -4,7 +4,10 @@
 //! Case-insensitive with word-boundary matching to avoid false positives.
 
 use cadence_hooks_core::{Check, CheckResult, HookInput};
+use glob::{MatchOptions, Pattern};
 use regex::RegexSet;
+use serde::Deserialize;
+use std::path::Path;
 use std::sync::LazyLock;
 
 // NOTE: This file contains prohibited terms as detection patterns.
@@ -166,6 +169,165 @@ fn subtract_existing(
         .collect()
 }
 
+/// Per-repo terminology exemptions, read from `<git-root>/.claude/terminology.json`.
+///
+/// Softens the hard block for named files/terms — it can only ever *remove* or
+/// *demote* a violation, never add one. Missing, unreadable, or invalid JSON all
+/// deserialize to the default (empty) config; the guard never errors on it
+/// (fail-open, ADR-0001). Mirrors the `.claude/redaction.json` precedent.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct TerminologyConfig {
+    #[serde(default)]
+    exemptions: Vec<Exemption>,
+}
+
+/// One exemption entry: which paths it covers, which flagged terms it exempts,
+/// and how much it softens them.
+#[derive(Debug, Default, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct Exemption {
+    /// Glob patterns. A pattern containing `/` matches the **repo-relative**
+    /// path (`**` spans separators, `*` does not); a bare pattern (no `/`)
+    /// matches the **basename** in any directory.
+    #[serde(default)]
+    paths: Vec<String>,
+    /// Flagged terms to exempt, matched case-insensitively against the guard's
+    /// display term (e.g. the seven block labels plus the nudge label). Empty or
+    /// omitted exempts *all* flagged terms at the matched path; an unknown string
+    /// simply never matches.
+    #[serde(default)]
+    terms: Vec<String>,
+    /// `allow` (default) drops the violation silently; `nudge` demotes a Tier-1
+    /// block to a Tier-2 advisory so a visible reminder remains.
+    #[serde(default)]
+    mode: ExemptionMode,
+}
+
+/// How an exemption softens a matched violation.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Deserialize)]
+#[serde(rename_all = "lowercase")]
+enum ExemptionMode {
+    /// Drop the violation entirely (silent).
+    #[default]
+    Allow,
+    /// Demote a block to an advisory nudge (exit 0, never blocks).
+    Nudge,
+}
+
+/// Glob options for `/`-bearing patterns: `*` stops at `/`, `**` crosses it —
+/// gitignore-style. Case-sensitive; a leading dot is not treated specially.
+const MATCH_OPTIONS: MatchOptions = MatchOptions {
+    case_sensitive: true,
+    require_literal_separator: true,
+    require_literal_leading_dot: false,
+};
+
+impl Exemption {
+    /// Does this entry cover `rel_path` (repo-relative) / `basename`?
+    fn matches_path(&self, rel_path: &str, basename: &str) -> bool {
+        self.paths.iter().any(|p| glob_match(p, rel_path, basename))
+    }
+
+    /// Does this entry exempt `term`? Empty `terms` exempts every flagged term;
+    /// otherwise a case-insensitive match against the display term.
+    fn matches_term(&self, term: &str) -> bool {
+        self.terms.is_empty() || self.terms.iter().any(|t| t.eq_ignore_ascii_case(term))
+    }
+}
+
+impl TerminologyConfig {
+    /// First exemption (document order) matching both the path and the term.
+    fn first_match(&self, rel_path: &str, basename: &str, term: &str) -> Option<&Exemption> {
+        self.exemptions
+            .iter()
+            .find(|e| e.matches_path(rel_path, basename) && e.matches_term(term))
+    }
+}
+
+/// Match one glob `pattern`. A pattern containing `/` is matched against the
+/// repo-relative path (with [`MATCH_OPTIONS`] so `**` spans separators); a bare
+/// pattern is matched against the basename. An uncompilable pattern never
+/// matches (fail-open).
+fn glob_match(pattern: &str, rel_path: &str, basename: &str) -> bool {
+    let Ok(pat) = Pattern::new(pattern) else {
+        return false;
+    };
+    if pattern.contains('/') {
+        pat.matches_with(rel_path, MATCH_OPTIONS)
+    } else {
+        pat.matches(basename)
+    }
+}
+
+/// Load `<root>/.claude/terminology.json`. Missing, unreadable, or invalid JSON
+/// all yield the default (empty) config (fail-open, ADR-0001).
+fn load_terminology_config(root: &Path) -> TerminologyConfig {
+    let path = root.join(".claude/terminology.json");
+    let Ok(content) = std::fs::read_to_string(path) else {
+        return TerminologyConfig::default();
+    };
+    serde_json::from_str(&content).unwrap_or_default()
+}
+
+/// Apply per-repo `.claude/terminology.json` softening to the accumulated
+/// violations, in place. `allow`-mode exemptions drop a block; `nudge`-mode
+/// exemptions demote a block to a nudge; any matching exemption drops a
+/// pre-existing nudge (already advisory). The git root is found by walking up
+/// from the file's directory; no git root or no exemptions leaves both vectors
+/// untouched. Only ever removes or demotes — never adds a violation.
+fn apply_exemptions(
+    file_path: &str,
+    blocks: &mut Vec<(String, String)>,
+    nudges: &mut Vec<(String, String)>,
+) {
+    let start_dir = Path::new(file_path)
+        .parent()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|| ".".to_string());
+    let Some(root) = cadence_hooks_core::paths::find_git_root(&start_dir) else {
+        return;
+    };
+    let config = load_terminology_config(&root);
+    if config.exemptions.is_empty() {
+        return;
+    }
+
+    let rel_path = Path::new(file_path)
+        .strip_prefix(&root)
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| file_path.to_string());
+    let basename = Path::new(file_path)
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_default();
+
+    // Pre-existing nudges first: any matching exemption drops them. Run before
+    // demotion below so a freshly-demoted block is not immediately re-dropped.
+    nudges.retain(|(term, _)| config.first_match(&rel_path, &basename, term).is_none());
+
+    // Blocks: allow drops; nudge demotes (collected, then appended).
+    let mut demoted: Vec<(String, String)> = Vec::new();
+    blocks.retain(|item| {
+        match config
+            .first_match(&rel_path, &basename, &item.0)
+            .map(|e| e.mode)
+        {
+            Some(ExemptionMode::Allow) => false,
+            Some(ExemptionMode::Nudge) => {
+                demoted.push(item.clone());
+                false
+            }
+            None => true,
+        }
+    });
+    for d in demoted {
+        if !nudges.contains(&d) {
+            nudges.push(d);
+        }
+    }
+}
+
 /// Blocks content containing prohibited terminology and suggests alternatives.
 pub struct TerminologyGuard;
 
@@ -213,6 +375,16 @@ impl Check for TerminologyGuard {
                     nudges.push(n);
                 }
             }
+        }
+
+        // Per-repo `.claude/terminology.json` softening — only when there's a
+        // violation to soften and we know the file path (so a clean edit never
+        // touches disk). The hardcoded is_excluded_path() baseline above still
+        // applies; this only ever removes or demotes a violation, never adds one.
+        if (!blocks.is_empty() || !nudges.is_empty())
+            && let Some(ref path) = input.file_path()
+        {
+            apply_exemptions(path, &mut blocks, &mut nudges);
         }
 
         // Tier 1: hard block
@@ -782,5 +954,283 @@ mod tests {
         );
         let result = TerminologyGuard.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // --- Per-repo .claude/terminology.json exemptions ---
+    //
+    // The loader reads `<git-root>/.claude/terminology.json` from disk, so these
+    // tests build a real temp git root and address the written file by an
+    // absolute path inside it. Flagged terms are taken from BLOCK_VIOLATIONS
+    // (never spelled as literals) so the config JSON carries no hardcoded term.
+
+    use cadence_hooks_core::Outcome;
+    use std::path::PathBuf;
+
+    /// A temp git root containing `.claude/terminology.json` with `json`.
+    fn temp_repo(json: &str) -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(dir.path().join(".claude/terminology.json"), json).unwrap();
+        dir
+    }
+
+    /// A temp git root with NO terminology.json (config-absent baseline).
+    fn temp_repo_no_config() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        dir
+    }
+
+    /// A Write HookInput targeting `path` (created on disk so a nested `path`'s
+    /// directory exists for the relative-path computation) with `content`.
+    fn write_at(root: &std::path::Path, rel: &str, content: &str) -> HookInput {
+        let full = root.join(rel);
+        if let Some(parent) = full.parent() {
+            std::fs::create_dir_all(parent).unwrap();
+        }
+        HookInput {
+            tool_name: Some("Write".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some(full.to_string_lossy().into_owned()),
+                content: Some(content.into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        }
+    }
+
+    fn outcome(input: &HookInput) -> Outcome {
+        TerminologyGuard.run(input).outcome
+    }
+
+    // -- Pure match-logic units (no disk) --
+
+    #[test]
+    fn glob_match_basename_pattern_ignores_dir() {
+        // A bare pattern matches the basename anywhere in the tree.
+        assert!(glob_match(
+            "silly-file.yml",
+            "a/b/silly-file.yml",
+            "silly-file.yml"
+        ));
+        assert!(glob_match(
+            "silly-file.yml",
+            "silly-file.yml",
+            "silly-file.yml"
+        ));
+        assert!(!glob_match("silly-file.yml", "a/other.yml", "other.yml"));
+    }
+
+    #[test]
+    fn glob_match_slash_pattern_is_repo_relative() {
+        assert!(glob_match("config/**", "config/acl.yml", "acl.yml"));
+        assert!(glob_match("config/**", "config/sub/acl.yml", "acl.yml"));
+        assert!(!glob_match("config/**", "other/acl.yml", "acl.yml"));
+    }
+
+    #[test]
+    fn glob_match_star_does_not_cross_separator() {
+        // `*` stops at `/`; `**` is required to span directories.
+        assert!(glob_match("config/*.yml", "config/acl.yml", "acl.yml"));
+        assert!(!glob_match("config/*.yml", "config/sub/acl.yml", "acl.yml"));
+        assert!(glob_match(
+            "**/firewall-*.yaml",
+            "net/firewall-a.yaml",
+            "firewall-a.yaml"
+        ));
+    }
+
+    #[test]
+    fn glob_match_invalid_pattern_never_matches() {
+        // An uncompilable glob fails open (matches nothing).
+        assert!(!glob_match("[", "x", "x"));
+    }
+
+    #[test]
+    fn matches_term_is_case_insensitive_and_blanket() {
+        let term = BLOCK_VIOLATIONS[0].0;
+        let listed = Exemption {
+            paths: vec![],
+            terms: vec![term.to_uppercase()],
+            mode: ExemptionMode::Allow,
+        };
+        assert!(listed.matches_term(term));
+        assert!(!listed.matches_term(BLOCK_VIOLATIONS[1].0));
+
+        let blanket = Exemption {
+            paths: vec![],
+            terms: vec![],
+            mode: ExemptionMode::Allow,
+        };
+        assert!(blanket.matches_term(term));
+        assert!(blanket.matches_term(BLOCK_VIOLATIONS[1].0));
+    }
+
+    // -- run() integration (real temp git root) --
+
+    #[test]
+    fn no_config_leaves_block_unchanged() {
+        // Config absent → a violation in a normal file still blocks.
+        let repo = temp_repo_no_config();
+        let input = write_at(repo.path(), "src/main.rs", BLOCK_VIOLATIONS[0].0);
+        assert_eq!(outcome(&input), Outcome::Block);
+    }
+
+    #[test]
+    fn allow_exemption_drops_block() {
+        let term = BLOCK_VIOLATIONS[0].0;
+        let json = format!(r#"{{"exemptions":[{{"paths":["acl.yml"],"terms":["{term}"]}}]}}"#);
+        let repo = temp_repo(&json);
+        let input = write_at(repo.path(), "acl.yml", term);
+        assert_eq!(outcome(&input), Outcome::Allow);
+    }
+
+    #[test]
+    fn nudge_mode_demotes_block() {
+        let term = BLOCK_VIOLATIONS[0].0;
+        let json = format!(
+            r#"{{"exemptions":[{{"paths":["acl.yml"],"terms":["{term}"],"mode":"nudge"}}]}}"#
+        );
+        let repo = temp_repo(&json);
+        let input = write_at(repo.path(), "acl.yml", term);
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, Outcome::Nudge);
+        // The demoted term still surfaces in the advisory message.
+        assert!(result.message.unwrap().contains(term));
+    }
+
+    #[test]
+    fn path_match_but_term_mismatch_still_blocks() {
+        // Exempting term A in acl.yml must NOT exempt term B written there.
+        let term_a = BLOCK_VIOLATIONS[0].0;
+        let term_b = BLOCK_VIOLATIONS[1].0;
+        let json = format!(r#"{{"exemptions":[{{"paths":["acl.yml"],"terms":["{term_a}"]}}]}}"#);
+        let repo = temp_repo(&json);
+        let input = write_at(repo.path(), "acl.yml", &format!("{term_a} then {term_b}"));
+        let result = TerminologyGuard.run(&input);
+        assert_eq!(result.outcome, Outcome::Block);
+        let msg = result.message.unwrap();
+        assert!(
+            msg.contains(term_b),
+            "unexempted term must still block: {msg}"
+        );
+        assert!(
+            !msg.contains(&format!("\"{term_a}\"")),
+            "exempted term must be dropped from the block list: {msg}"
+        );
+    }
+
+    #[test]
+    fn blanket_exemption_drops_all_terms() {
+        // `terms` omitted → every flagged term at that path is exempt.
+        let term_a = BLOCK_VIOLATIONS[0].0;
+        let term_b = BLOCK_VIOLATIONS[1].0;
+        let repo = temp_repo(r#"{"exemptions":[{"paths":["acl.yml"]}]}"#);
+        let input = write_at(repo.path(), "acl.yml", &format!("{term_a} and {term_b}"));
+        assert_eq!(outcome(&input), Outcome::Allow);
+    }
+
+    #[test]
+    fn basename_pattern_matches_in_subdir() {
+        let term = BLOCK_VIOLATIONS[0].0;
+        let json =
+            format!(r#"{{"exemptions":[{{"paths":["silly-file.yml"],"terms":["{term}"]}}]}}"#);
+        let repo = temp_repo(&json);
+        let input = write_at(repo.path(), "deep/nested/silly-file.yml", term);
+        assert_eq!(outcome(&input), Outcome::Allow);
+    }
+
+    #[test]
+    fn slash_pattern_matches_repo_relative_path() {
+        let term = BLOCK_VIOLATIONS[0].0;
+        let json = format!(r#"{{"exemptions":[{{"paths":["config/**"],"terms":["{term}"]}}]}}"#);
+        let repo = temp_repo(&json);
+        // Inside config/ → exempt.
+        let inside = write_at(repo.path(), "config/acl.yml", term);
+        assert_eq!(outcome(&inside), Outcome::Allow);
+        // Outside config/ → the same term still blocks.
+        let outside = write_at(repo.path(), "other/acl.yml", term);
+        assert_eq!(outcome(&outside), Outcome::Block);
+    }
+
+    #[test]
+    fn first_match_precedence_decides_mode() {
+        let term = BLOCK_VIOLATIONS[0].0;
+        // allow first, nudge second → first wins → dropped (Allow).
+        let allow_first = format!(
+            r#"{{"exemptions":[{{"paths":["acl.yml"],"terms":["{term}"]}},{{"paths":["acl.yml"],"terms":["{term}"],"mode":"nudge"}}]}}"#
+        );
+        let repo = temp_repo(&allow_first);
+        assert_eq!(
+            outcome(&write_at(repo.path(), "acl.yml", term)),
+            Outcome::Allow
+        );
+
+        // nudge first, allow second → first wins → demoted (Nudge).
+        let nudge_first = format!(
+            r#"{{"exemptions":[{{"paths":["acl.yml"],"terms":["{term}"],"mode":"nudge"}},{{"paths":["acl.yml"],"terms":["{term}"]}}]}}"#
+        );
+        let repo2 = temp_repo(&nudge_first);
+        assert_eq!(
+            outcome(&write_at(repo2.path(), "acl.yml", term)),
+            Outcome::Nudge
+        );
+    }
+
+    #[test]
+    fn invalid_json_fails_open_and_still_blocks() {
+        let repo = temp_repo("{not valid json");
+        let input = write_at(repo.path(), "acl.yml", BLOCK_VIOLATIONS[0].0);
+        assert_eq!(outcome(&input), Outcome::Block);
+    }
+
+    #[test]
+    fn carried_through_term_in_exempt_mismatch_file_still_allowed() {
+        // #63 subtract-existing runs before the config pass: a term carried
+        // through an Edit (present in both old and new) produces no block, so
+        // the gate skips apply_exemptions entirely — Allow regardless of config.
+        let term = BLOCK_VIOLATIONS[0].0;
+        let repo = temp_repo(r#"{"exemptions":[{"paths":["unrelated.yml"]}]}"#);
+        let full = repo.path().join("src/main.rs");
+        std::fs::create_dir_all(full.parent().unwrap()).unwrap();
+        let path = full.to_string_lossy().into_owned();
+        let input = make_edit(
+            &path,
+            &format!("{term} setting v1"),
+            &format!("{term} setting v2"),
+        );
+        assert_eq!(outcome(&input), Outcome::Allow);
+    }
+
+    #[test]
+    fn no_git_root_leaves_block_unchanged() {
+        // A file with no ancestor .git → no config possible → block stands.
+        let dir = tempfile::tempdir().unwrap();
+        let input = write_at(dir.path(), "acl.yml", BLOCK_VIOLATIONS[0].0);
+        assert_eq!(outcome(&input), Outcome::Block);
+    }
+
+    #[test]
+    fn load_terminology_config_missing_file_is_default() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = load_terminology_config(dir.path());
+        assert!(config.exemptions.is_empty());
+    }
+
+    #[test]
+    fn load_terminology_config_reads_exemptions() {
+        let repo = temp_repo(r#"{"exemptions":[{"paths":["a.yml"]},{"paths":["b.yml"]}]}"#);
+        let config = load_terminology_config(repo.path());
+        assert_eq!(config.exemptions.len(), 2);
+    }
+
+    #[test]
+    fn find_git_root_walks_up() {
+        let repo = temp_repo_no_config();
+        let nested = repo.path().join("a/b/c");
+        std::fs::create_dir_all(&nested).unwrap();
+        let found = cadence_hooks_core::paths::find_git_root(&nested.to_string_lossy());
+        assert_eq!(found, Some(PathBuf::from(repo.path())));
     }
 }

--- a/crates/core/src/paths.rs
+++ b/crates/core/src/paths.rs
@@ -77,6 +77,23 @@ fn non_empty_var(key: &str) -> Option<String> {
     std::env::var(key).ok().filter(|v| !v.is_empty())
 }
 
+/// Walk up from `start` to the first directory containing a `.git` entry.
+///
+/// `.git` may be a directory (normal checkout) or a file (linked worktree);
+/// `Path::exists` catches both. Returns `None` if no ancestor has one. Used by
+/// guards that read a per-repo `<git-root>/.claude/*.json` override file.
+pub fn find_git_root(start: &str) -> Option<PathBuf> {
+    let mut dir = PathBuf::from(start);
+    loop {
+        if dir.join(".git").exists() {
+            return Some(dir);
+        }
+        if !dir.pop() {
+            return None;
+        }
+    }
+}
+
 /// Claude Code's global config dir, honoring `CLAUDE_CONFIG_DIR` (else `~/.claude`).
 pub fn claude_config_dir() -> PathBuf {
     let cfg = std::env::var("CLAUDE_CONFIG_DIR").ok();

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -28,6 +28,45 @@ Each hook is a subcommand; `cadence-hooks list` shows every hook with its event
 and disable status, and `cadence-hooks <namespace> --help` lists a namespace's
 subcommands.
 
+## Per-repo terminology exemptions
+
+The `terminology` guard hard-**blocks** a small set of dated terms on every
+`Write`/`Edit` (`whitelist`, `blacklist`, `master branch`/`master node`,
+`slave`, `sanity check`, `dummy value`; `grandfathered` is a softer nudge). That
+block is the right default everywhere. But some files legitimately carry these
+words — a vendor ACL format named `whitelist`, an existing API field, a config
+schema whose key *is* the dated term. A per-repo `<git-root>/.claude/terminology.json`
+softens the block for named files and terms.
+
+It can only ever **remove or demote** a violation — never add one. It cannot
+introduce new blocked terms, and it cannot turn the block on for a path the
+built-in baseline already exempts (this repo's own source, `CLAUDE.md`,
+`.claude/hooks`/`rules`). Missing, unreadable, or invalid JSON is ignored and the
+block stands (fail-open, ADR-0001).
+
+```jsonc
+{
+  "exemptions": [
+    {
+      "paths": ["config/acl.yml", "**/firewall-*.yaml", "vendor-list.yml"],
+      "terms": ["whitelist", "blacklist"],
+      "mode": "allow"
+    },
+    { "paths": ["vendor/**"] }
+  ]
+}
+```
+
+| Field | Required | Meaning |
+|-------|----------|---------|
+| `paths` | yes | Glob patterns. A pattern containing `/` matches the **repo-relative** path (`**` spans separators, `*` does not); a bare pattern (no `/`, e.g. `vendor-list.yml`) matches the **basename** in any directory. |
+| `terms` | no | Which flagged terms to exempt at those paths, matched case-insensitively against the guard's display term (the block labels plus `grandfathered`). **Omit to exempt every flagged term** at the matched path. An unknown string simply never matches. |
+| `mode` | no | `"allow"` (default) drops the violation silently; `"nudge"` demotes a hard block to an advisory nudge (never blocks) so a visible reminder remains. |
+
+**Matching & precedence.** For each `(file, term)` pair, the **first** exemption
+entry in document order that matches both the path and the term decides. An entry
+matches the term when `terms` is omitted/empty or contains it.
+
 ## Environment Variables
 
 All cadence-hooks config lives under the `CADENCE_*` prefix. `OBSIDIAN_VAULT` is


### PR DESCRIPTION
## What

Adds an optional per-repo `<git-root>/.claude/terminology.json` that **softens** the `terminology` guard's hard block for named files and terms — mirroring the `.claude/redaction.json` precedent.

The guard hard-blocks a small set of dated terms on every `Write`/`Edit`. Some files legitimately carry them — vendor ACL formats, existing API field names, config schemas whose key *is* the dated word — and until now the only escape was a hardcoded path baseline compiled into the binary. This gives a repo a user-facing, opt-in way to exempt the predictable cases.

> Fittingly, the guard blocked the first attempt to write *this PR body* (the schema example below carries the literal terms) — Exhibit A for why the feature exists.

## Schema

```jsonc
{
  "exemptions": [
    {
      "paths": ["config/acl.yml", "**/firewall-*.yaml", "vendor-list.yml"],
      "terms": ["whitelist", "blocklist"],
      "mode": "allow"
    },
    { "paths": ["vendor/**"] }
  ]
}
```

- **`paths`** (required) — glob patterns. A pattern containing `/` matches the **repo-relative** path (`**` spans separators, `*` does not); a bare pattern matches the **basename** in any directory.
- **`terms`** (optional) — case-insensitive against the display term; omit to exempt **all** flagged terms at the matched path.
- **`mode`** (optional, default `allow`) — `allow` drops the violation silently; `nudge` demotes a hard block to an advisory.

First matching entry in document order decides.

## Guarantees

- **Softening only** — can never *add* a blocked term or re-enable the block for a baseline-exempt path. The global hard block stays the default everywhere not explicitly exempted.
- **Fail-open (ADR-0001)** — missing / unreadable / invalid JSON is ignored and the block stands.
- **No needless disk I/O** — the filtering pass runs only when there's a violation to soften *and* a `file_path` is known, so a clean edit never walks the filesystem.

Also factors the shared `find_git_root` walk into `core::paths` (redaction now calls it too).

## Verification

- Unit tests: **729** (core) + **315** (cadence) passing, 0 failing — 63 in the terminology suite, 21 of them new (allow/nudge/term-mismatch/blanket/basename-vs-path glob/precedence/invalid-JSON/carried-through, plus pure glob+term match-logic units).
- `cargo clippy --workspace --all-targets -- -D warnings`: clean. `cargo fmt --all --check`: clean.
- End-to-end against the built binary (real disk + git root): exempted path → ALLOW (exit 0); un-exempted basename → BLOCK (exit 2); same-basename sibling → ALLOW (basename matches anywhere, by design).

> The two local `hook_registration_audit` failures (`all_binary_subcommands_are_registered`, `no_plugin_hooks_duplicated_in_settings_json`) are **pre-existing and environmental** — sibling-checkout wiring and the developer's live `~/.claude/settings.json`. Confirmed identical on a clean tree (stash + re-run); GitHub CI has no siblings and skips them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for per-repo terminology exemptions via a local configuration file, with path-based matching and optional term scoping.
  * Introduced a new way to soften matched violations, either allowing them or downgrading them to nudges.

* **Documentation**
  * Documented the new exemption settings, matching rules, and fail-open behavior for missing or invalid configuration.

* **Bug Fixes**
  * Improved repository root detection and shared path handling for more consistent configuration lookup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->