### PR TITLE
style: apply cargo fmt to restore green CI on main

### DIFF
--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -45,9 +45,7 @@ impl Check for NudgePolishBeforePr {
         // readable. A missing path, a non-file, or a read error all collapse to
         // `None`, and `decide` then fails open to a nudge — we never block on
         // our own missing data (ADR-0001).
-        let tp = input
-            .transcript_path()
-            .filter(|p| Path::new(p).is_file());
+        let tp = input.transcript_path().filter(|p| Path::new(p).is_file());
         let transcript = tp.and_then(|p| std::fs::read_to_string(p).ok());
         // Polish run inside a *subagent* lives in a child transcript the parent
         // scan above never sees (#247). Only scan those children on the path
@@ -188,7 +186,11 @@ mod tests {
     fn decide_pr_create_with_polish_run_allows_silently() {
         // Polish actually ran → silent allow. This is the noise-kill: today the
         // nudge fires even after a real polish run.
-        let result = decide("gh pr create --title test", Some(polish_transcript()), false);
+        let result = decide(
+            "gh pr create --title test",
+            Some(polish_transcript()),
+            false,
+        );
         assert_eq!(result.outcome, Outcome::Allow);
         assert!(
             result.message.is_none(),
@@ -277,7 +279,10 @@ mod tests {
             decide("gh pr list", Some(no_polish_transcript()), false).outcome,
             Outcome::Allow
         );
-        assert_eq!(decide("git commit -m x", None, false).outcome, Outcome::Allow);
+        assert_eq!(
+            decide("git commit -m x", None, false).outcome,
+            Outcome::Allow
+        );
     }
 
     #[test]

--- a/crates/core/src/transcript.rs
+++ b/crates/core/src/transcript.rs
@@ -221,7 +221,10 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let parent = parent_with_subagents(tmp.path());
         std::fs::write(
-            tmp.path().join("sess").join("subagents").join("agent-a1.jsonl"),
+            tmp.path()
+                .join("sess")
+                .join("subagents")
+                .join("agent-a1.jsonl"),
             POLISH_LINE,
         )
         .unwrap();


### PR DESCRIPTION
main's `cargo fmt --all -- --check` CI step is red: #120/#124 merged unformatted Rust and main is not branch-protected, so nothing gated it. This applies rustfmt to the two affected files (`crates/cadence/src/nudge_polish_before_pr.rs`, `crates/core/src/transcript.rs`) — pure mechanical formatting, no logic change. clippy + all tests stay green. Unblocks #121/#122/#123 rebasing onto a clean base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)