### PR TITLE
fix(cadence): nudge-polish-before-pr sees polish run in a subagent session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **nudge-polish-before-pr: see polish run in a subagent transcript** (#247 on
+  claude-configurations). The pre-PR polish gate (and the `log-polish-nudge`
+  metric) read only the *parent* session transcript, so `cadence-forge:polish`
+  invoked inside a subagent was invisible — delegated PR flows were hard-blocked
+  and logged `polished: false` despite a real polish run. Both now also scan
+  this session's child transcripts (`<stem>/subagents/agent-*.jsonl`): a polish
+  run in any child satisfies the gate. The scan is lazy (only on the
+  would-block path) and fail-open at every step (missing dir / unreadable child
+  → falls through, never blocks on our own missing data, ADR-0001).
+
 ## [0.41.0] - 2026-06-23
 
 ### Changed

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -22,8 +22,11 @@
 //! `nudge-polish-before-pr` for wiring stability even though it now can block.)
 
 use cadence_hooks_core::shell::is_gh_pr_create;
-use cadence_hooks_core::transcript::transcript_has_polish_run;
+use cadence_hooks_core::transcript::{
+    subagent_transcripts_have_polish_run, transcript_has_polish_run,
+};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
+use std::path::Path;
 
 /// Gates `/polish` (cadence-forge:polish) before opening a PR — conditional on
 /// transcript evidence of a real polish run.
@@ -42,11 +45,27 @@ impl Check for NudgePolishBeforePr {
         // readable. A missing path, a non-file, or a read error all collapse to
         // `None`, and `decide` then fails open to a nudge — we never block on
         // our own missing data (ADR-0001).
-        let transcript = input
+        let tp = input
             .transcript_path()
-            .filter(|p| std::path::Path::new(p).is_file())
-            .and_then(|p| std::fs::read_to_string(p).ok());
-        decide(command, transcript.as_deref())
+            .filter(|p| Path::new(p).is_file());
+        let transcript = tp.and_then(|p| std::fs::read_to_string(p).ok());
+        // Polish run inside a *subagent* lives in a child transcript the parent
+        // scan above never sees (#247). Only scan those children on the path
+        // that would otherwise block — a gh-pr-create whose parent transcript is
+        // readable, non-empty, and shows no polish — so the common allow/nudge
+        // paths pay no directory-walk cost.
+        let subagent_polish = match transcript.as_deref() {
+            Some(t)
+                if is_gh_pr_create(command)
+                    && !t.trim().is_empty()
+                    && !transcript_has_polish_run(t) =>
+            {
+                tp.map(Path::new)
+                    .is_some_and(subagent_transcripts_have_polish_run)
+            }
+            _ => false,
+        };
+        decide(command, transcript.as_deref(), subagent_polish)
     }
 }
 
@@ -56,9 +75,14 @@ impl Check for NudgePolishBeforePr {
 ///
 /// - non-`gh pr create` → allow.
 /// - `gh pr create` + transcript showing a polish Skill run → allow (silent).
+/// - `gh pr create` + parent shows no polish but a subagent did → allow (delegated flow, #247).
 /// - `gh pr create` + readable, **non-empty** transcript without a polish run → block.
 /// - `gh pr create` + `None` / empty / whitespace-only transcript → nudge (fail-open floor).
-fn decide(command: &str, transcript: Option<&str>) -> CheckResult {
+///
+/// `subagent_polish` is the caller's pre-computed verdict on whether a child
+/// subagent transcript shows polish; it is kept out of `decide` so this stays
+/// pure (no I/O) and unit-testable.
+fn decide(command: &str, transcript: Option<&str>, subagent_polish: bool) -> CheckResult {
     if !is_gh_pr_create(command) {
         return CheckResult::allow();
     }
@@ -71,6 +95,9 @@ fn decide(command: &str, transcript: Option<&str>) -> CheckResult {
         Some(t) if t.trim().is_empty() => CheckResult::nudge(nudge_message()),
         // Polish actually ran — silent allow. Kills the nag-after-polish noise.
         Some(t) if transcript_has_polish_run(t) => CheckResult::allow(),
+        // Parent shows no polish, but a subagent of this session ran it — the
+        // delegated-flow case (#247). Silent allow, same as a parent-side run.
+        Some(_) if subagent_polish => CheckResult::allow(),
         // Readable, non-empty transcript with no polish run — an evidenced skip.
         // The teeth.
         Some(_) => CheckResult::block(block_message()),
@@ -161,7 +188,7 @@ mod tests {
     fn decide_pr_create_with_polish_run_allows_silently() {
         // Polish actually ran → silent allow. This is the noise-kill: today the
         // nudge fires even after a real polish run.
-        let result = decide("gh pr create --title test", Some(polish_transcript()));
+        let result = decide("gh pr create --title test", Some(polish_transcript()), false);
         assert_eq!(result.outcome, Outcome::Allow);
         assert!(
             result.message.is_none(),
@@ -173,7 +200,11 @@ mod tests {
     fn decide_pr_create_without_polish_run_blocks() {
         // The teeth: a readable transcript with no polish Skill run is an
         // evidenced skip → hard block.
-        let result = decide("gh pr create --title test", Some(no_polish_transcript()));
+        let result = decide(
+            "gh pr create --title test",
+            Some(no_polish_transcript()),
+            false,
+        );
         assert_eq!(result.outcome, Outcome::Block);
         let msg = result.message.unwrap_or_default();
         // The block carries the same loophole-closing clauses the nudge does.
@@ -216,11 +247,11 @@ mod tests {
         // evidence", not an evidenced skip — it must nudge, never block. Guards
         // the 0-byte / not-yet-flushed file case (security review finding 1).
         assert_eq!(
-            decide("gh pr create --title x", Some("")).outcome,
+            decide("gh pr create --title x", Some(""), false).outcome,
             Outcome::Nudge
         );
         assert_eq!(
-            decide("gh pr create --title x", Some("   \n\t  ")).outcome,
+            decide("gh pr create --title x", Some("   \n\t  "), false).outcome,
             Outcome::Nudge
         );
     }
@@ -229,7 +260,7 @@ mod tests {
     fn decide_pr_create_no_transcript_nudges() {
         // Fail-open floor (ADR-0001): no transcript evidence → today's soft
         // nudge, never a block. Preserves the pre-teeth behavior exactly.
-        let result = decide("gh pr create --title test", None);
+        let result = decide("gh pr create --title test", None, false);
         assert_eq!(result.outcome, Outcome::Nudge);
         let msg = result.message.unwrap_or_default();
         assert!(msg.contains("/polish"));
@@ -243,10 +274,10 @@ mod tests {
         // The matcher only scopes the process spawn; decide() still guards
         // against a non-create gh command slipping through.
         assert_eq!(
-            decide("gh pr list", Some(no_polish_transcript())).outcome,
+            decide("gh pr list", Some(no_polish_transcript()), false).outcome,
             Outcome::Allow
         );
-        assert_eq!(decide("git commit -m x", None).outcome, Outcome::Allow);
+        assert_eq!(decide("git commit -m x", None, false).outcome, Outcome::Allow);
     }
 
     #[test]
@@ -306,5 +337,48 @@ mod tests {
         // Branch named gh-pr-create-experiments shouldn't fire.
         let result = NudgePolishBeforePr.run(&make_bash("git checkout gh-pr-create-experiments"));
         assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- the delegated-flow case (#247) ---
+
+    #[test]
+    fn decide_pr_create_subagent_polish_allows() {
+        // Parent transcript shows no polish, but a subagent did (subagent_polish
+        // = true) → allow, not block. This is the delegated-PR-flow fix: polish
+        // run inside a child satisfies the gate.
+        let result = decide(
+            "gh pr create --title test",
+            Some(no_polish_transcript()),
+            true,
+        );
+        assert_eq!(result.outcome, Outcome::Allow);
+        assert!(
+            result.message.is_none(),
+            "a subagent polish run must allow silently, same as a parent run"
+        );
+    }
+
+    #[test]
+    fn run_allows_when_only_subagent_polished() {
+        // End-to-end through `run()`: a real gh-pr-create payload whose parent
+        // transcript shows no polish, but a sibling `<stem>/subagents/agent-*.jsonl`
+        // does → Allow. Proves run() reads the child transcripts, not just decide().
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("sess.jsonl");
+        std::fs::write(&parent, no_polish_transcript()).unwrap();
+        let subagents = tmp.path().join("sess").join("subagents");
+        std::fs::create_dir_all(&subagents).unwrap();
+        std::fs::write(subagents.join("agent-a1.jsonl"), polish_transcript()).unwrap();
+
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                command: Some("gh pr create --title test".into()),
+                ..Default::default()
+            }),
+            transcript_path: Some(parent.to_str().unwrap().into()),
+            ..Default::default()
+        };
+        assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Allow);
     }
 }

--- a/crates/core/src/transcript.rs
+++ b/crates/core/src/transcript.rs
@@ -9,6 +9,7 @@
 //! set of tests.
 
 use serde_json::Value;
+use std::path::{Path, PathBuf};
 
 /// True when the session transcript contains a `cadence-forge:polish` Skill
 /// invocation. Pure — operates on the transcript text, no I/O.
@@ -58,6 +59,59 @@ fn is_polish_skill(skill: &str) -> bool {
         .rsplit(':')
         .next()
         .is_some_and(|leaf| leaf.eq_ignore_ascii_case("polish"))
+}
+
+/// True when any child subagent transcript under
+/// `<parent-stem>/subagents/agent-*.jsonl` shows a polish Skill run.
+///
+/// Claude Code records a subagent's transcript next to the parent's: a parent
+/// `<dir>/<session>.jsonl` has its children at `<dir>/<session>/subagents/`.
+/// Polish invoked *inside* a delegated session therefore lives in a child file
+/// the parent-only [`transcript_has_polish_run`] never reads — this scans those
+/// children so a delegated polish run still satisfies the pre-PR gate (#247).
+///
+/// Fail-safe at every step: a missing `subagents/` dir, no children, or an
+/// unreadable child all yield `false`, so the caller falls through to the
+/// existing parent-transcript decision (ADR-0001 — never block on our own
+/// missing data). Never panics. `.any()` short-circuits on the first child that
+/// shows a polish run.
+pub fn subagent_transcripts_have_polish_run(parent_transcript_path: &Path) -> bool {
+    let Some(dir) = subagents_dir(parent_transcript_path) else {
+        return false;
+    };
+    let Ok(entries) = std::fs::read_dir(&dir) else {
+        return false;
+    };
+    entries.flatten().any(|entry| {
+        let path = entry.path();
+        is_agent_transcript(&path)
+            && std::fs::read_to_string(&path)
+                .map(|c| transcript_has_polish_run(&c))
+                .unwrap_or(false)
+    })
+}
+
+/// The `subagents/` directory a parent transcript's children live in:
+/// `<parent-dir>/<parent-stem>/subagents`. `None` when the path has no parent
+/// or no file stem (so a degenerate path can't panic the scan).
+fn subagents_dir(parent_transcript_path: &Path) -> Option<PathBuf> {
+    Some(
+        parent_transcript_path
+            .parent()?
+            .join(parent_transcript_path.file_stem()?)
+            .join("subagents"),
+    )
+}
+
+/// True when a path names a subagent transcript: a `.jsonl` file whose name
+/// starts with `agent-`. Excludes the `agent-*.meta.json` companion sidecars
+/// (extension `json`, not `jsonl`), which are not transcripts.
+fn is_agent_transcript(path: &Path) -> bool {
+    path.extension().and_then(|e| e.to_str()) == Some("jsonl")
+        && path
+            .file_name()
+            .and_then(|n| n.to_str())
+            .is_some_and(|n| n.starts_with("agent-"))
 }
 
 #[cfg(test)]
@@ -146,5 +200,75 @@ mod tests {
     #[test]
     fn corrupt_transcript_line_is_skipped() {
         assert!(!transcript_has_polish_run("not json {{\n"));
+    }
+
+    // --- subagent_transcripts_have_polish_run (#247) ---
+
+    /// A realistic transcript line carrying a `cadence-forge:polish` Skill run.
+    const POLISH_LINE: &str = r#"{"message":{"role":"assistant","content":[{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:polish"}}]}}"#;
+
+    /// Stand up a `<dir>/<sess>/subagents/` tree and return the *parent*
+    /// transcript path (`<dir>/<sess>.jsonl`) the helper derives children from.
+    /// The parent file itself is never read by the helper, so it need not exist.
+    fn parent_with_subagents(dir: &std::path::Path) -> PathBuf {
+        let subagents = dir.join("sess").join("subagents");
+        std::fs::create_dir_all(&subagents).unwrap();
+        dir.join("sess.jsonl")
+    }
+
+    #[test]
+    fn subagent_polish_in_child_is_detected() {
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = parent_with_subagents(tmp.path());
+        std::fs::write(
+            tmp.path().join("sess").join("subagents").join("agent-a1.jsonl"),
+            POLISH_LINE,
+        )
+        .unwrap();
+        assert!(
+            subagent_transcripts_have_polish_run(&parent),
+            "a polish run in a child subagent transcript must be detected"
+        );
+    }
+
+    #[test]
+    fn subagent_meta_json_companion_is_ignored() {
+        // Only an `agent-a1.meta.json` sidecar exists (no `.jsonl` transcript).
+        // It is not a transcript, so it must not count even if it held polish text.
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = parent_with_subagents(tmp.path());
+        std::fs::write(
+            tmp.path()
+                .join("sess")
+                .join("subagents")
+                .join("agent-a1.meta.json"),
+            POLISH_LINE,
+        )
+        .unwrap();
+        assert!(
+            !subagent_transcripts_have_polish_run(&parent),
+            "a .meta.json companion must be ignored, not scanned"
+        );
+    }
+
+    #[test]
+    fn no_subagents_dir_is_false() {
+        // Parent path with no `subagents/` directory beside it → false, never panic.
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = tmp.path().join("sess.jsonl");
+        assert!(!subagent_transcripts_have_polish_run(&parent));
+    }
+
+    #[test]
+    fn child_without_polish_is_false() {
+        // A child transcript exists but holds no polish Skill run → false.
+        let tmp = tempfile::tempdir().unwrap();
+        let parent = parent_with_subagents(tmp.path());
+        std::fs::write(
+            tmp.path().join("sess").join("subagents").join("agent-a1.jsonl"),
+            r#"{"message":{"role":"assistant","content":[{"type":"text","text":"no polish here"}]}}"#,
+        )
+        .unwrap();
+        assert!(!subagent_transcripts_have_polish_run(&parent));
     }
 }

--- a/crates/metrics/src/log_polish_nudge.rs
+++ b/crates/metrics/src/log_polish_nudge.rs
@@ -15,7 +15,9 @@
 
 use crate::common;
 use cadence_hooks_core::shell::is_gh_pr_create;
-use cadence_hooks_core::transcript::transcript_has_polish_run;
+use cadence_hooks_core::transcript::{
+    subagent_transcripts_have_polish_run, transcript_has_polish_run,
+};
 use cadence_hooks_core::{Logger, MetricsInput};
 use serde_json::{Value, json};
 use std::io::Write;
@@ -49,13 +51,19 @@ impl Logger for LogPolishNudge {
 
         // Did `/polish` run earlier this session? Best-effort — a missing or
         // unreadable transcript yields `false` (an honest "no evidence of
-        // polish"), never a panic.
+        // polish"), never a panic. Scans the parent transcript *and* this
+        // session's subagent transcripts, so a delegated polish run is recorded
+        // honestly rather than logged as `polished: false` (#247).
         let polished = input
             .transcript_path
             .as_deref()
             .filter(|p| std::path::Path::new(p).is_file())
-            .and_then(|p| std::fs::read_to_string(p).ok())
-            .map(|t| transcript_has_polish_run(&t))
+            .map(|p| {
+                let parent_polished = std::fs::read_to_string(p)
+                    .map(|t| transcript_has_polish_run(&t))
+                    .unwrap_or(false);
+                parent_polished || subagent_transcripts_have_polish_run(std::path::Path::new(p))
+            })
             .unwrap_or(false);
 
         let dir = common::metrics_dir();


### PR DESCRIPTION
## What

Teaches the `nudge-polish-before-pr` gate (and the `log-polish-nudge` metric) to recognize `cadence-forge:polish` invoked inside a subagent. When the parent session's JSONL shows no polish, it now also scans the session's child subagent JSONL files (`<stem>/subagents/agent-*.jsonl`); a polish run in any child satisfies the gate.

## Why

The gate read only the parent session's JSONL, so polish invoked inside a subagent — the normal case for any orchestrated / delegated PR flow — was invisible, and the gate hard-blocked `gh pr create` even though polish had run. The `log-polish-nudge` metric had the same parent-only blind spot, logging delegated-polish PRs as `polished: false`.

## How

- New fail-open helper in the core crate that scans the session's child subagent JSONL files (missing dir / unreadable child → false; `.meta.json` companions skipped).
- `decide()` stays pure (I/O-free) — it gains a `subagent_polish` arg and an allow-branch inserted **before** the block, so a child can only flip block→allow, never the reverse (the ADR-0001 fail-open invariant holds).
- `run()` computes it lazily — only on the would-block PR path, so no extra I/O on the common allow/nudge paths.
- Companion: the `log-polish-nudge` metric ORs in the same scan, so delegated polish is logged honestly.

## Tests

New unit + integration tests: parent-only polish still allows; subagent-only polish now allows; no polish still blocks; `.meta.json` companions ignored; missing dir falls through. Full suite green (core / cadence / metrics + `hook_registration_audit`), clippy clean. No `hooks.json` change — a behavior-only change to an existing guard; it ships on the next cadence-hooks release.

Closes cameronsjo/claude-configurations#247


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `/polish` now recognizes polish runs that happened in delegated child/subagent transcripts, not just the main transcript.
  * PR creation can now proceed when polish was completed in a child transcript, even if the parent transcript does not show it.

* **Bug Fixes**
  * Improved handling of missing, unreadable, or empty transcript data so these cases no longer block progress unnecessarily.
  * Session logging now more accurately reflects whether polish already ran.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->