### PR TITLE
fix(rules): validate-frontmatter accepts the valid paths field

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   run in any child satisfies the gate. The scan is lazy (only on the
   would-block path) and fail-open at every step (missing dir / unreadable child
   → falls through, never blocks on our own missing data, ADR-0001).
+- **rules validate-frontmatter: accept the valid `paths` field** (#227 on
+  claude-configurations). `paths` — Claude Code's conditional-activation field
+  that scopes a skill to fire only when matching files are touched, documented
+  in `cadence:writing-skills` — was absent from the validator's allowed-field
+  set, so every `Write` to a path-scoped `SKILL.md` under a real skills
+  directory hard-blocked with `Unknown frontmatter field: 'paths'`. Added
+  `paths` to `VALID_FIELDS`; path-conditional skills now write cleanly.
 
 ## [0.41.0] - 2026-06-23
 

--- a/crates/rules/src/validate_skill_frontmatter.rs
+++ b/crates/rules/src/validate_skill_frontmatter.rs
@@ -21,6 +21,7 @@ const VALID_FIELDS: &[&str] = &[
     "context",
     "agent",
     "hooks",
+    "paths",
 ];
 
 // Kebab-case name, optionally prefixed by a kebab `namespace:` (the
@@ -576,6 +577,19 @@ mod tests {
         let input = make_write_input(
             "/plugins/skills/my-skill/SKILL.md",
             "---\nname: my-skill\ndescription: A skill\nmodel: opus\nallowed-tools: Read,Grep\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn valid_skill_with_paths_field() {
+        // #227: `paths` is a valid Claude Code conditional-activation field
+        // (scopes a skill to activate only when matching files are touched).
+        // It must not be rejected as an unknown frontmatter field.
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\npaths: src/**/*.rs\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);


### PR DESCRIPTION
## Problem

`rules validate-frontmatter` blocked every `Write` to a path-scoped `SKILL.md` under a real skills directory with `Unknown frontmatter field: 'paths'`.

`paths` is a valid Claude Code skill frontmatter field — it scopes a skill to activate only when matching files are touched (conditional activation), and is documented in `cadence:writing-skills`. The validator's allowed-field set simply didn't include it, so any path-conditional personal skill was blocked at write time (the reporter's workaround was a Bash heredoc to bypass the `PreToolUse:Write` hook).

## Fix

Add `paths` to `VALID_FIELDS` in `crates/rules/src/validate_skill_frontmatter.rs`.

Scope was deliberately kept to `paths` alone: a tally of all 132 shipped `SKILL.md` files shows no skill uses `effort`/`version`/`shell`/`disallowed-tools` (the other fields floated in the issue), and widening a guard's allowlist to fields that aren't confirmed-valid would weaken exactly the typo-catching this check exists for. Those can be added later if a real skill needs them.

## Test

`run_skill_with_paths_field_allowed` — a `SKILL.md` carrying `paths:` now ALLOWs. RED confirmed before the fix (`Block` → `Allow`); 105/105 rules lib tests green after.

Note: the local `hook_registration_audit` cross-sibling legs fail unrelated to this change (sibling plugin checkouts lack not-yet-merged wiring, e.g. `metrics log-polish-nudge`); verified identical failure with this change stashed. GitHub CI has no siblings and skips those legs.

Closes cameronsjo/claude-configurations#227

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `rules validate-frontmatter` now accepts the `paths` frontmatter field for path-scoped skills, so valid skill files no longer fail validation.
  * Skill files with `paths` metadata now validate successfully in real skill directories.

* **Documentation**
  * Updated the changelog to reflect the validation fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->