### PR TITLE
feat(guardrails): enforce-worktree — block mutations in primary checkouts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,18 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Added
 
+- **`guardrails enforce-worktree` — hard block on mutations in a primary
+  checkout of a branch-mode repo.** Enforces the worktree-isolation invariant
+  (every session in its own worktree, or in a `CADENCE_ALLOW_MAIN` repo where
+  main is the working branch by design) that replaces advisory multi-session
+  coordination — see claude-configurations ADR-0030. Blocks Edit/Write/MultiEdit
+  and leading-`git commit` (including `git -C <primary>` forms) when the target
+  repo's `.git` is a directory; linked worktrees (`.git` file) pass untouched.
+  Exemptions: `CADENCE_ALLOW_MAIN`, the `CADENCE_NO_ENFORCE_WORKTREE` kill
+  switch, temp-rooted scratch repos, `.claude/` and `docs/plans/` paths, and a
+  new `guardrails dismiss-enforce-worktree --for <duration>` snooze (24h cap).
+  Fails open on any git/parse failure (ADR-0001).
+
 - **Per-repo terminology exemptions (`.claude/terminology.json`).** The
   `terminology` guard now reads an optional `<git-root>/.claude/terminology.json`
   that softens its hard block for named files and terms — mirroring the

--- a/crates/guardrails/src/dismiss_enforce_worktree.rs
+++ b/crates/guardrails/src/dismiss_enforce_worktree.rs
@@ -1,0 +1,161 @@
+//! Per-repo snooze for the `enforce-worktree` guard.
+//!
+//! Mirrors [`crate::dismiss_main_branch_warn`] — same marker format
+//! (epoch-seconds line under `.git/cadence-hooks/`), same 24h cap, same
+//! duration grammar — but with its own marker file so snoozing the hard block
+//! and snoozing the main-branch nudge stay independent decisions.
+//!
+//! Exposes:
+//! - `is_snoozed_now(repo_root)` — used by `enforce-worktree` before blocking
+//! - `run_dismiss(duration_str)` — the `dismiss-enforce-worktree` subcommand
+//!
+//! The marker lives in the **primary checkout's** `.git/` directory — which is
+//! exactly where the guard fires, so `git rev-parse --show-toplevel` from the
+//! blocked directory resolves to the right root.
+
+use crate::dismiss_main_branch_warn::{is_snoozed_at, parse_duration};
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::{self, Command};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+const SNOOZE_DIR: &str = ".git/cadence-hooks";
+const SNOOZE_FILE: &str = "enforce-worktree-snoozed-until";
+/// Same cap as the main-branch snooze: a lingering marker would silently
+/// disable the block long after the one-off reason for it expired.
+const MAX_SNOOZE_SECONDS: u64 = 24 * 60 * 60;
+
+/// Marker file path for a given repo root.
+pub fn marker_path(repo_root: &Path) -> PathBuf {
+    repo_root.join(SNOOZE_DIR).join(SNOOZE_FILE)
+}
+
+fn now_epoch() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+/// Read the marker for the given repo and decide if the snooze is active.
+pub fn is_snoozed_now(repo_root: &Path) -> bool {
+    let Ok(contents) = fs::read_to_string(marker_path(repo_root)) else {
+        return false;
+    };
+    is_snoozed_at(&contents, now_epoch())
+}
+
+/// Locate the current repo root via `git rev-parse --show-toplevel`.
+fn repo_root() -> Option<PathBuf> {
+    let out = Command::new("git")
+        .args(["rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(PathBuf::from(path))
+    }
+}
+
+/// Entry point for the `dismiss-enforce-worktree` subcommand.
+///
+/// Writes the epoch-seconds expiry marker and confirms. Exits 1 on failure
+/// (missing repo, invalid duration, write error); 0 on success — this is a
+/// user-facing CLI, not a hook.
+pub fn run_dismiss(duration_str: &str) -> ! {
+    let Some(duration) = parse_duration(duration_str) else {
+        eprintln!(
+            "cadence-hooks: invalid duration '{duration_str}'\n   \
+             Expected: <number><s|m|h|d>, e.g. `30m`, `2h`, `1d`"
+        );
+        process::exit(1);
+    };
+
+    let secs = duration.as_secs();
+    if secs > MAX_SNOOZE_SECONDS {
+        eprintln!(
+            "cadence-hooks: snooze duration capped at 24h (got {duration_str})\n   \
+             Re-run with a smaller window, or run again later to renew."
+        );
+        process::exit(1);
+    }
+
+    let Some(root) = repo_root() else {
+        eprintln!(
+            "cadence-hooks: not inside a git repository\n   \
+             dismiss-enforce-worktree must be run from within the repo you want to unblock."
+        );
+        process::exit(1);
+    };
+
+    let path = marker_path(&root);
+    if let Some(parent) = path.parent()
+        && let Err(e) = fs::create_dir_all(parent)
+    {
+        eprintln!("cadence-hooks: could not create {}: {e}", parent.display());
+        process::exit(1);
+    }
+
+    let until = now_epoch().saturating_add(secs);
+    if let Err(e) = fs::write(&path, format!("{until}\n")) {
+        eprintln!("cadence-hooks: could not write {}: {e}", path.display());
+        process::exit(1);
+    }
+
+    println!(
+        "enforce-worktree unblocked for {duration_str} in {} (until epoch {until})",
+        root.display()
+    );
+    process::exit(0);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn marker_path_is_under_dot_git() {
+        let p = marker_path(Path::new("/tmp/repo"));
+        assert_eq!(
+            p,
+            Path::new("/tmp/repo/.git/cadence-hooks/enforce-worktree-snoozed-until")
+        );
+    }
+
+    #[test]
+    fn marker_is_distinct_from_main_branch_snooze() {
+        // Snoozing the hard block and snoozing the nudge are independent.
+        let root = Path::new("/tmp/repo");
+        assert_ne!(
+            marker_path(root),
+            crate::dismiss_main_branch_warn::marker_path(root)
+        );
+    }
+
+    #[test]
+    fn unreadable_marker_is_not_snoozed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        assert!(!is_snoozed_now(tmp.path()));
+    }
+
+    #[test]
+    fn future_marker_is_snoozed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = marker_path(tmp.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, format!("{}\n", now_epoch() + 3600)).unwrap();
+        assert!(is_snoozed_now(tmp.path()));
+    }
+
+    #[test]
+    fn expired_marker_is_not_snoozed() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = marker_path(tmp.path());
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, "100\n").unwrap();
+        assert!(!is_snoozed_now(tmp.path()));
+    }
+}

--- a/crates/guardrails/src/dismiss_main_branch_warn.rs
+++ b/crates/guardrails/src/dismiss_main_branch_warn.rs
@@ -30,7 +30,9 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
     if s.is_empty() {
         return None;
     }
-    let (num_part, unit) = s.split_at(s.len() - 1);
+    // Split before the final *character* — a byte index panics mid-char when
+    // the value ends in a multibyte char (e.g. `--for 5€`).
+    let (num_part, unit) = s.split_at(s.char_indices().last().map(|(i, _)| i)?);
     let n: u64 = num_part.parse().ok()?;
     if n == 0 {
         return None;
@@ -186,6 +188,13 @@ mod tests {
     #[test]
     fn parse_duration_rejects_unknown_unit() {
         assert_eq!(parse_duration("30y"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_multibyte_unit() {
+        // A multibyte final char must reject, not panic — `5€`'s len-1 is not
+        // a char boundary, so a byte-index split_at would panic mid-char.
+        assert_eq!(parse_duration("5€"), None);
     }
 
     #[test]

--- a/crates/guardrails/src/dismiss_main_branch_warn.rs
+++ b/crates/guardrails/src/dismiss_main_branch_warn.rs
@@ -51,7 +51,8 @@ pub fn marker_path(repo_root: &Path) -> PathBuf {
 }
 
 /// Pure: given the marker contents and current epoch, is the snooze active?
-fn is_snoozed_at(marker_contents: &str, now_epoch: u64) -> bool {
+/// Shared with `dismiss_enforce_worktree`, which uses the same marker format.
+pub(crate) fn is_snoozed_at(marker_contents: &str, now_epoch: u64) -> bool {
     let parsed: Option<u64> = marker_contents.trim().parse().ok();
     matches!(parsed, Some(until) if until > now_epoch)
 }

--- a/crates/guardrails/src/enforce_worktree.rs
+++ b/crates/guardrails/src/enforce_worktree.rs
@@ -30,7 +30,11 @@
 //! boundary): file mutations via bash (`sed -i`, redirects) are not inspected —
 //! the `git commit` arm is the persistence backstop; `git --work-tree=…` /
 //! `--git-dir=…` commit forms and commits wrapped in `sh -c '…'` skip the check
-//! (the target tree cannot be cheaply resolved — ambiguity fails open). A
+//! (the target tree cannot be cheaply resolved — ambiguity fails open).
+//! Env-prefixed forms (`VAR=x git commit`) are missed too — the leading word
+//! isn't `git` — and a `GIT_DIR=`/`GIT_WORK_TREE=` prefix can even invert the
+//! target (a rare false block when committing into a worktree *from* the
+//! primary via env); both accepted as exotic. A
 //! `git -C <path> commit` IS resolved against `<path>`, so committing into the
 //! primary from elsewhere still blocks, and committing into a worktree from
 //! the primary does not.
@@ -82,7 +86,15 @@ fn is_temp_root(repo_root: &Path, tmpdir: Option<&str>) -> bool {
     let via_env = tmpdir
         .map(str::trim)
         .filter(|t| !t.is_empty() && *t != "/")
-        .is_some_and(|t| repo_root.starts_with(t));
+        .is_some_and(|t| {
+            // `repo_root` comes from `git rev-parse --show-toplevel`, which
+            // canonicalizes (`/private/var/…` on macOS) while `$TMPDIR` does
+            // not (`/var/folders/…`) — compare against the canonicalized
+            // tmpdir too, or the exemption never fires on macOS.
+            repo_root.starts_with(t)
+                || std::fs::canonicalize(t)
+                    .is_ok_and(|c| c != Path::new("/") && repo_root.starts_with(&c))
+        });
     fixed || via_env
 }
 
@@ -95,6 +107,8 @@ type CommitTarget = Option<String>;
 /// `commit`, return where that commit lands: `Some(path)` for `git -C <path>
 /// commit`, `None` for the cwd. Segments using `--work-tree`/`--git-dir` are
 /// skipped entirely — the target tree is ambiguous, and ambiguity fails open.
+/// `-c <key>=<val>` pairs are walked over (value consumed) so the subcommand
+/// is still found behind inline config.
 ///
 /// The leading-word discipline mirrors `is_branch_switch` in the session
 /// crate: a `git commit` quoted in prose or a heredoc body is not this session
@@ -111,7 +125,9 @@ fn git_commit_targets(command: &str) -> Vec<CommitTarget> {
         let mut redirect: Option<&str> = None;
         let mut ambiguous = false;
         let mut idx = 1;
-        while idx < tokens.len() && (tokens[idx].starts_with('-') || tokens[idx - 1] == "-C") {
+        while idx < tokens.len()
+            && (tokens[idx].starts_with('-') || tokens[idx - 1] == "-C" || tokens[idx - 1] == "-c")
+        {
             let t = tokens[idx];
             if tokens[idx - 1] == "-C" {
                 redirect = Some(t);
@@ -345,6 +361,23 @@ mod tests {
         assert!(!is_temp_root(Path::new("/tmpfoo/repo"), None));
     }
 
+    #[test]
+    #[cfg(unix)]
+    fn tmpdir_env_canonicalization_mismatch_is_temp() {
+        // macOS: `git rev-parse --show-toplevel` canonicalizes
+        // (`/private/var/…`) while `$TMPDIR` stays `/var/folders/…` — the
+        // exemption must fire anyway. Simulated with a symlinked tmpdir under
+        // the non-temp scratch root (`Scratch` is defined with the
+        // end-to-end tests below).
+        let scratch = Scratch::new("tmpdir-canon");
+        let real = scratch.0.join("real");
+        let link = scratch.0.join("link");
+        std::fs::create_dir_all(&real).unwrap();
+        std::os::unix::fs::symlink(&real, &link).unwrap();
+        let repo_root = std::fs::canonicalize(&real).unwrap().join("repo");
+        assert!(is_temp_root(&repo_root, Some(link.to_str().unwrap())));
+    }
+
     // --- git_commit_targets (pure parsing) ---
 
     #[test]
@@ -365,6 +398,20 @@ mod tests {
         assert_eq!(
             git_commit_targets("git -C /some/worktree commit -m 'x'"),
             vec![Some("/some/worktree".to_string())]
+        );
+    }
+
+    #[test]
+    fn inline_config_commit_targets_cwd() {
+        // `git -c key=val commit` — the -c value must be consumed, not end
+        // the flag walk (else the commit is silently missed).
+        assert_eq!(
+            git_commit_targets("git -c user.email=x@y.z commit -m 'x'"),
+            vec![None]
+        );
+        assert_eq!(
+            git_commit_targets("git -c commit.gpgsign=false -C /wt commit -m 'x'"),
+            vec![Some("/wt".to_string())]
         );
     }
 

--- a/crates/guardrails/src/enforce_worktree.rs
+++ b/crates/guardrails/src/enforce_worktree.rs
@@ -1,0 +1,631 @@
+//! `enforce-worktree` — block mutations in a primary checkout of a branch-mode repo.
+//!
+//! The invariant this enforces: **every session works in its own worktree on its
+//! own branch, or in a repo where `main` is the working branch by design**
+//! (dotfiles, vaults — marked with `CADENCE_ALLOW_MAIN`). Sessions in separate
+//! worktrees cannot collide on checkout state, which is what lets the advisory
+//! multi-session coordination layer (cadence-canon) retire — see
+//! claude-configurations ADR-0030.
+//!
+//! Blocks (exit 2) when a file mutation (`Edit`/`Write`/`MultiEdit`) or a Bash
+//! `git commit` targets the **primary checkout** (`.git` is a directory) of a
+//! branch-mode repo. A linked worktree's `.git` is a file, so worktrees pass
+//! untouched — that is the point.
+//!
+//! Exemptions (→ allow):
+//! - `CADENCE_ALLOW_MAIN` truthy — the existing main-only-repo marker; a repo
+//!   that works on `main` by design has no worktree discipline to enforce.
+//! - `CADENCE_NO_ENFORCE_WORKTREE` truthy — user-global kill switch for the
+//!   proving period; rollback without uninstalling.
+//! - Repo root under a temp directory (`/tmp`, `/private/tmp`, `$TMPDIR`) —
+//!   scratch and fixture repos are not the long-lived checkouts this guards.
+//! - Paths inside a `.claude/` directory or under `docs/plans/` — same
+//!   carve-outs as `warn-main-branch` (issues #33, #35, #226).
+//! - Active snooze via `cadence-hooks guardrails dismiss-enforce-worktree
+//!   --for <duration>` — the one-off escape (e.g. committing a plan doc on the
+//!   default branch).
+//! - Not a git repo, or git unavailable — fail open (ADR-0001).
+//!
+//! Known misses, accepted by design (this is a discipline guard, not a security
+//! boundary): file mutations via bash (`sed -i`, redirects) are not inspected —
+//! the `git commit` arm is the persistence backstop; `git --work-tree=…` /
+//! `--git-dir=…` commit forms and commits wrapped in `sh -c '…'` skip the check
+//! (the target tree cannot be cheaply resolved — ambiguity fails open). A
+//! `git -C <path> commit` IS resolved against `<path>`, so committing into the
+//! primary from elsewhere still blocks, and committing into a worktree from
+//! the primary does not.
+
+use crate::dismiss_enforce_worktree;
+use crate::warn_main_branch::{git_dir_for_input, is_claude_managed_dir, is_plan_doc_dir};
+use crate::warn_subagent_worktree::is_primary_checkout;
+use cadence_hooks_core::shell::split_segments;
+use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Pure: classify a truthy env value (`1`/`true`/`yes`, trimmed,
+/// case-insensitive). Mirrors `warn_main_branch::is_main_allowed_value`.
+fn is_truthy(value: Option<&str>) -> bool {
+    matches!(
+        value.map(str::trim).map(str::to_ascii_lowercase).as_deref(),
+        Some("1" | "true" | "yes")
+    )
+}
+
+/// Environment inputs resolved once per invocation, injected into the
+/// assessment so tests can pin them without touching process env.
+struct EnvConfig {
+    /// `CADENCE_ALLOW_MAIN` — repo works on main by design (dotfiles, vaults).
+    allow_main: bool,
+    /// `CADENCE_NO_ENFORCE_WORKTREE` — user-global kill switch.
+    kill_switch: bool,
+    /// `$TMPDIR`, for the scratch-repo exemption.
+    tmpdir: Option<String>,
+}
+
+impl EnvConfig {
+    fn from_env() -> Self {
+        let truthy = |var: &str| is_truthy(std::env::var(var).ok().as_deref());
+        Self {
+            allow_main: truthy("CADENCE_ALLOW_MAIN"),
+            kill_switch: truthy("CADENCE_NO_ENFORCE_WORKTREE"),
+            tmpdir: std::env::var("TMPDIR").ok(),
+        }
+    }
+}
+
+/// Pure: is `repo_root` inside a temp tree? `tmpdir` is the `$TMPDIR` value,
+/// when set. Scratch/fixture repos live here; enforcing worktree discipline on
+/// them would only produce noise.
+fn is_temp_root(repo_root: &Path, tmpdir: Option<&str>) -> bool {
+    let fixed = repo_root.starts_with("/tmp") || repo_root.starts_with("/private/tmp");
+    let via_env = tmpdir
+        .map(str::trim)
+        .filter(|t| !t.is_empty() && *t != "/")
+        .is_some_and(|t| repo_root.starts_with(t));
+    fixed || via_env
+}
+
+/// The per-segment commit target: `-C <path>` when the commit redirects there,
+/// `None` for the current directory.
+type CommitTarget = Option<String>;
+
+/// Pure: for each `&&`/`;`/`|`-separated segment (heredoc bodies stripped by
+/// [`split_segments`]) whose **leading** word is `git` and whose subcommand is
+/// `commit`, return where that commit lands: `Some(path)` for `git -C <path>
+/// commit`, `None` for the cwd. Segments using `--work-tree`/`--git-dir` are
+/// skipped entirely — the target tree is ambiguous, and ambiguity fails open.
+///
+/// The leading-word discipline mirrors `is_branch_switch` in the session
+/// crate: a `git commit` quoted in prose or a heredoc body is not this session
+/// committing.
+fn git_commit_targets(command: &str) -> Vec<CommitTarget> {
+    let mut targets = Vec::new();
+    for segment in split_segments(command) {
+        let tokens: Vec<&str> = segment.split_whitespace().collect();
+        if tokens.first() != Some(&"git") {
+            continue;
+        }
+        // Walk git's own global flags to find the subcommand, capturing a
+        // `-C <path>` redirect on the way.
+        let mut redirect: Option<&str> = None;
+        let mut ambiguous = false;
+        let mut idx = 1;
+        while idx < tokens.len() && (tokens[idx].starts_with('-') || tokens[idx - 1] == "-C") {
+            let t = tokens[idx];
+            if tokens[idx - 1] == "-C" {
+                redirect = Some(t);
+            } else if t == "--work-tree"
+                || t == "--git-dir"
+                || t.starts_with("--work-tree=")
+                || t.starts_with("--git-dir=")
+            {
+                ambiguous = true;
+            }
+            idx += 1;
+        }
+        if ambiguous {
+            continue;
+        }
+        if tokens.get(idx) == Some(&"commit") {
+            targets.push(redirect.map(String::from));
+        }
+    }
+    targets
+}
+
+/// Pure decision, all environment resolved by the caller.
+fn should_block(
+    is_primary: bool,
+    allowed_main: bool,
+    kill_switch: bool,
+    temp_root: bool,
+    snoozed: bool,
+) -> bool {
+    is_primary && !allowed_main && !kill_switch && !temp_root && !snoozed
+}
+
+/// The block message: names the checkout and every escape hatch.
+fn block_message(repo_root: &str) -> String {
+    format!(
+        "Blocked: `{repo_root}` is a primary checkout — feature work belongs in a worktree, \
+         not the shared primary tree.\n\
+         Create one: `git worktree add .claude/worktrees/<slug> -b feat/<slug>` \
+         (or EnterWorktree / `/worktree create feat <slug>`), then work there.\n\
+         One-off exception: `cadence-hooks guardrails dismiss-enforce-worktree --for 30m`\n\
+         Repo works on main by design (dotfiles, vaults)? Set CADENCE_ALLOW_MAIN=true in \
+         .claude/settings.json's env block.\n\
+         Disable everywhere: CADENCE_NO_ENFORCE_WORKTREE=1"
+    )
+}
+
+/// Resolve the repo root enclosing `dir`, if any.
+fn repo_root_for(dir: &Path) -> Option<String> {
+    let out = Command::new("git")
+        .args(["-C", &dir.to_string_lossy(), "rev-parse", "--show-toplevel"])
+        .output()
+        .ok()
+        .filter(|o| o.status.success())?;
+    let root = String::from_utf8_lossy(&out.stdout).trim().to_string();
+    if root.is_empty() { None } else { Some(root) }
+}
+
+/// Evaluate one candidate directory: allow, or block with the message.
+fn assess_dir(dir: &Path, cfg: &EnvConfig) -> CheckResult {
+    if is_claude_managed_dir(dir) || is_plan_doc_dir(dir) {
+        return CheckResult::allow();
+    }
+    let Some(repo_root) = repo_root_for(dir) else {
+        // Not a git repo (or a bare container dir) — nothing to enforce.
+        return CheckResult::allow();
+    };
+    let blocked = should_block(
+        is_primary_checkout(&repo_root),
+        cfg.allow_main,
+        cfg.kill_switch,
+        is_temp_root(Path::new(&repo_root), cfg.tmpdir.as_deref()),
+        dismiss_enforce_worktree::is_snoozed_now(Path::new(&repo_root)),
+    );
+    if blocked {
+        CheckResult::block(block_message(&repo_root))
+    } else {
+        CheckResult::allow()
+    }
+}
+
+/// Testable core: assess the hook input under the given environment.
+fn run_enforce(input: &HookInput, cfg: &EnvConfig) -> CheckResult {
+    match input.tool_name() {
+        Some("Edit") | Some("Write") | Some("MultiEdit") => {
+            if input.file_path().is_none() {
+                // No target file — nothing to assess, fail open.
+                return CheckResult::allow();
+            }
+            assess_dir(&git_dir_for_input(input), cfg)
+        }
+        Some("Bash") => {
+            let Some(command) = input.command() else {
+                return CheckResult::allow();
+            };
+            let cwd = input
+                .cwd
+                .as_deref()
+                .map(PathBuf::from)
+                .unwrap_or_else(|| PathBuf::from("."));
+            for target in git_commit_targets(command) {
+                let dir = match target {
+                    Some(path) => {
+                        let p = PathBuf::from(&path);
+                        if p.is_absolute() { p } else { cwd.join(p) }
+                    }
+                    None => cwd.clone(),
+                };
+                let result = assess_dir(&dir, cfg);
+                if result.outcome != Outcome::Allow {
+                    return result;
+                }
+            }
+            CheckResult::allow()
+        }
+        _ => CheckResult::allow(),
+    }
+}
+
+/// Block mutations in a primary checkout of a branch-mode repo.
+pub struct EnforceWorktree;
+
+impl Check for EnforceWorktree {
+    fn name(&self) -> &str {
+        "enforce-worktree"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        run_enforce(input, &EnvConfig::from_env())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::test_builders::{make_bash, make_edit};
+
+    fn cfg(allow_main: bool, kill_switch: bool) -> EnvConfig {
+        EnvConfig {
+            allow_main,
+            kill_switch,
+            tmpdir: None,
+        }
+    }
+
+    // --- should_block (pure decision) ---
+
+    #[test]
+    fn primary_branch_mode_blocks() {
+        assert!(should_block(true, false, false, false, false));
+    }
+
+    #[test]
+    fn worktree_allows() {
+        assert!(!should_block(false, false, false, false, false));
+    }
+
+    #[test]
+    fn allow_main_repo_allows() {
+        // Dotfiles/vaults: main is the working branch by design.
+        assert!(!should_block(true, true, false, false, false));
+    }
+
+    #[test]
+    fn kill_switch_allows() {
+        assert!(!should_block(true, false, true, false, false));
+    }
+
+    #[test]
+    fn temp_root_allows() {
+        assert!(!should_block(true, false, false, true, false));
+    }
+
+    #[test]
+    fn snoozed_allows() {
+        assert!(!should_block(true, false, false, false, true));
+    }
+
+    // --- is_truthy ---
+
+    #[test]
+    fn truthy_values() {
+        assert!(is_truthy(Some("1")));
+        assert!(is_truthy(Some("true")));
+        assert!(is_truthy(Some("YES")));
+        assert!(is_truthy(Some("  true  ")));
+    }
+
+    #[test]
+    fn falsy_values() {
+        assert!(!is_truthy(None));
+        assert!(!is_truthy(Some("")));
+        assert!(!is_truthy(Some("0")));
+        assert!(!is_truthy(Some("false")));
+        assert!(!is_truthy(Some("off")));
+    }
+
+    // --- is_temp_root ---
+
+    #[test]
+    fn tmp_roots_are_temp() {
+        assert!(is_temp_root(Path::new("/tmp/scratch-repo"), None));
+        assert!(is_temp_root(Path::new("/private/tmp/fixture"), None));
+    }
+
+    #[test]
+    fn tmpdir_env_root_is_temp() {
+        assert!(is_temp_root(
+            Path::new("/var/folders/xy/T/repo"),
+            Some("/var/folders/xy/T")
+        ));
+    }
+
+    #[test]
+    fn home_repo_is_not_temp() {
+        assert!(!is_temp_root(Path::new("/Users/dev/Projects/repo"), None));
+        // A degenerate `$TMPDIR=/` must not exempt everything.
+        assert!(!is_temp_root(
+            Path::new("/Users/dev/Projects/repo"),
+            Some("/")
+        ));
+        assert!(!is_temp_root(
+            Path::new("/Users/dev/Projects/repo"),
+            Some("")
+        ));
+    }
+
+    #[test]
+    fn temp_lookalike_is_not_temp() {
+        // Path-component boundary: /tmpfoo is not under /tmp.
+        assert!(!is_temp_root(Path::new("/tmpfoo/repo"), None));
+    }
+
+    // --- git_commit_targets (pure parsing) ---
+
+    #[test]
+    fn plain_commit_targets_cwd() {
+        assert_eq!(git_commit_targets("git commit -m 'x'"), vec![None]);
+    }
+
+    #[test]
+    fn commit_with_flags_targets_cwd() {
+        assert_eq!(
+            git_commit_targets("git commit --amend --no-edit"),
+            vec![None]
+        );
+    }
+
+    #[test]
+    fn dash_c_commit_targets_redirect() {
+        assert_eq!(
+            git_commit_targets("git -C /some/worktree commit -m 'x'"),
+            vec![Some("/some/worktree".to_string())]
+        );
+    }
+
+    #[test]
+    fn chained_commit_found() {
+        assert_eq!(
+            git_commit_targets("git add src/main.rs && git commit -m 'x' && git push"),
+            vec![None]
+        );
+    }
+
+    #[test]
+    fn non_commit_git_ignored() {
+        assert!(git_commit_targets("git status").is_empty());
+        assert!(git_commit_targets("git add -A").is_empty());
+        assert!(git_commit_targets("git push origin main").is_empty());
+    }
+
+    #[test]
+    fn non_leading_git_ignored() {
+        // Prose and echoes are not this session committing.
+        assert!(git_commit_targets("echo git commit -m 'x'").is_empty());
+    }
+
+    #[test]
+    fn heredoc_body_commit_ignored() {
+        // split_segments strips heredoc bodies — a commit mentioned in a
+        // document being written is not a commit being run.
+        assert!(
+            git_commit_targets("cat > notes.md <<'EOF'\nrun: git commit -m fix\nEOF").is_empty()
+        );
+    }
+
+    #[test]
+    fn work_tree_form_is_skipped() {
+        // Ambiguous target tree → fail open, documented miss.
+        assert!(git_commit_targets("git --work-tree=/other commit -m 'x'").is_empty());
+        assert!(git_commit_targets("git --git-dir=/o/.git commit -m 'x'").is_empty());
+    }
+
+    #[test]
+    fn multiple_commits_all_reported() {
+        assert_eq!(
+            git_commit_targets("git -C /a commit -m x; git commit -m y"),
+            vec![Some("/a".to_string()), None]
+        );
+    }
+
+    // --- block message ---
+
+    #[test]
+    fn message_names_every_escape_hatch() {
+        let msg = block_message("/Users/dev/repo");
+        assert!(msg.contains("/Users/dev/repo"));
+        assert!(msg.contains("git worktree add"));
+        assert!(msg.contains("dismiss-enforce-worktree"));
+        assert!(msg.contains("CADENCE_ALLOW_MAIN"));
+        assert!(msg.contains("CADENCE_NO_ENFORCE_WORKTREE"));
+    }
+
+    // --- end-to-end against real repos ---
+    //
+    // The scratch root lives under the workspace `target/` dir, NOT a tempdir:
+    // the temp-root exemption would otherwise mask the block path entirely.
+
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(tag: &str) -> Self {
+            let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../target/enforce-worktree-scratch")
+                .join(format!("{tag}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&root);
+            std::fs::create_dir_all(&root).unwrap();
+            Self(root)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn git_in(dir: &Path, args: &[&str]) {
+        let ok = Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        assert!(ok, "git {args:?} failed in {dir:?}");
+    }
+
+    fn init_repo(dir: &Path) {
+        git_in(dir, &["init", "-q", "-b", "main"]);
+        git_in(dir, &["config", "user.email", "t@t"]);
+        git_in(dir, &["config", "user.name", "t"]);
+        std::fs::write(dir.join("f.txt"), "x").unwrap();
+        git_in(dir, &["add", "f.txt"]);
+        git_in(dir, &["commit", "-q", "-m", "init"]);
+    }
+
+    /// Primary repo + linked worktree under a non-temp scratch root.
+    fn primary_and_worktree(scratch: &Scratch) -> (PathBuf, PathBuf) {
+        let primary = scratch.0.join("repo");
+        std::fs::create_dir(&primary).unwrap();
+        init_repo(&primary);
+        let wt = scratch.0.join("wt");
+        git_in(
+            &primary,
+            &["worktree", "add", &wt.to_string_lossy(), "-b", "feat/x"],
+        );
+        (primary, wt)
+    }
+
+    #[test]
+    fn edit_in_primary_blocks_and_in_worktree_allows() {
+        let scratch = Scratch::new("edit");
+        let (primary, wt) = primary_and_worktree(&scratch);
+
+        let file = primary.join("src.rs");
+        let input = make_edit(&file.to_string_lossy(), "a", "b");
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Block, "primary checkout must block");
+        let msg = r.message.unwrap();
+        assert!(msg.contains("worktree"), "fix named in message: {msg}");
+
+        let file = wt.join("src.rs");
+        let input = make_edit(&file.to_string_lossy(), "a", "b");
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow, "linked worktree must pass");
+    }
+
+    #[test]
+    fn allow_main_and_kill_switch_exempt_primary() {
+        let scratch = Scratch::new("env");
+        let (primary, _wt) = primary_and_worktree(&scratch);
+        let file = primary.join("src.rs");
+        let input = make_edit(&file.to_string_lossy(), "a", "b");
+
+        let r = run_enforce(&input, &cfg(true, false));
+        assert_eq!(r.outcome, Outcome::Allow, "CADENCE_ALLOW_MAIN exempts");
+        let r = run_enforce(&input, &cfg(false, true));
+        assert_eq!(
+            r.outcome,
+            Outcome::Allow,
+            "CADENCE_NO_ENFORCE_WORKTREE exempts"
+        );
+    }
+
+    #[test]
+    fn claude_dir_and_plan_docs_exempt_in_primary() {
+        let scratch = Scratch::new("carveouts");
+        let (primary, _wt) = primary_and_worktree(&scratch);
+
+        for sub in [".claude/worktrees/x/src.rs", "docs/plans/2026-07-02-p.md"] {
+            let file = primary.join(sub);
+            std::fs::create_dir_all(file.parent().unwrap()).unwrap();
+            let input = make_edit(&file.to_string_lossy(), "a", "b");
+            let r = run_enforce(&input, &cfg(false, false));
+            assert_eq!(r.outcome, Outcome::Allow, "carve-out for {sub}");
+        }
+    }
+
+    #[test]
+    fn snooze_marker_exempts_primary() {
+        let scratch = Scratch::new("snooze");
+        let (primary, _wt) = primary_and_worktree(&scratch);
+
+        let marker = dismiss_enforce_worktree::marker_path(&primary);
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        let until = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        std::fs::write(&marker, format!("{until}\n")).unwrap();
+
+        let file = primary.join("src.rs");
+        let input = make_edit(&file.to_string_lossy(), "a", "b");
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow, "active snooze exempts");
+    }
+
+    #[test]
+    fn commit_in_primary_blocks_and_in_worktree_allows() {
+        let scratch = Scratch::new("commit");
+        let (primary, wt) = primary_and_worktree(&scratch);
+
+        let mut input = make_bash("git commit -m 'x'");
+        input.cwd = Some(primary.to_string_lossy().into_owned());
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Block, "commit in primary must block");
+
+        let mut input = make_bash("git add f.txt && git commit -m 'x'");
+        input.cwd = Some(wt.to_string_lossy().into_owned());
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow, "commit in worktree must pass");
+
+        // `git -C <worktree> commit` from the primary resolves to the worktree.
+        let mut input = make_bash(&format!("git -C {} commit -m 'x'", wt.to_string_lossy()));
+        input.cwd = Some(primary.to_string_lossy().into_owned());
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(
+            r.outcome,
+            Outcome::Allow,
+            "-C redirect into a worktree must pass"
+        );
+
+        // …and the reverse still blocks.
+        let mut input = make_bash(&format!(
+            "git -C {} commit -m 'x'",
+            primary.to_string_lossy()
+        ));
+        input.cwd = Some(wt.to_string_lossy().into_owned());
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(
+            r.outcome,
+            Outcome::Block,
+            "-C redirect into the primary must block"
+        );
+    }
+
+    #[test]
+    fn missing_dir_fails_open() {
+        // A directory git cannot resolve (nonexistent path) → no repo root →
+        // allow. ADR-0001: the guard's own failure never blocks.
+        assert!(repo_root_for(Path::new("/nonexistent-enforce-worktree")).is_none());
+        let input = make_edit("/nonexistent-enforce-worktree/f.rs", "a", "b");
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    // --- tool gating ---
+
+    #[test]
+    fn read_tool_allows() {
+        let input = HookInput {
+            tool_name: Some("Read".into()),
+            ..Default::default()
+        };
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn edit_without_file_path_allows() {
+        let input = HookInput {
+            tool_name: Some("Edit".into()),
+            ..Default::default()
+        };
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn bash_without_commit_allows() {
+        let mut input = make_bash("git status && cargo test");
+        input.cwd = Some("/".into());
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+}

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -5,8 +5,12 @@
 
 /// Nudge after idle periods between edits to re-check context.
 pub mod check_idle_return;
+/// Per-repo snooze command + helper consumed by `enforce_worktree`.
+pub mod dismiss_enforce_worktree;
 /// Per-repo snooze command + helper consumed by `warn_main_branch`.
 pub mod dismiss_main_branch_warn;
+/// Block mutations in a primary checkout of a branch-mode repo.
+pub mod enforce_worktree;
 /// Block the first Claude-in-Chrome action per session until the device is confirmed.
 pub mod guard_browser_device;
 /// Block direct edits to production dotfiles; redirect to chezmoi source.

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -35,7 +35,7 @@ use std::process::Command;
 /// against the hook event's CWD, not the hook process's CWD. For Bash hooks
 /// (no file path), falls back to `input.cwd` then `.` so we still target the
 /// session's working directory rather than wherever the hook process started.
-fn git_dir_for_input(input: &HookInput) -> PathBuf {
+pub(crate) fn git_dir_for_input(input: &HookInput) -> PathBuf {
     let cwd = input
         .cwd
         .as_deref()
@@ -75,7 +75,7 @@ fn git_dir_for_input(input: &HookInput) -> PathBuf {
 ///
 /// Matches on an exact `.claude` path component, so look-alikes like
 /// `.claude-old` or `myclaude` are not exempt.
-fn is_claude_managed_dir(dir: &Path) -> bool {
+pub(crate) fn is_claude_managed_dir(dir: &Path) -> bool {
     dir.components().any(|c| c.as_os_str() == ".claude")
 }
 
@@ -90,7 +90,7 @@ fn is_claude_managed_dir(dir: &Path) -> bool {
 /// Matches consecutive `docs` → `plans` path components anywhere in the path, so
 /// a bare `plans/`, a non-adjacent `docs/foo/plans`, or a look-alike like
 /// `mydocs/plans` is not exempt.
-fn is_plan_doc_dir(dir: &Path) -> bool {
+pub(crate) fn is_plan_doc_dir(dir: &Path) -> bool {
     let comps: Vec<_> = dir.components().map(|c| c.as_os_str()).collect();
     comps.windows(2).any(|w| w[0] == "docs" && w[1] == "plans")
 }

--- a/crates/guardrails/src/warn_subagent_worktree.rs
+++ b/crates/guardrails/src/warn_subagent_worktree.rs
@@ -33,7 +33,7 @@ use std::path::{Path, PathBuf};
 /// repo's `.git/worktrees/`, so a `false` here means the session is already
 /// inside a worktree (and its subagents inherit that worktree). Mirrors the
 /// `.git`-dir primitive in `cadence_hooks_session::registry::ensure_git_excluded`.
-fn is_primary_checkout(repo_root: &str) -> bool {
+pub(crate) fn is_primary_checkout(repo_root: &str) -> bool {
     Path::new(repo_root).join(".git").is_dir()
 }
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -83,7 +83,8 @@ kept unprefixed because it's a cross-tool convention.
 | `CADENCE_GH_STRICT_LOOPS` | `guard-gh-write` | Set to `1` to block all looped gh writes lacking `-R`, even provably deterministic ones |
 | `CADENCE_ISSUE_TRACKER` | `warn-issue-tracker` | Override the canonical issue-tracker repo (`owner/repo`) the nudge steers `gh issue create` toward (default `cameronsjo/claude-configurations`) |
 | `CADENCE_GUARD_DOTFILES` | `guard-dotfiles` | Set to `1` to block direct edits to production dotfiles (clean no-op otherwise) |
-| `CADENCE_ALLOW_MAIN` | `warn-main-branch` | Set truthy (`1`/`true`/`yes`) in a repo's `.claude/settings.json` `env` block to permanently silence the main-branch warning where `main` is the working branch by design (dotfiles, vaults, scratchpads) |
+| `CADENCE_ALLOW_MAIN` | `warn-main-branch`, `enforce-worktree` | Set truthy (`1`/`true`/`yes`) in a repo's `.claude/settings.json` `env` block to mark a repo where `main` is the working branch by design (dotfiles, vaults, scratchpads) — silences the main-branch warning and exempts the repo from worktree enforcement |
+| `CADENCE_NO_ENFORCE_WORKTREE` | `enforce-worktree` | Set truthy (`1`/`true`/`yes`) to disable the primary-checkout block everywhere — the kill switch for the proving period; prefer `CADENCE_ALLOW_MAIN` per repo |
 | `CADENCE_SKIP_OVERSHARE_AUDIT` | `warn-overshare` | Set to `1` for a session-scoped bypass in repos that legitimately hold personal context |
 | `CADENCE_METRICS_PRICES` | `log-commit` | Path to a model price-table JSON; takes precedence over the `--prices` flag and the embedded default |
 | `CADENCE_METRICS_DIR` | metrics loggers | When set non-empty, the metrics root (JSONL files and the `state/` subdir live directly inside it); otherwise `<config_dir>/metrics` (honoring `CLAUDE_CONFIG_DIR`) |
@@ -186,3 +187,17 @@ cadence-hooks guardrails dismiss-main-branch-warn --for 2h
 The snooze marker lives at `<repo>/.git/cadence-hooks/main-branch-snoozed-until`, so it's per-repo and ignored by default (`.git/` is never committed). The hook's own warn output also points at the command, so it's discoverable when the warning fires.
 
 For a repo where `main` is the working branch by design, set `CADENCE_ALLOW_MAIN=true` in `.claude/settings.json` to silence the warning permanently instead.
+
+## Snoozing enforce-worktree
+
+`enforce-worktree` hard-blocks mutations in a primary checkout of a branch-mode repo. For the legitimate one-off — committing an approved plan doc on the default branch, a hotfix the user explicitly wants in the primary tree — snooze it per-repo:
+
+```bash
+# Default: 30 minutes
+cadence-hooks guardrails dismiss-enforce-worktree
+
+# Explicit duration: 2h, 1d, 45s, etc. Capped at 24h.
+cadence-hooks guardrails dismiss-enforce-worktree --for 2h
+```
+
+The marker lives at `<repo>/.git/cadence-hooks/enforce-worktree-snoozed-until` — independent of the `warn-main-branch` snooze, so unblocking the guard doesn't also silence the nudge. For a repo where `main` is the working branch by design, `CADENCE_ALLOW_MAIN=true` exempts it permanently; `CADENCE_NO_ENFORCE_WORKTREE=1` (user-global) disables the guard everywhere.

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -41,6 +41,7 @@ judgment to the model. It exempts retro paths and writes under `$OBSIDIAN_VAULT`
 | `guard-gh-dangerous` | PreToolUse (Bash) | Block irreversible gh operations (repo delete) |
 | `guard-git-init` | PostToolUse (Bash) | Nudge to scaffold and confirm license after `git init` or `gh repo create` |
 | `warn-main-branch` | PreToolUse (Write, Edit) | Warn when editing on main/master branch |
+| `enforce-worktree` | PreToolUse (Write, Edit, Bash) | Block mutations and `git commit` in a primary checkout of a branch-mode repo — work in a worktree instead (exempt: `CADENCE_ALLOW_MAIN` repos, temp/scratch repos, `.claude/` + `docs/plans/` paths) |
 | `warn-branch-base` | PreToolUse (Bash) | Warn when creating a branch from a non-main base |
 | `warn-cron-datetime` | PreToolUse (CronCreate) | Inject current datetime before scheduling cron jobs |
 | `warn-untracked` | PreToolUse (Bash) | Warn about untracked files during git commit |
@@ -155,3 +156,4 @@ during maintenance.
 | `session declare` | Declare what this session is working on (`--intent`, `--touching`) so peers can assess collision risk |
 | `session status` | List live and stale sessions registered in this repo |
 | `guardrails dismiss-main-branch-warn` | Snooze `warn-main-branch` for this repo for a bounded window (`--for 2h`, capped at 24h) — see [Snoozing warn-main-branch](configuration.md#snoozing-warn-main-branch) |
+| `guardrails dismiss-enforce-worktree` | Snooze the `enforce-worktree` block for this repo for a bounded window (`--for 30m`, capped at 24h) — the one-off escape for a legitimate primary-checkout mutation |

--- a/src/main.rs
+++ b/src/main.rs
@@ -198,6 +198,14 @@ enum GuardrailsCommands {
         #[arg(long = "for", default_value = "30m", value_name = "DURATION")]
         for_: String,
     },
+    /// Block mutations in a primary checkout of a branch-mode repo
+    EnforceWorktree,
+    /// Snooze enforce-worktree for this repo for the given duration
+    DismissEnforceWorktree {
+        /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
+        #[arg(long = "for", default_value = "30m", value_name = "DURATION")]
+        for_: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -319,11 +327,13 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::WarnAliasParsing => "warn-alias-parsing",
             GuardrailsCommands::GuardBrowserDevice => "guard-browser-device",
             GuardrailsCommands::InjectGhContext => "inject-gh-context",
-            // dismiss-main-branch-warn is a CLI action, not a hook —
-            // it has no PreToolUse/PostToolUse wiring and isn't subject
+            GuardrailsCommands::EnforceWorktree => "enforce-worktree",
+            // The dismiss-* subcommands are CLI actions, not hooks —
+            // they have no PreToolUse/PostToolUse wiring and aren't subject
             // to CADENCE_DISABLE. Falling out of the Some(...) here is
-            // intentional; handle it specially below.
+            // intentional; handle them specially below.
             GuardrailsCommands::DismissMainBranchWarn { .. } => return None,
+            GuardrailsCommands::DismissEnforceWorktree { .. } => return None,
         }),
         Commands::Rules(r) => Some(match r {
             RulesCommands::ValidateFrontmatter => "validate-frontmatter",
@@ -730,8 +740,15 @@ fn main() {
                 &cadence_hooks_guardrails::inject_gh_context::InjectGhContext,
                 session,
             ),
+            GuardrailsCommands::EnforceWorktree => run_check_from_stdin(
+                &cadence_hooks_guardrails::enforce_worktree::EnforceWorktree,
+                pre,
+            ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {
                 cadence_hooks_guardrails::dismiss_main_branch_warn::run_dismiss(&for_);
+            }
+            GuardrailsCommands::DismissEnforceWorktree { for_ } => {
+                cadence_hooks_guardrails::dismiss_enforce_worktree::run_dismiss(&for_);
             }
         },
         Commands::Rules(cmd) => match cmd {

--- a/src/main.rs
+++ b/src/main.rs
@@ -869,7 +869,12 @@ mod tests {
             "session",
         ];
         // clap subcommands that are CLI actions, not hooks (no hooks.json wiring).
-        let non_hooks = ["dismiss-main-branch-warn", "declare", "status"];
+        let non_hooks = [
+            "dismiss-main-branch-warn",
+            "dismiss-enforce-worktree",
+            "declare",
+            "status",
+        ];
 
         let mut clap_pairs: Vec<(String, String)> = Vec::new();
         for ns in namespaces {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -132,6 +132,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::PreToolUse),
     },
     HookEntry {
+        name: "enforce-worktree",
+        description: "Block mutations in a primary checkout of a branch-mode repo",
+        plugin: "guardrails",
+        event: Some(HookEvent::PreToolUse),
+    },
+    HookEntry {
         name: "warn-subagent-worktree",
         description: "Warn when dispatching a subagent from main while a sibling worktree exists",
         plugin: "guardrails",
@@ -429,6 +435,12 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         // directory to resolve against.
         ("guardrails", "warn-subagent-worktree") => Some(
             r#"{"tool_name":"Agent","tool_input":{"subagent_type":"general-purpose"},"cwd":"/tmp"}"#,
+        ),
+        // enforce-worktree only engages on a file mutation or git commit; the
+        // generic Bash sample would no-op. Note `try` substitutes the process
+        // cwd, so from a real primary checkout this smoke-tests live state.
+        ("guardrails", "enforce-worktree") => Some(
+            r#"{"tool_name":"Edit","tool_input":{"file_path":"/tmp/sample/file.txt"},"cwd":"/tmp"}"#,
         ),
         _ => None,
     }


### PR DESCRIPTION
## What

PR 1 of 2 for retiring multi-session coordination (ADR-0030, cameronsjo/claude-configurations): a hard-blocking guard that enforces the invariant **every session works in its own worktree on its own branch, or in a repo where main is the working branch by design**.

- **`guardrails enforce-worktree`** (PreToolUse): blocks Edit/Write/MultiEdit and leading `git commit` when the target repo is a **primary checkout** (`.git` is a directory) of a branch-mode repo. Linked worktrees (`.git` file) always pass. `git -C <path> commit` resolves against `<path>`, so committing into the primary from a worktree still blocks and vice versa.
- **`guardrails dismiss-enforce-worktree --for <dur>`**: per-repo snooze (24h cap), marker independent of the `warn-main-branch` snooze.
- **Exemptions**: `CADENCE_ALLOW_MAIN` (dotfiles/vaults — reuses the existing marker), `CADENCE_NO_ENFORCE_WORKTREE` kill switch for the proving period, temp-rooted scratch repos, `.claude/` and `docs/plans/` paths (same carve-outs as `warn-main-branch`), plus `CADENCE_BYPASS`/`CADENCE_DISABLE` as usual. Fails open on any git/parse failure (ADR-0001).
- Reuses the existing primitives: `git_dir_for_input` / `is_claude_managed_dir` / `is_plan_doc_dir` (now `pub(crate)` in `warn_main_branch`), `is_primary_checkout` (`warn_subagent_worktree`), `parse_duration`/`is_snoozed_at` (`dismiss_main_branch_warn`).

## Known misses (by design — discipline guard, not a security boundary)

Bash-side file mutations (`sed -i`, redirects) are not inspected — the commit block is the persistence backstop. `--work-tree`/`--git-dir` commit forms and `sh -c '…'` wrappers fail open (ambiguous target tree). Documented in the module docs.

Per the repo convention, `git_commit_targets` is new shell parsing feeding a guard — a `cadence-forge:security-reviewer` adversarial pass before merge is recommended. Note its failure direction is benign relative to the convention's trigger: a parser miss here means *no block* (allow), never a hidden command reaching another guard.

## Testing

Unit tests cover the pure decision, parsing (heredoc/prose/`-C`/`--work-tree` forms), temp-root and truthy classification, and end-to-end block/allow against real `git init` + `git worktree add` repos created under `target/` (deliberately outside the temp exemption so the block path is exercised). **Not run locally**: this session's sandbox blocks `static.crates.io`, so CI is the first real build — treat the CI legs as the verdict, per CLAUDE.md.

## Sequencing

Merge + release this first; the plugin wiring PR (cameronsjo/cadence) references the new subcommand and fails open (exit 1) on older binaries. Companion PRs: cameronsjo/cadence (wiring), cameronsjo/claude-configurations (ADR-0030 + phase-2 removal plan). PR 2 (delete cadence-canon + session modules) comes after the proving period defined in the plan doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Yc8aiTfZpWGxJPj4bPHnjJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01Yc8aiTfZpWGxJPj4bPHnjJ)_