### PR TITLE
chore: relicense BSL-1.1 → PolyForm Noncommercial 1.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 version = "0.41.0"
 edition = "2024"
-license = "BSL-1.1"
+license = "PolyForm-Noncommercial-1.0.0"
 authors = ["Cameron Sjo"]
 repository = "https://github.com/cameronsjo/cadence-hooks"
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,92 +1,133 @@
-Business Source License 1.1
+Required Notice: Copyright (c) 2025 Cameron Sjo (https://github.com/cameronsjo)
 
-License text copyright (c) 2017 MariaDB Corporation Ab, All Rights Reserved.
-"Business Source License" is a trademark of MariaDB Corporation Ab.
+# PolyForm Noncommercial License 1.0.0
 
-Parameters
+<https://polyformproject.org/licenses/noncommercial/1.0.0>
 
-Licensor:             Cameron Sjo
-Licensed Work:        cadence-hooks
-                      The Licensed Work is (c) 2025 Cameron Sjo.
-Additional Use Grant: You may use the Licensed Work in a personal or
-                      team capacity within the Licensor's employer.
-Change Date:          2050-01-01
-Change License:       Apache License, Version 2.0
+## Acceptance
 
-For information about alternative licensing arrangements, contact
-the Licensor.
+In order to get any license under these terms, you must agree
+to them as both strict obligations and conditions to all
+your licenses.
 
-Notice
+## Copyright License
 
-The Business Source License (this document, or the "License") is not
-an Open Source license. However, the Licensed Work will eventually be
-made available under an Open Source License, as stated in this License.
+The licensor grants you a copyright license for the
+software to do everything you might do with the software
+that would otherwise infringe the licensor's copyright
+in it for any permitted purpose.  However, you may
+only distribute the software according to [Distribution
+License](#distribution-license) and make changes or new works
+based on the software according to [Changes and New Works
+License](#changes-and-new-works-license).
 
-License text: https://mariadb.com/bsl11/
+## Distribution License
 
-Terms
+The licensor grants you an additional copyright license
+to distribute copies of the software.  Your license
+to distribute covers distributing the software with
+changes and new works permitted by [Changes and New Works
+License](#changes-and-new-works-license).
 
-The Licensor hereby grants you the right to copy, modify, create derivative
-works, redistribute, and make non-production use of the Licensed Work. The
-Licensor may make an Additional Use Grant, above, permitting limited
-production use.
+## Notices
 
-Effective on the Change Date, or the fourth anniversary of the first publicly
-available distribution of a specific version of the Licensed Work under this
-License, whichever comes first, the Licensor hereby grants you rights under
-the terms of the Change License, and the rights granted in the paragraph
-above terminate.
+You must ensure that anyone who gets a copy of any part of
+the software from you also gets a copy of these terms or the
+URL for them above, as well as copies of any plain-text lines
+beginning with `Required Notice:` that the licensor provided
+with the software.  For example:
 
-If your use of the Licensed Work does not comply with the requirements
-currently in effect as described in this License, you must purchase a
-commercial license from the Licensor, its affiliated entities, or authorized
-resellers, or you must refrain from using the Licensed Work.
+> Required Notice: Copyright Yoyodyne, Inc. (http://example.com)
 
-All copies of the original and modified Licensed Work, and derivative works
-of the Licensed Work, are subject to this License. This License applies
-separately for each version of the Licensed Work and the Change Date may vary
-for each version of the Licensed Work released by Licensor.
+## Changes and New Works License
 
-You must conspicuously display this License on each original or modified copy
-of the Licensed Work. If you receive the Licensed Work in original or
-modified form from a third party, the terms and conditions set forth in this
-License apply to your use of that work.
+The licensor grants you an additional copyright license to
+make changes and new works based on the software for any
+permitted purpose.
 
-Any use of the Licensed Work in violation of this License will automatically
-terminate your rights under this License for the current and all other
-versions of the Licensed Work.
+## Patent License
 
-This License does not grant you any right in any trademark or logo of
-Licensor or its affiliates (provided that you may use a trademark or logo of
-Licensor as expressly required by this License).
+The licensor grants you a patent license for the software that
+covers patent claims the licensor can license, or becomes able
+to license, that you would infringe by using the software.
 
-TO THE EXTENT PERMITTED BY APPLICABLE LAW, THE LICENSED WORK IS PROVIDED ON
-AN "AS IS" BASIS. LICENSOR HEREBY DISCLAIMS ALL WARRANTIES AND CONDITIONS,
-EXPRESS OR IMPLIED, INCLUDING (WITHOUT LIMITATION) WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, NON-INFRINGEMENT, AND
-TITLE.
+## Noncommercial Purposes
 
-MariaDB hereby grants you permission to use this License's text to license
-your works, and to refer to it using the trademark "Business Source License",
-as long as you comply with the Covenants of Licensor below.
+Any noncommercial purpose is a permitted purpose.
 
-Covenants of Licensor
+## Personal Uses
 
-In consideration of the right to use this License's text and the "Business
-Source License" name and trademark, Licensor covenants to MariaDB, and to all
-other recipients of the licensed work to be provided by Licensor:
+Personal use for research, experiment, and testing for
+the benefit of public knowledge, personal study, private
+entertainment, hobby projects, amateur pursuits, or religious
+observance, without any anticipated commercial application,
+is use for a permitted purpose.
 
-1. To specify as the Change License the GPL Version 2.0 or any later version,
-   or a license that is compatible with GPL Version 2.0 or a later version,
-   where "compatible" means that software provided under the Change License can
-   be included in a program with software provided under GPL Version 2.0 or a
-   later version. Licensor may specify additional Change Licenses without
-   limitation.
+## Noncommercial Organizations
 
-2. To either: (a) specify an additional grant of rights to use that does not
-   impose any additional restriction on the right granted in this License, as
-   the Additional Use Grant; or (b) insert the text "None".
+Use by any charitable organization, educational institution,
+public research organization, public safety or health
+organization, environmental protection organization,
+or government institution is use for a permitted purpose
+regardless of the source of funding or obligations resulting
+from the funding.
 
-3. To specify a Change Date.
+## Fair Use
 
-4. Not to modify this License in any other way.
+You may have "fair use" rights for the software under the
+law. These terms do not limit them.
+
+## No Other Rights
+
+These terms do not allow you to sublicense or transfer any of
+your licenses to anyone else, or prevent the licensor from
+granting licenses to anyone else.  These terms do not imply
+any other licenses.
+
+## Patent Defense
+
+If you make any written claim that the software infringes or
+contributes to infringement of any patent, your patent license
+for the software granted under these terms ends immediately. If
+your company makes such a claim, your patent license ends
+immediately for work on behalf of your company.
+
+## Violations
+
+The first time you are notified in writing that you have
+violated any of these terms, or done anything with the software
+not covered by your licenses, your licenses can nonetheless
+continue if you come into full compliance with these terms,
+and take practical steps to correct past violations, within
+32 days of receiving notice.  Otherwise, all your licenses
+end immediately.
+
+## No Liability
+
+***As far as the law allows, the software comes as is, without
+any warranty or condition, and the licensor will not be liable
+to you for any damages arising out of these terms or the use
+or nature of the software, under any kind of legal claim.***
+
+## Definitions
+
+The **licensor** is the individual or entity offering these
+terms, and the **software** is the software the licensor makes
+available under these terms.
+
+**You** refers to the individual or entity agreeing to these
+terms.
+
+**Your company** is any legal entity, sole proprietorship,
+or other kind of organization that you work for, plus all
+organizations that have control over, are under the control of,
+or are under common control with that organization.  **Control**
+means ownership of substantially all the assets of an entity,
+or the power to direct its management and policies by vote,
+contract, or otherwise.  Control can be direct or indirect.
+
+**Your licenses** are all the licenses granted to you for the
+software under these terms.
+
+**Use** means anything you do with the software requiring one
+of your licenses.

--- a/README.md
+++ b/README.md
@@ -172,4 +172,4 @@ hook firing in error is `/cadence:feedback`.
 
 ## License
 
-[BSL-1.1](LICENSE) — free for personal, non-commercial use. Converts to MIT after four years.
+[PolyForm Noncommercial 1.0.0](LICENSE) — free for any noncommercial use. Commercial use requires a separate license from the author.


### PR DESCRIPTION
Part of the ecosystem relicense (cameronsjo/claude-configurations#178): **BSL 1.1 → PolyForm Noncommercial 1.0.0**.

- **LICENSE** — byte-verbatim SPDX `PolyForm-Noncommercial-1.0.0` text + a `Required Notice:` copyright header (validated byte-for-byte against the SPDX license-list source per claude-configurations#216).
- **Cargo.toml** — `license = "PolyForm-Noncommercial-1.0.0"`.
- **README** — dropped the BSL "converts to MIT after four years" promise (PolyForm never converts).

Sole-authored (verified `git shortlog -sne --all`: only Cameron + AI tooling + CI bot), so no external consent needed. Future-only — anything already published under BSL stays BSL.

**Left open for your review — not merging.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s license to PolyForm Noncommercial 1.0.0.
  * Replaced the previous license text with the new terms and required notice.
* **Documentation**
  * Revised the README license section to reflect the new noncommercial licensing terms and commercial-use requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->