### PR TITLE
feat(core): session-scoped marker primitive + git common-dir resolution (CP0 marker integrity)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@
 
 pub mod config;
 pub mod loop_analysis;
+pub mod markers;
 pub mod paths;
 pub mod shell;
 pub mod time;

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -77,18 +77,18 @@ fn harden_marker_dir(dir: &Path) -> io::Result<()> {
     std::fs::create_dir_all(dir)
 }
 
-/// The session scope key: the Claude Code `session_id` when present, else the
-/// legacy `PPID`→`process::id()` fallback. Hooks are child processes, so `PPID`
-/// (the Claude Code process) is the stable identifier when a payload omits the
-/// session id; `process::id()` is the last-resort per-invocation value.
+/// The session scope key: the Claude Code `session_id` when present, else a
+/// per-process best-effort id.
+///
+/// No session_id in payload → per-process best-effort (advisory only; a future
+/// block-gating consumer must require session_id). The pre-CP0 `PPID` env read is
+/// gone — `PPID` is never exported into a hook's environment (the very bug #133
+/// fixed), so it only ever fell through to `process::id()` anyway.
 fn session_scope(input: &HookInput) -> String {
-    input.session_id().map(str::to_string).unwrap_or_else(|| {
-        std::env::var("PPID")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or_else(std::process::id)
-            .to_string()
-    })
+    input
+        .session_id()
+        .map(str::to_string)
+        .unwrap_or_else(|| std::process::id().to_string())
 }
 
 /// Non-cryptographic hash of `s`. `DefaultHasher::new()` uses fixed keys, so the

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -1,0 +1,296 @@
+//! Session-scoped, per-user marker primitive for the advisory marker family.
+//!
+//! The once-per-session guards (`warn-main-branch`, `warn-subagent-worktree`,
+//! `guard-browser-device`, `check-idle-return`, and the main-branch snooze) all
+//! record state in a temp-file marker. Before CP0 each rolled its own path
+//! scheme, keyed on `PPID`→`process::id()` — but `PPID` is a shell builtin that
+//! is never exported into a hook's environment, so the fallback fired and every
+//! separate hook process got a fresh `process::id()`, defeating the once-per-
+//! *session* intent (the marker was never found on the next invocation).
+//!
+//! This module centralizes the family (#147) on two guarantees:
+//! - **Session scoping** via [`session_marker`]: the key is the Claude Code
+//!   `session_id` (stable across a session's many hook processes), hashed.
+//! - **A private 0700 directory** via [`marker_dir`]: removes the cross-user
+//!   symlink pre-plant that a world-writable `/tmp` marker name invites, with
+//!   [`write_marker`] adding `create_new`+`rename` as same-user TOCTOU defense.
+//!
+//! Markers are advisory — every failure path degrades open (ADR-0001): a marker
+//! that can't be written just means the nudge may re-fire, never a block.
+
+use crate::HookInput;
+use crate::paths;
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::io;
+use std::path::{Path, PathBuf};
+
+/// The per-user private directory holding the advisory marker family.
+///
+/// `<temp>/cadence-hooks-{hash(home)}`, created `0700` on unix so a co-tenant
+/// cannot pre-plant a symlink at a predictable marker name (the actual #147
+/// attack). The home hash keeps two users on a shared host from colliding.
+///
+/// **Fails open** to the shared [`paths::marker_temp_dir`] when the private dir
+/// can't be created or secured (or a symlink squats its path): markers are
+/// advisory, so a re-fired nudge is the acceptable degraded mode, never a block.
+pub fn marker_dir() -> PathBuf {
+    let base = paths::marker_temp_dir();
+    let mut hasher = DefaultHasher::new();
+    paths::user_home_lossy_or_default().hash(&mut hasher);
+    let dir = base.join(format!("cadence-hooks-{:x}", hasher.finish()));
+    if harden_marker_dir(&dir).is_ok() {
+        dir
+    } else {
+        base
+    }
+}
+
+/// Create the marker dir and lock it to `0700`, refusing a pre-planted symlink.
+#[cfg(unix)]
+fn harden_marker_dir(dir: &Path) -> io::Result<()> {
+    use std::os::unix::fs::PermissionsExt;
+    if let Ok(meta) = std::fs::symlink_metadata(dir)
+        && meta.file_type().is_symlink()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "marker dir path is a symlink",
+        ));
+    }
+    std::fs::create_dir_all(dir)?;
+    std::fs::set_permissions(dir, std::fs::Permissions::from_mode(0o700))
+}
+
+/// Non-unix: create the dir, still refusing a pre-planted symlink. Windows has
+/// no `0700` equivalent here — the per-user temp root already carries the ACL.
+#[cfg(not(unix))]
+fn harden_marker_dir(dir: &Path) -> io::Result<()> {
+    if let Ok(meta) = std::fs::symlink_metadata(dir)
+        && meta.file_type().is_symlink()
+    {
+        return Err(io::Error::new(
+            io::ErrorKind::AlreadyExists,
+            "marker dir path is a symlink",
+        ));
+    }
+    std::fs::create_dir_all(dir)
+}
+
+/// The session scope key: the Claude Code `session_id` when present, else the
+/// legacy `PPID`→`process::id()` fallback. Hooks are child processes, so `PPID`
+/// (the Claude Code process) is the stable identifier when a payload omits the
+/// session id; `process::id()` is the last-resort per-invocation value.
+fn session_scope(input: &HookInput) -> String {
+    input.session_id().map(str::to_string).unwrap_or_else(|| {
+        std::env::var("PPID")
+            .ok()
+            .and_then(|s| s.parse::<u32>().ok())
+            .unwrap_or_else(std::process::id)
+            .to_string()
+    })
+}
+
+/// Non-cryptographic hash of `s`. `DefaultHasher::new()` uses fixed keys, so the
+/// value is stable across the many separate hook processes of one session — the
+/// property the whole marker scheme depends on.
+fn hash_of(s: &str) -> u64 {
+    let mut h = DefaultHasher::new();
+    s.hash(&mut h);
+    h.finish()
+}
+
+/// Build a session-scoped marker path under the private [`marker_dir`].
+///
+/// Filename `{kind}-{repo_hash:x}-{sid_hash:x}`; the repo component is omitted
+/// when `repo_root` is `None` (e.g. the session-global browser-device
+/// handshake, which has no repo). Both `session_id` and `repo_root` are
+/// payload-controlled strings, so they are ALWAYS hashed, never used as path
+/// components — a manual `--session-id ../../x` is inert (the result is a direct
+/// child of [`marker_dir`]).
+///
+/// The hash is non-cryptographic and fixed-seed, so marker names are predictable
+/// by design: security rests on the `0700` [`marker_dir`], never on name
+/// secrecy. `agent_id` is deliberately NOT part of the key — `HookInput` carries
+/// none today, and CP2 will decide whether subagent-scoped markers extend it.
+pub fn session_marker(input: &HookInput, kind: &str, repo_root: Option<&str>) -> PathBuf {
+    let sid_hash = hash_of(&session_scope(input));
+    let name = match repo_root {
+        Some(root) => format!("{kind}-{:x}-{sid_hash:x}", hash_of(root)),
+        None => format!("{kind}-{sid_hash:x}"),
+    };
+    marker_dir().join(name)
+}
+
+/// Write `contents` to a marker path symlink-safely.
+///
+/// Stage to a uniquely-named `.{name}.{pid}.tmp` sibling with `create_new`
+/// (`O_EXCL`, which never follows a pre-planted symlink), then `rename` over the
+/// target (`rename` replaces the path itself, never following a symlink at the
+/// target). Lifted from `cadence_hooks_session::registry::atomic_write` so the
+/// marker family has one hardened write surface (#147). Never call bare
+/// `fs::write` on a marker path — that follows a symlink squatting the name.
+///
+/// Callers that use a marker purely as a presence flag may ignore the returned
+/// error: a failed write degrades to a re-fired nudge, never a block (ADR-0001).
+pub fn write_marker(path: &Path, contents: &str) -> io::Result<()> {
+    use std::io::Write;
+    let dir = path.parent().unwrap_or_else(|| Path::new("."));
+    let file_name = path
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "marker".to_string());
+    let tmp = dir.join(format!(".{file_name}.{}.tmp", std::process::id()));
+    let mut file = match std::fs::OpenOptions::new()
+        .write(true)
+        .create_new(true)
+        .open(&tmp)
+    {
+        Ok(f) => f,
+        // A stale temp from a crashed same-PID process is the only benign
+        // collision — remove and retry once.
+        Err(e) if e.kind() == io::ErrorKind::AlreadyExists => {
+            std::fs::remove_file(&tmp)?;
+            std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&tmp)?
+        }
+        Err(e) => return Err(e),
+    };
+    if let Err(e) = file.write_all(contents.as_bytes()) {
+        drop(file);
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    drop(file);
+    if let Err(e) = std::fs::rename(&tmp, path) {
+        let _ = std::fs::remove_file(&tmp);
+        return Err(e);
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input_with_session(sid: &str) -> HookInput {
+        HookInput {
+            session_id: Some(sid.into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn session_marker_differs_per_session() {
+        let a = session_marker(&input_with_session("sid-a"), "kind", Some("/tmp/repo"));
+        let b = session_marker(&input_with_session("sid-b"), "kind", Some("/tmp/repo"));
+        assert_ne!(a, b, "distinct sessions must not share a marker");
+    }
+
+    #[test]
+    fn session_marker_differs_per_repo() {
+        let a = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo-a"));
+        let b = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo-b"));
+        assert_ne!(a, b, "distinct repos must not share a marker");
+    }
+
+    #[test]
+    fn session_marker_stable_for_same_inputs() {
+        let a = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo"));
+        let b = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo"));
+        assert_eq!(a, b, "same inputs must produce the same marker");
+    }
+
+    #[test]
+    fn session_marker_repo_scoped_differs_from_global() {
+        // Omitting repo_root (global handshake) must not collide with a
+        // repo-scoped marker for the same kind + session.
+        let scoped = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo"));
+        let global = session_marker(&input_with_session("sid"), "kind", None);
+        assert_ne!(scoped, global);
+    }
+
+    #[test]
+    fn session_marker_never_embeds_raw_session_id() {
+        // A path-traversal session id must be hashed to a plain filename — the
+        // result is always a direct child of marker_dir(), never an escape.
+        let input = input_with_session("../../evil");
+        let p = session_marker(&input, "test-kind", None);
+        assert_eq!(
+            p.parent(),
+            Some(marker_dir().as_path()),
+            "marker must be a direct child of the private dir: {p:?}"
+        );
+        let name = p.file_name().unwrap().to_string_lossy();
+        assert!(
+            !name.contains('/') && !name.contains(".."),
+            "filename must carry no traversal: {name}"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn marker_dir_is_owner_only() {
+        use std::os::unix::fs::PermissionsExt;
+        let dir = marker_dir();
+        // marker_dir() only returns the private path when it secured it; if it
+        // fell back to the shared temp root, that's the fail-open path and 0700
+        // is not asserted. In the normal test environment the private dir is
+        // created and locked down.
+        if dir != paths::marker_temp_dir() {
+            let mode = std::fs::metadata(&dir).unwrap().permissions().mode();
+            assert_eq!(mode & 0o777, 0o700, "marker dir must be owner-only");
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn write_marker_does_not_clobber_preplanted_symlink() {
+        use std::os::unix::fs::symlink;
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_path_buf();
+        let victim = tmp.path().join("victim.txt");
+        std::fs::write(&victim, "precious\n").unwrap();
+
+        let target = dir.join("some-marker");
+        let temp_path = dir.join(format!(".some-marker.{}.tmp", std::process::id()));
+        symlink(&victim, &temp_path).unwrap();
+
+        write_marker(&target, "state").expect("marker write succeeds");
+        assert_eq!(
+            std::fs::read_to_string(&victim).unwrap(),
+            "precious\n",
+            "victim must not be clobbered through the pre-planted symlink"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "state",
+            "the marker still lands"
+        );
+    }
+
+    #[test]
+    fn write_marker_round_trips_and_leaves_no_temp() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("m");
+        write_marker(&target, "hello").unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "hello");
+        let names: Vec<String> = std::fs::read_dir(tmp.path())
+            .unwrap()
+            .flatten()
+            .map(|e| e.file_name().to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(names, vec!["m".to_string()], "no stray .tmp left behind");
+    }
+
+    #[test]
+    fn write_marker_overwrites_existing() {
+        let tmp = tempfile::tempdir().unwrap();
+        let target = tmp.path().join("m");
+        write_marker(&target, "first").unwrap();
+        write_marker(&target, "second").unwrap();
+        assert_eq!(std::fs::read_to_string(&target).unwrap(), "second");
+    }
+}

--- a/crates/core/src/paths.rs
+++ b/crates/core/src/paths.rs
@@ -12,7 +12,7 @@
 //! races parallel tests), mirroring the `expand_tilde`/`expand_tilde_with`
 //! split elsewhere in the workspace.
 
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 /// The current user's home directory, portably.
 ///
@@ -91,6 +91,75 @@ pub fn find_git_root(start: &str) -> Option<PathBuf> {
         if !dir.pop() {
             return None;
         }
+    }
+}
+
+/// Resolve a checkout's git **common directory** — the shared `.git` that holds
+/// repo-wide plumbing (`info/exclude`, `refs`, `objects`) for the primary
+/// checkout and every linked worktree of the same repository.
+///
+/// Pure filesystem walk, no `git` spawn (this is the future primitive for the
+/// #164 worktree classifier — keep it dependency-free):
+/// - `.git` is a directory → that directory is the common dir.
+/// - `.git` is a file (`gitdir: <path>`) → parse the target worktree admin dir,
+///   then read its `commondir` file to reach the shared `.git`. A relative
+///   `gitdir` joins against `repo_root`; a relative `commondir` joins against the
+///   admin dir. No `commondir` file → the admin dir is itself the common dir
+///   (submodule layout).
+///
+/// Returns `None` unless the resolved directory looks like a real git dir (a
+/// `HEAD` entry exists). The `.git` file is repo-controlled data and downstream
+/// callers *write* into the returned dir, so a crafted `gitdir: /Users/x/.ssh`
+/// must not resolve — the `HEAD` check bounds where a downstream write can land.
+pub fn resolve_git_common_dir(repo_root: &Path) -> Option<PathBuf> {
+    let dot_git = repo_root.join(".git");
+    let common = if dot_git.is_dir() {
+        dot_git
+    } else if dot_git.is_file() {
+        let gitdir = read_gitdir_file(&dot_git, repo_root)?;
+        resolve_commondir(&gitdir)
+    } else {
+        return None;
+    };
+    // A real git dir has a HEAD. This bounds a crafted `.git` file that would
+    // otherwise point a downstream write at an arbitrary directory.
+    common.join("HEAD").exists().then_some(common)
+}
+
+/// Parse a `.git` *file*'s `gitdir: <path>` line into the worktree admin dir,
+/// joining a relative target against the `.git` file's parent (`repo_root`).
+fn read_gitdir_file(dot_git_file: &Path, repo_root: &Path) -> Option<PathBuf> {
+    let contents = std::fs::read_to_string(dot_git_file).ok()?;
+    let target = contents
+        .lines()
+        .find_map(|l| l.trim().strip_prefix("gitdir:"))
+        .map(str::trim)?;
+    Some(join_maybe_relative(target, repo_root))
+}
+
+/// Read `<gitdir>/commondir` to reach the shared `.git`; absent or empty →
+/// `gitdir` itself is the common dir (a submodule has no separate common dir).
+fn resolve_commondir(gitdir: &Path) -> PathBuf {
+    match std::fs::read_to_string(gitdir.join("commondir")) {
+        Ok(raw) => {
+            let rel = raw.trim();
+            if rel.is_empty() {
+                gitdir.to_path_buf()
+            } else {
+                join_maybe_relative(rel, gitdir)
+            }
+        }
+        Err(_) => gitdir.to_path_buf(),
+    }
+}
+
+/// Join `p` against `base` when relative; return it as-is when absolute.
+fn join_maybe_relative(p: &str, base: &Path) -> PathBuf {
+    let path = PathBuf::from(p);
+    if path.is_absolute() {
+        path
+    } else {
+        base.join(path)
     }
 }
 
@@ -239,6 +308,101 @@ mod tests {
         // std::env::temp_dir is always an absolute, existing-or-creatable path
         // on every supported platform; we only assert it is non-empty/absolute.
         assert!(marker_temp_dir().is_absolute());
+    }
+
+    // --- resolve_git_common_dir (#130 / #164 primitive) ---
+
+    #[test]
+    fn common_dir_plain_checkout_is_dot_git() {
+        let tmp = tempfile::tempdir().unwrap();
+        let git = tmp.path().join(".git");
+        std::fs::create_dir_all(&git).unwrap();
+        std::fs::write(git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        assert_eq!(resolve_git_common_dir(tmp.path()), Some(git));
+    }
+
+    #[test]
+    fn common_dir_linked_worktree_absolute_gitdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let primary_git = tmp.path().join("primary").join(".git");
+        std::fs::create_dir_all(&primary_git).unwrap();
+        std::fs::write(primary_git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        let admin = primary_git.join("worktrees").join("wt");
+        std::fs::create_dir_all(&admin).unwrap();
+        std::fs::write(admin.join("commondir"), "../..\n").unwrap();
+
+        let linked = tmp.path().join("linked");
+        std::fs::create_dir_all(&linked).unwrap();
+        std::fs::write(
+            linked.join(".git"),
+            format!("gitdir: {}\n", admin.display()),
+        )
+        .unwrap();
+
+        let common = resolve_git_common_dir(&linked).expect("resolves");
+        // Points at the primary .git (via ../..); HEAD is reachable through it.
+        assert!(common.join("HEAD").exists());
+    }
+
+    #[test]
+    fn common_dir_linked_worktree_relative_gitdir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let primary_git = tmp.path().join(".git");
+        std::fs::create_dir_all(&primary_git).unwrap();
+        std::fs::write(primary_git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        let admin = primary_git.join("worktrees").join("wt");
+        std::fs::create_dir_all(&admin).unwrap();
+        std::fs::write(admin.join("commondir"), "../..\n").unwrap();
+
+        // A .git file whose gitdir is RELATIVE to the worktree root.
+        let linked = tmp.path().join("linked");
+        std::fs::create_dir_all(&linked).unwrap();
+        std::fs::write(linked.join(".git"), "gitdir: ../.git/worktrees/wt\n").unwrap();
+
+        let common = resolve_git_common_dir(&linked).expect("resolves relative gitdir");
+        assert!(common.join("HEAD").exists());
+    }
+
+    #[test]
+    fn common_dir_submodule_without_commondir_is_gitdir() {
+        // A submodule's .git file points at an admin dir with a HEAD but no
+        // commondir file → the admin dir itself is the common dir.
+        let tmp = tempfile::tempdir().unwrap();
+        let admin = tmp.path().join(".git-modules").join("sub");
+        std::fs::create_dir_all(&admin).unwrap();
+        std::fs::write(admin.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+
+        let sub = tmp.path().join("sub");
+        std::fs::create_dir_all(&sub).unwrap();
+        std::fs::write(sub.join(".git"), format!("gitdir: {}\n", admin.display())).unwrap();
+
+        assert_eq!(resolve_git_common_dir(&sub), Some(admin));
+    }
+
+    #[test]
+    fn common_dir_garbage_git_file_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        std::fs::write(tmp.path().join(".git"), "not a gitdir line\n").unwrap();
+        assert_eq!(resolve_git_common_dir(tmp.path()), None);
+    }
+
+    #[test]
+    fn common_dir_resolved_without_head_is_none() {
+        // A crafted `.git` file pointing at a real dir that has NO HEAD must not
+        // resolve — otherwise a downstream write could land anywhere (#147/#130).
+        let tmp = tempfile::tempdir().unwrap();
+        let evil = tmp.path().join("not-a-git-dir");
+        std::fs::create_dir_all(&evil).unwrap();
+        let repo = tmp.path().join("repo");
+        std::fs::create_dir_all(&repo).unwrap();
+        std::fs::write(repo.join(".git"), format!("gitdir: {}\n", evil.display())).unwrap();
+        assert_eq!(resolve_git_common_dir(&repo), None);
+    }
+
+    #[test]
+    fn common_dir_absent_git_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(resolve_git_common_dir(tmp.path()), None);
     }
 
     #[test]

--- a/crates/guardrails/src/check_idle_return.rs
+++ b/crates/guardrails/src/check_idle_return.rs
@@ -4,14 +4,12 @@
 //! returns after 5+ minutes of inactivity, warns them to review context.
 //! After 8+ hours, suggests starting a fresh session.
 
+use cadence_hooks_core::shell::git_command;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 #[cfg(test)]
 use cadence_hooks_core::Outcome;
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
-use std::process::Command;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 const IDLE_THRESHOLD_SECS: u64 = 300; // 5 minutes
@@ -50,22 +48,20 @@ fn idle_outcome(gap: Option<u64>) -> CheckResult {
 pub struct CheckIdleReturn;
 
 impl CheckIdleReturn {
-    fn marker_path() -> Option<PathBuf> {
-        let repo_root = Command::new("git")
-            .args(["rev-parse", "--show-toplevel"])
-            .output()
-            .ok()
-            .filter(|o| o.status.success())
-            .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())?;
-
-        let mut hasher = DefaultHasher::new();
-        repo_root.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        Some(
-            cadence_hooks_core::paths::marker_temp_dir()
-                .join(format!(".claude-last-edit-{hash:x}")),
-        )
+    /// The last-edit marker, scoped to this session AND the edited file's repo.
+    ///
+    /// Repo resolution uses `git -C <cwd>` (house style) so nested-repo edits key
+    /// to the right checkout. Session-scoping is the #132 fix: "idle" now means
+    /// *this session's* last edit — a peer's activity in the same repo no longer
+    /// refreshes your marker and masks your idle return.
+    fn marker_path(input: &HookInput) -> Option<PathBuf> {
+        let cwd = input.cwd.as_deref().unwrap_or(".");
+        let repo_root = git_command(cwd, &["rev-parse", "--show-toplevel"])?;
+        Some(cadence_hooks_core::markers::session_marker(
+            input,
+            "last-edit",
+            Some(&repo_root),
+        ))
     }
 
     fn now_secs() -> u64 {
@@ -81,8 +77,8 @@ impl Check for CheckIdleReturn {
         "check-idle-return"
     }
 
-    fn run(&self, _input: &HookInput) -> CheckResult {
-        let Some(marker) = Self::marker_path() else {
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let Some(marker) = Self::marker_path(input) else {
             return CheckResult::allow();
         };
 
@@ -95,8 +91,8 @@ impl Check for CheckIdleReturn {
 
         let result = idle_outcome(gap);
 
-        // Always update marker with current timestamp
-        let _ = std::fs::write(&marker, now.to_string());
+        // Always update this session's marker with the current timestamp.
+        let _ = cadence_hooks_core::markers::write_marker(&marker, &now.to_string());
 
         result
     }
@@ -242,6 +238,64 @@ mod tests {
                 .as_deref()
                 .expect("nudge should have a message")
                 .contains("fresh session")
+        );
+    }
+
+    // --- session-scoped marker keying (#132) ---
+
+    fn init_git_repo() -> tempfile::TempDir {
+        let dir = tempfile::tempdir().unwrap();
+        let ok = std::process::Command::new("git")
+            .args(["init", "-q"])
+            .current_dir(dir.path())
+            .status()
+            .expect("git init");
+        assert!(ok.success(), "git init failed");
+        dir
+    }
+
+    fn input_in_repo(session_id: &str, repo: &std::path::Path) -> HookInput {
+        HookInput {
+            tool_name: Some("Edit".into()),
+            session_id: Some(session_id.into()),
+            cwd: Some(repo.to_string_lossy().into_owned()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn marker_path_differs_per_session() {
+        // Same repo, two sessions → distinct markers. Before #132 the marker was
+        // keyed on the repo hash alone, so both sessions shared one path.
+        let repo = init_git_repo();
+        let a = CheckIdleReturn::marker_path(&input_in_repo("sid-a", repo.path()));
+        let b = CheckIdleReturn::marker_path(&input_in_repo("sid-b", repo.path()));
+        assert!(a.is_some() && b.is_some(), "repo resolves");
+        assert_ne!(a, b, "same repo, different session → distinct markers");
+    }
+
+    #[test]
+    fn peer_activity_does_not_mask_idle_session() {
+        // Session A last edited 10m ago; peer B just edited in the same repo. A's
+        // idle return must still fire — B's fresh marker is B's, not A's (#132).
+        let repo = init_git_repo();
+        let input_a = input_in_repo("idle-session-a", repo.path());
+        let input_b = input_in_repo("busy-session-b", repo.path());
+        let now = CheckIdleReturn::now_secs();
+        let marker_a = CheckIdleReturn::marker_path(&input_a).expect("A marker");
+        let marker_b = CheckIdleReturn::marker_path(&input_b).expect("B marker");
+        cadence_hooks_core::markers::write_marker(&marker_a, &(now - 600).to_string()).unwrap();
+        cadence_hooks_core::markers::write_marker(&marker_b, &now.to_string()).unwrap();
+
+        let result = CheckIdleReturn.run(&input_a);
+        assert_eq!(
+            result.outcome,
+            Outcome::Nudge,
+            "A's idle return still fires"
+        );
+        assert!(
+            result.message.as_deref().unwrap().contains("10m"),
+            "A sees its own 10m gap, not B's fresh activity"
         );
     }
 }

--- a/crates/guardrails/src/dismiss_main_branch_warn.rs
+++ b/crates/guardrails/src/dismiss_main_branch_warn.rs
@@ -1,13 +1,24 @@
-//! Per-repo snooze for the `warn-main-branch` hook.
+//! Per-session snooze for the `warn-main-branch` hook (#135).
 //!
 //! Exposes:
-//! - `is_snoozed_now(repo_root)` — used by `warn-main-branch` to skip its nudge
+//! - `is_snoozed_now(input, repo_root)` — used by `warn-main-branch` to skip its nudge
 //! - `run_dismiss(duration_str)` — the `dismiss-main-branch-warn` subcommand entry point
 //!
-//! The marker file lives at `<repo_root>/.git/cadence-hooks/main-branch-snoozed-until`
-//! and contains a single Unix epoch-seconds line. `.git/` is gitignored by
-//! default, so the marker never accidentally gets committed.
+//! The snooze is **session-scoped**: each session dismisses the nudge for itself,
+//! and that consent does not transfer to peer sessions sharing the checkout. The
+//! marker lives in the private per-user marker dir (via
+//! [`cadence_hooks_core::markers::session_marker`], kind `main-branch-snooze`),
+//! keyed on the session id + repo hash, and holds a single Unix epoch-seconds
+//! expiry line. The 24h cap is enforced on **read** as well as write (clamped to
+//! `mtime + 24h`), so a tampered far-future body can't outlive the window.
+//!
+//! The legacy `<repo_root>/.git/cadence-hooks/main-branch-snoozed-until` location
+//! is no longer read or written by the snooze logic; [`marker_path`] is retained
+//! only as the distinctness reference the `dismiss-enforce-worktree` snooze pins
+//! against (its marker must differ from this one). Stale legacy files are
+//! orphaned harmlessly.
 
+use cadence_hooks_core::HookInput;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::process::{self, Command};
@@ -47,16 +58,62 @@ pub fn parse_duration(s: &str) -> Option<Duration> {
     n.checked_mul(secs_per_unit).map(Duration::from_secs)
 }
 
-/// Marker file path for a given repo root.
+/// Legacy `.git/`-relative marker path, retained ONLY as the distinctness
+/// reference the `dismiss-enforce-worktree` snooze pins against (its marker must
+/// differ from the main-branch one). The session-scoped snooze no longer reads
+/// or writes here — see [`session_snooze_marker`].
 pub fn marker_path(repo_root: &Path) -> PathBuf {
     repo_root.join(SNOOZE_DIR).join(SNOOZE_FILE)
 }
 
+/// The session-scoped snooze marker: private per-user dir, keyed on the session
+/// id + repo hash. Both writer (`run_dismiss`) and reader ([`is_snoozed_now`])
+/// resolve it through this one helper so the paths always agree.
+fn session_snooze_marker(input: &HookInput, repo_root: &Path) -> PathBuf {
+    cadence_hooks_core::markers::session_marker(
+        input,
+        "main-branch-snooze",
+        Some(&repo_root.to_string_lossy()),
+    )
+}
+
 /// Pure: given the marker contents and current epoch, is the snooze active?
-/// Shared with `dismiss_enforce_worktree`, which uses the same marker format.
+/// Shared with `dismiss_enforce_worktree`, which uses the same marker format and
+/// stays repo-scoped by design (it exempts the shared primary checkout).
 pub(crate) fn is_snoozed_at(marker_contents: &str, now_epoch: u64) -> bool {
     let parsed: Option<u64> = marker_contents.trim().parse().ok();
     matches!(parsed, Some(until) if until > now_epoch)
+}
+
+/// Pure: is the session snooze active, with the parsed expiry **clamped** to
+/// `mtime_epoch + MAX_SNOOZE_SECONDS`? The 24h cap is thereby enforced on read,
+/// not just at write time — a marker whose body was tampered to a far-future
+/// epoch still expires 24h after it was last written (the second half of #135).
+fn is_snoozed_clamped(marker_contents: &str, mtime_epoch: u64, now_epoch: u64) -> bool {
+    let Some(parsed) = marker_contents.trim().parse::<u64>().ok() else {
+        return false;
+    };
+    let cap = mtime_epoch.saturating_add(MAX_SNOOZE_SECONDS);
+    parsed.min(cap) > now_epoch
+}
+
+/// A file's mtime as Unix epoch seconds, `None` when unreadable.
+fn file_mtime_epoch(path: &Path) -> Option<u64> {
+    fs::metadata(path)
+        .ok()?
+        .modified()
+        .ok()?
+        .duration_since(UNIX_EPOCH)
+        .ok()
+        .map(|d| d.as_secs())
+}
+
+/// The Claude Code session id for the dismiss CLI, from `CLAUDE_CODE_SESSION_ID`
+/// (exported into the Bash tool environment). Empty/unset → `None`.
+fn session_id_from_env() -> Option<String> {
+    std::env::var("CLAUDE_CODE_SESSION_ID")
+        .ok()
+        .filter(|s| !s.is_empty())
 }
 
 /// Locate the current repo root via `git rev-parse --show-toplevel`.
@@ -82,28 +139,30 @@ fn now_epoch() -> u64 {
         .unwrap_or(0)
 }
 
-/// Convenience: read the marker for the given repo and decide if it's still
+/// Read this session's snooze marker for `repo_root` and decide if it's still
 /// active. Used by `warn-main-branch` before evaluating its own logic.
 ///
-/// The caller is responsible for resolving `repo_root` — typically via the
-/// same `git -C` query that drove branch detection. This keeps the snooze
-/// lookup keyed to the same repo as the marker write, which matters when the
-/// hook fires inside a nested repo (the outer CWD's repo would be the wrong
-/// key).
-pub fn is_snoozed_now(repo_root: &Path) -> bool {
-    let path = marker_path(repo_root);
+/// Session-scoped (#135): a peer session's snooze never suppresses this
+/// session's nudge. The caller resolves `repo_root` via the same `git -C` query
+/// that drove branch detection, so the snooze key matches the marker write even
+/// when the hook fires inside a nested repo. The parsed expiry is clamped to
+/// `mtime + 24h` on read, so a tampered body can't outlive the cap.
+pub fn is_snoozed_now(input: &HookInput, repo_root: &Path) -> bool {
+    let path = session_snooze_marker(input, repo_root);
     let Ok(contents) = fs::read_to_string(&path) else {
         return false;
     };
-    is_snoozed_at(&contents, now_epoch())
+    let mtime = file_mtime_epoch(&path).unwrap_or(0);
+    is_snoozed_clamped(&contents, mtime, now_epoch())
 }
 
 /// Entry point for the `dismiss-main-branch-warn` subcommand.
 ///
-/// Writes `<repo_root>/.git/cadence-hooks/main-branch-snoozed-until` with the
-/// epoch seconds when the snooze expires, then prints a confirmation. Exits 1
-/// on failure (missing repo, invalid duration, write error). Stays at exit 0
-/// on success — this is a user-facing CLI, not a hook.
+/// Writes the session-scoped snooze marker (private marker dir, keyed on the
+/// session id resolved from `CLAUDE_CODE_SESSION_ID`) with the epoch seconds when
+/// the snooze expires, then prints a confirmation. Exits 1 on failure (no session
+/// id, missing repo, invalid duration, write error). Stays at exit 0 on success —
+/// this is a user-facing CLI, not a hook.
 pub fn run_dismiss(duration_str: &str) -> ! {
     let duration = match parse_duration(duration_str) {
         Some(d) => d,
@@ -125,6 +184,16 @@ pub fn run_dismiss(duration_str: &str) -> ! {
         process::exit(1);
     }
 
+    // The snooze is session-scoped, so it needs the session id at write time.
+    let Some(session_id) = session_id_from_env() else {
+        eprintln!(
+            "cadence-hooks: no Claude Code session id\n   \
+             Run dismiss-main-branch-warn inside a Claude Code session \
+             (or export CLAUDE_CODE_SESSION_ID)."
+        );
+        process::exit(1);
+    };
+
     let Some(root) = repo_root() else {
         eprintln!(
             "cadence-hooks: not inside a git repository\n   \
@@ -133,22 +202,20 @@ pub fn run_dismiss(duration_str: &str) -> ! {
         process::exit(1);
     };
 
-    let path = marker_path(&root);
-    if let Some(parent) = path.parent()
-        && let Err(e) = fs::create_dir_all(parent)
-    {
-        eprintln!("cadence-hooks: could not create {}: {e}", parent.display());
-        process::exit(1);
-    }
+    let input = HookInput {
+        session_id: Some(session_id),
+        ..Default::default()
+    };
+    let path = session_snooze_marker(&input, &root);
 
     let until = now_epoch().saturating_add(secs);
-    if let Err(e) = fs::write(&path, format!("{until}\n")) {
+    if let Err(e) = cadence_hooks_core::markers::write_marker(&path, &format!("{until}\n")) {
         eprintln!("cadence-hooks: could not write {}: {e}", path.display());
         process::exit(1);
     }
 
     println!(
-        "warn-main-branch silenced for {duration_str} in {} (until epoch {until})",
+        "warn-main-branch silenced for this session for {duration_str} in {} (until epoch {until})",
         root.display()
     );
     process::exit(0);
@@ -256,10 +323,75 @@ mod tests {
 
     #[test]
     fn marker_path_is_under_dot_git() {
+        // Legacy path retained as the enforce-worktree distinctness reference.
         let p = marker_path(Path::new("/tmp/repo"));
         assert_eq!(
             p,
             Path::new("/tmp/repo/.git/cadence-hooks/main-branch-snoozed-until")
         );
+    }
+
+    // --- session-scoped snooze (#135) ---
+
+    fn input_with_session(sid: &str) -> HookInput {
+        HookInput {
+            session_id: Some(sid.into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn snooze_is_session_scoped() {
+        // A snooze set by session A must not silence the nudge for peer session B
+        // sharing the same checkout — consent doesn't transfer (#135).
+        let repo = Path::new("/tmp/cp0-snooze-scope-repo");
+        let input_a = input_with_session("snooze-scope-a");
+        let input_b = input_with_session("snooze-scope-b");
+        let path_a = session_snooze_marker(&input_a, repo);
+        let until = now_epoch() + 3600;
+        cadence_hooks_core::markers::write_marker(&path_a, &format!("{until}\n")).unwrap();
+
+        assert!(is_snoozed_now(&input_a, repo), "A's own snooze is active");
+        assert!(
+            !is_snoozed_now(&input_b, repo),
+            "B is not snoozed by A's marker"
+        );
+
+        let _ = fs::remove_file(&path_a);
+    }
+
+    #[test]
+    fn read_path_clamps_expiry_to_cap() {
+        // A body tampered to a far-future epoch (year ~2100) is snoozed right
+        // after write, but the 24h read clamp expires it once we pass mtime+24h.
+        let mtime = 1_000_000_000;
+        let far_future = "4102444800"; // ~2100-01-01
+        assert!(
+            is_snoozed_clamped(far_future, mtime, mtime + 60),
+            "fresh far-future marker reads as snoozed within the cap"
+        );
+        assert!(
+            !is_snoozed_clamped(far_future, mtime, mtime + MAX_SNOOZE_SECONDS + 1),
+            "past mtime + 24h the clamp expires it despite the 2100 body"
+        );
+    }
+
+    #[test]
+    fn clamp_allows_normal_snooze_within_cap() {
+        // A within-cap 1h snooze behaves normally: active until its own expiry.
+        let mtime = 1_000_000_000;
+        let until = mtime + 3600;
+        assert!(is_snoozed_clamped(&until.to_string(), mtime, mtime + 60));
+        assert!(!is_snoozed_clamped(&until.to_string(), mtime, until + 1));
+    }
+
+    #[test]
+    fn clamp_rejects_unparseable() {
+        assert!(!is_snoozed_clamped(
+            "not-a-number",
+            1_000_000_000,
+            1_000_000_000
+        ));
+        assert!(!is_snoozed_clamped("", 1_000_000_000, 1_000_000_000));
     }
 }

--- a/crates/guardrails/src/guard_browser_device.rs
+++ b/crates/guardrails/src/guard_browser_device.rs
@@ -26,8 +26,6 @@
 //! the gate for the rest of the session.
 
 use cadence_hooks_core::{Check, CheckResult, HookInput};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::PathBuf;
 
 /// Fully-qualified prefix shared by every claude-in-chrome MCP tool.
@@ -47,27 +45,15 @@ Fix:   1) list_connected_browsers  2) AskUserQuestion listing every connected\n\
 pub struct GuardBrowserDevice;
 
 impl GuardBrowserDevice {
-    /// Per-session marker path.
+    /// Per-session marker path (session-global — no repo component).
     ///
-    /// Hashes the session id so concurrent sessions don't share the handshake.
-    /// Falls back to `PPID` (the Claude Code process — hooks run as separate
-    /// children, so `process::id()` changes every invocation) and finally to
-    /// `process::id()`, mirroring [`crate::warn_main_branch`]'s scoping.
+    /// The device handshake is once per *session*, independent of any repo, so
+    /// the marker carries no repo scope. Delegates to the shared
+    /// [`cadence_hooks_core::markers::session_marker`] primitive, which supplies
+    /// the session-id key (with the PPID→pid fallback) under the private 0700
+    /// marker dir.
     fn marker_path(input: &HookInput) -> PathBuf {
-        let scope = input.session_id().map(str::to_string).unwrap_or_else(|| {
-            std::env::var("PPID")
-                .ok()
-                .and_then(|s| s.parse::<u32>().ok())
-                .unwrap_or_else(std::process::id)
-                .to_string()
-        });
-
-        let mut hasher = DefaultHasher::new();
-        scope.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        cadence_hooks_core::paths::marker_temp_dir()
-            .join(format!(".claude-browser-device-{hash:x}"))
+        cadence_hooks_core::markers::session_marker(input, "browser-device", None)
     }
 }
 
@@ -94,7 +80,7 @@ impl Check for GuardBrowserDevice {
         // First call: record the handshake *before* returning so the marker
         // persists even though we exit 2, then block. A write failure is not a
         // reason to keep blocking — fail open (ADR-0001).
-        let _ = std::fs::write(&marker, "");
+        let _ = cadence_hooks_core::markers::write_marker(&marker, "");
         CheckResult::block(BLOCK_MESSAGE)
     }
 }

--- a/crates/guardrails/src/guard_browser_device.rs
+++ b/crates/guardrails/src/guard_browser_device.rs
@@ -50,7 +50,7 @@ impl GuardBrowserDevice {
     /// The device handshake is once per *session*, independent of any repo, so
     /// the marker carries no repo scope. Delegates to the shared
     /// [`cadence_hooks_core::markers::session_marker`] primitive, which supplies
-    /// the session-id key (with the PPID→pid fallback) under the private 0700
+    /// the session-id key (with a per-process fallback) under the private 0700
     /// marker dir.
     fn marker_path(input: &HookInput) -> PathBuf {
         cadence_hooks_core::markers::session_marker(input, "browser-device", None)

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -19,8 +19,6 @@
 
 use crate::dismiss_main_branch_warn;
 use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -145,22 +143,13 @@ pub struct WarnMainBranch;
 impl WarnMainBranch {
     /// Build the per-session marker path scoped to a specific repo root.
     ///
-    /// Hashes the repo root so two repos with the same name don't share
-    /// markers. The PPID component ties the marker to the Claude Code
-    /// session — hooks run as separate child processes so `process::id()`
-    /// would change every invocation.
-    fn marker_path(repo_root: &str) -> PathBuf {
-        let mut hasher = DefaultHasher::new();
-        repo_root.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        let ppid = std::env::var("PPID")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or_else(std::process::id);
-
-        cadence_hooks_core::paths::marker_temp_dir()
-            .join(format!(".claude-main-branch-warned-{hash:x}-{ppid}"))
+    /// Delegates to the shared [`cadence_hooks_core::markers::session_marker`]
+    /// primitive: keyed on the Claude Code session id (stable across a session's
+    /// many separate hook processes — the pre-CP0 `PPID`→pid scheme re-warned
+    /// every edit because `PPID` is never exported, #133) and the repo-root hash,
+    /// under the private 0700 marker dir.
+    fn marker_path(input: &HookInput, repo_root: &str) -> PathBuf {
+        cadence_hooks_core::markers::session_marker(input, "main-branch-warned", Some(repo_root))
     }
 }
 
@@ -208,15 +197,15 @@ impl Check for WarnMainBranch {
             _ => return CheckResult::allow(),
         };
 
-        let marker = Self::marker_path(&repo_root);
+        let marker = Self::marker_path(input, &repo_root);
         let already_warned = marker.exists();
-        let snoozed = dismiss_main_branch_warn::is_snoozed_now(Path::new(&repo_root));
+        let snoozed = dismiss_main_branch_warn::is_snoozed_now(input, Path::new(&repo_root));
         let allowed = is_main_allowed();
 
         let result = should_warn(&branch, already_warned, snoozed, allowed);
 
         if result.outcome == Outcome::Nudge {
-            let _ = std::fs::write(&marker, "");
+            let _ = cadence_hooks_core::markers::write_marker(&marker, "");
         }
 
         result
@@ -324,24 +313,6 @@ mod tests {
         );
     }
 
-    #[test]
-    fn marker_uses_ppid_not_pid() {
-        // Bug: code uses process::id() (current PID) but names var "ppid"
-        // Since hooks run as separate processes, each invocation gets a new PID,
-        // so the marker file from a previous invocation is never found.
-        // The intent was to use the PARENT PID (Claude Code process) for session scoping.
-        let ppid_env = std::env::var("PPID")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok());
-        let current_pid = std::process::id();
-        if let Some(ppid) = ppid_env {
-            assert_ne!(
-                current_pid, ppid,
-                "PID should differ from PPID — marker_path() should use PPID for session scoping"
-            );
-        }
-    }
-
     // --- Regression: nested-repo branch resolution (issue #26) ---
     // When CWD is an outer repo and the edited file is in a nested inner repo,
     // branch resolution must follow the file path, not CWD. Using `git -C
@@ -416,22 +387,40 @@ mod tests {
         assert_eq!(git_dir_for_input(&input), PathBuf::from("."));
     }
 
+    fn input_with_session(sid: &str) -> HookInput {
+        HookInput {
+            session_id: Some(sid.into()),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn marker_path_differs_per_repo() {
         // Two different repo roots should produce distinct marker paths
         // so a snooze in one repo doesn't suppress warnings in another.
-        let a = WarnMainBranch::marker_path("/tmp/repo-a");
-        let b = WarnMainBranch::marker_path("/tmp/repo-b");
+        let input = input_with_session("sid");
+        let a = WarnMainBranch::marker_path(&input, "/tmp/repo-a");
+        let b = WarnMainBranch::marker_path(&input, "/tmp/repo-b");
         assert_ne!(a, b, "marker path must include a repo-specific hash");
     }
 
     #[test]
     fn marker_path_stable_for_same_repo() {
-        // Same repo root, called twice in the same process, should produce
-        // the same marker path so suppression works.
-        let a = WarnMainBranch::marker_path("/tmp/repo");
-        let b = WarnMainBranch::marker_path("/tmp/repo");
+        // Same repo root and session, called twice, should produce the same
+        // marker path so suppression works.
+        let input = input_with_session("sid");
+        let a = WarnMainBranch::marker_path(&input, "/tmp/repo");
+        let b = WarnMainBranch::marker_path(&input, "/tmp/repo");
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn marker_path_differs_per_session() {
+        // The #133 fix: the marker is keyed on the session id, so two sessions
+        // in the same repo each get their own once-per-session nudge.
+        let a = WarnMainBranch::marker_path(&input_with_session("sid-a"), "/tmp/repo");
+        let b = WarnMainBranch::marker_path(&input_with_session("sid-b"), "/tmp/repo");
+        assert_ne!(a, b, "marker must be session-scoped");
     }
 
     #[test]

--- a/crates/guardrails/src/warn_subagent_worktree.rs
+++ b/crates/guardrails/src/warn_subagent_worktree.rs
@@ -24,8 +24,6 @@
 
 use cadence_hooks_core::shell::git_command;
 use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
-use std::collections::hash_map::DefaultHasher;
-use std::hash::{Hash, Hasher};
 use std::path::{Path, PathBuf};
 
 /// Returns true if `repo_root` is a **primary checkout** — its `.git` is a
@@ -107,23 +105,16 @@ pub struct WarnSubagentWorktree;
 impl WarnSubagentWorktree {
     /// Build the per-session marker path scoped to a specific repo root.
     ///
-    /// Hashes the repo root so two repos with the same name don't share markers.
-    /// The PPID component ties the marker to the Claude Code session — hooks run
-    /// as separate child processes, so `process::id()` changes every invocation;
-    /// the parent PID (Claude Code) is stable across a session. Mirrors
-    /// `warn_main_branch::marker_path`.
-    fn marker_path(repo_root: &str) -> PathBuf {
-        let mut hasher = DefaultHasher::new();
-        repo_root.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        let ppid = std::env::var("PPID")
-            .ok()
-            .and_then(|s| s.parse::<u32>().ok())
-            .unwrap_or_else(std::process::id);
-
-        cadence_hooks_core::paths::marker_temp_dir()
-            .join(format!(".claude-subagent-worktree-warned-{hash:x}-{ppid}"))
+    /// Delegates to the shared [`cadence_hooks_core::markers::session_marker`]
+    /// primitive — keyed on the session id and repo-root hash under the private
+    /// 0700 marker dir. Migrated off the pre-CP0 `PPID`→pid scheme with the rest
+    /// of the marker family (#147); mirrors `warn_main_branch::marker_path`.
+    fn marker_path(input: &HookInput, repo_root: &str) -> PathBuf {
+        cadence_hooks_core::markers::session_marker(
+            input,
+            "subagent-worktree-warned",
+            Some(repo_root),
+        )
     }
 }
 
@@ -155,7 +146,7 @@ impl Check for WarnSubagentWorktree {
             .unwrap_or(false);
         let isolation_worktree = input.isolation() == Some("worktree");
 
-        let marker = Self::marker_path(&repo_root);
+        let marker = Self::marker_path(input, &repo_root);
         let already_warned = marker.exists();
         let allowed = is_subagent_from_main_allowed();
 
@@ -168,7 +159,7 @@ impl Check for WarnSubagentWorktree {
         );
 
         if result.outcome == Outcome::Nudge {
-            let _ = std::fs::write(&marker, "");
+            let _ = cadence_hooks_core::markers::write_marker(&marker, "");
         }
 
         result
@@ -331,25 +322,43 @@ mod tests {
 
     // --- marker path ---
 
+    fn input_with_session(sid: &str) -> HookInput {
+        HookInput {
+            session_id: Some(sid.into()),
+            ..Default::default()
+        }
+    }
+
     #[test]
     fn marker_path_differs_per_repo() {
-        let a = WarnSubagentWorktree::marker_path("/tmp/repo-a");
-        let b = WarnSubagentWorktree::marker_path("/tmp/repo-b");
+        let input = input_with_session("sid");
+        let a = WarnSubagentWorktree::marker_path(&input, "/tmp/repo-a");
+        let b = WarnSubagentWorktree::marker_path(&input, "/tmp/repo-b");
         assert_ne!(a, b, "marker path must include a repo-specific hash");
     }
 
     #[test]
     fn marker_path_stable_for_same_repo() {
-        let a = WarnSubagentWorktree::marker_path("/tmp/repo");
-        let b = WarnSubagentWorktree::marker_path("/tmp/repo");
+        let input = input_with_session("sid");
+        let a = WarnSubagentWorktree::marker_path(&input, "/tmp/repo");
+        let b = WarnSubagentWorktree::marker_path(&input, "/tmp/repo");
         assert_eq!(a, b);
+    }
+
+    #[test]
+    fn marker_path_differs_per_session() {
+        // Session-scoped like the rest of the family (#147): two sessions in the
+        // same repo each get their own once-per-session nudge.
+        let a = WarnSubagentWorktree::marker_path(&input_with_session("sid-a"), "/tmp/repo");
+        let b = WarnSubagentWorktree::marker_path(&input_with_session("sid-b"), "/tmp/repo");
+        assert_ne!(a, b, "marker must be session-scoped");
     }
 
     #[test]
     fn marker_path_is_distinct_from_main_branch_marker() {
         // The two once-per-session guards must not collide on a marker name, or
         // one warning would suppress the other.
-        let m = WarnSubagentWorktree::marker_path("/tmp/repo");
+        let m = WarnSubagentWorktree::marker_path(&input_with_session("sid"), "/tmp/repo");
         assert!(
             m.to_string_lossy().contains("subagent-worktree-warned"),
             "marker name must be guard-specific: {}",

--- a/crates/session/src/registry.rs
+++ b/crates/session/src/registry.rs
@@ -333,26 +333,53 @@ pub fn sweep_stale(dir: &Path, stale_secs: u64, own_session_id: &str) {
 /// inside a linked worktree still writes the exclude to the primary `.git` (#130,
 /// previously an early-return no-op that left worktree registries noisy). One
 /// write covers all checkouts and is idempotent with the dedupe below.
+///
+/// **Symlink safety.** The resolved common dir's contents are attacker-influenced:
+/// a crafted `.git` *file* can redirect resolution to any directory (bounded only
+/// by the resolver's HEAD-exists gate, which `exists()` satisfies *through*
+/// symlinks). Without care a planted `info/exclude` symlink would make us append
+/// the exclusion line to a victim-writable file. Two layers defend the write:
+/// (1) a pre-check refuses when `info` or `info/exclude` is a symlink (silent
+/// no-op, fail-open per ADR-0001 — a *nonexistent* exclude is the normal case and
+/// gets created); (2) the write goes through [`atomic_write`]'s O_EXCL-staged
+/// rename, so even a symlink re-planted at the leaf between check and write is
+/// replaced, never followed.
 pub fn ensure_git_excluded(repo_root: &Path) {
     const EXCLUDE_LINE: &str = ".claude/sessions/";
     let Some(common) = cadence_hooks_core::paths::resolve_git_common_dir(repo_root) else {
         return;
     };
-    let exclude_path = common.join("info").join("exclude");
+    let info_dir = common.join("info");
+    let exclude_path = info_dir.join("exclude");
+
+    // Refuse a symlinked info dir or exclude leaf — either would redirect the
+    // write to an attacker-chosen file. Fail open (no-op), never block.
+    if is_symlink(&info_dir) || is_symlink(&exclude_path) {
+        return;
+    }
+
     let existing = fs::read_to_string(&exclude_path).unwrap_or_default();
     if existing.lines().any(|l| l.trim() == EXCLUDE_LINE) {
         return;
     }
-    if let Some(parent) = exclude_path.parent() {
-        let _ = fs::create_dir_all(parent);
-    }
+    let _ = fs::create_dir_all(&info_dir);
     let mut updated = existing;
     if !updated.is_empty() && !updated.ends_with('\n') {
         updated.push('\n');
     }
     updated.push_str(EXCLUDE_LINE);
     updated.push('\n');
-    let _ = fs::write(&exclude_path, updated);
+    // O_EXCL-staged rename (never follows a symlink at the target), so a TOCTOU
+    // re-plant of the leaf between the check above and here can't be written
+    // through to a victim.
+    let _ = atomic_write(&exclude_path, updated.as_bytes());
+}
+
+/// True when `path` exists and is a symlink (`symlink_metadata` does not follow).
+fn is_symlink(path: &Path) -> bool {
+    fs::symlink_metadata(path)
+        .map(|m| m.file_type().is_symlink())
+        .unwrap_or(false)
 }
 
 #[cfg(test)]
@@ -838,6 +865,62 @@ mod tests {
         .unwrap();
         ensure_git_excluded(tmp.path());
         assert!(tmp.path().join(".git").is_file(), ".git file untouched");
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_git_excluded_refuses_symlinked_exclude() {
+        // A crafted checkout: a `.git` FILE redirects to an `evil` dir with a
+        // planted HEAD (passing the resolver's HEAD gate) and an `info/exclude`
+        // symlinked at a victim file. Following that symlink on write would append
+        // the exclusion line to the victim; ensure_git_excluded must refuse.
+        use std::os::unix::fs::symlink;
+        let tmp = TempDir::new().unwrap();
+        let victim = tmp.path().join("victim.txt");
+        fs::write(&victim, "victim-original\n").unwrap();
+
+        let evil = tmp.path().join("evil");
+        fs::create_dir_all(evil.join("info")).unwrap();
+        fs::write(evil.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        symlink(&victim, evil.join("info").join("exclude")).unwrap();
+
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join(".git"), format!("gitdir: {}\n", evil.display())).unwrap();
+
+        ensure_git_excluded(&repo);
+
+        assert_eq!(
+            fs::read_to_string(&victim).unwrap(),
+            "victim-original\n",
+            "a symlinked exclude must not be followed — victim untouched"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn ensure_git_excluded_refuses_symlinked_info_dir() {
+        // The dir-level variant: `info` itself is a symlink into a victim dir.
+        use std::os::unix::fs::symlink;
+        let tmp = TempDir::new().unwrap();
+        let victim_dir = tmp.path().join("victim_dir");
+        fs::create_dir_all(&victim_dir).unwrap();
+
+        let evil = tmp.path().join("evil");
+        fs::create_dir_all(&evil).unwrap();
+        fs::write(evil.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        symlink(&victim_dir, evil.join("info")).unwrap();
+
+        let repo = tmp.path().join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        fs::write(repo.join(".git"), format!("gitdir: {}\n", evil.display())).unwrap();
+
+        ensure_git_excluded(&repo);
+
+        assert!(
+            !victim_dir.join("exclude").exists(),
+            "a symlinked info dir must not be written through"
+        );
     }
 
     #[test]

--- a/crates/session/src/registry.rs
+++ b/crates/session/src/registry.rs
@@ -320,21 +320,25 @@ pub fn sweep_stale(dir: &Path, stale_secs: u64, own_session_id: &str) {
     }
 }
 
-/// Ensure `.claude/sessions/` is listed in the repo's `.git/info/exclude` so
-/// registry files never appear in `git status`.
+/// Ensure `.claude/sessions/` is listed in the repo's `info/exclude` so registry
+/// files never appear in `git status`.
 ///
-/// `.git/info/exclude` is per-checkout git plumbing — never committed, never
-/// shared — so this keeps the user's `.gitignore` untouched while preventing
-/// registry noise in every other guard that inspects untracked files.
+/// `info/exclude` is per-repo git plumbing — never committed, never shared — so
+/// this keeps the user's `.gitignore` untouched while preventing registry noise
+/// in every other guard that inspects untracked files.
+///
+/// The exclude lives in the git **common directory**, which is *shared* by the
+/// primary checkout and every linked worktree. Resolving it via
+/// [`cadence_hooks_core::paths::resolve_git_common_dir`] means a session running
+/// inside a linked worktree still writes the exclude to the primary `.git` (#130,
+/// previously an early-return no-op that left worktree registries noisy). One
+/// write covers all checkouts and is idempotent with the dedupe below.
 pub fn ensure_git_excluded(repo_root: &Path) {
     const EXCLUDE_LINE: &str = ".claude/sessions/";
-    let exclude_path = repo_root.join(".git").join("info").join("exclude");
-    // Only act inside a real checkout (a .git *directory* — skip worktrees and
-    // submodules whose .git is a file pointing elsewhere; their exclude file
-    // lives in the common dir and editing it is the user's call).
-    if !repo_root.join(".git").is_dir() {
+    let Some(common) = cadence_hooks_core::paths::resolve_git_common_dir(repo_root) else {
         return;
-    }
+    };
+    let exclude_path = common.join("info").join("exclude");
     let existing = fs::read_to_string(&exclude_path).unwrap_or_default();
     if existing.lines().any(|l| l.trim() == EXCLUDE_LINE) {
         return;
@@ -791,6 +795,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         fs::create_dir_all(root.join(".git/info")).unwrap();
+        fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
         ensure_git_excluded(root);
         ensure_git_excluded(root);
         let contents = fs::read_to_string(root.join(".git/info/exclude")).unwrap();
@@ -806,6 +811,7 @@ mod tests {
         let tmp = TempDir::new().unwrap();
         let root = tmp.path();
         fs::create_dir_all(root.join(".git/info")).unwrap();
+        fs::write(root.join(".git/HEAD"), "ref: refs/heads/main\n").unwrap();
         fs::write(root.join(".git/info/exclude"), "*.swp\n").unwrap();
         ensure_git_excluded(root);
         let contents = fs::read_to_string(root.join(".git/info/exclude")).unwrap();
@@ -821,8 +827,9 @@ mod tests {
     }
 
     #[test]
-    fn ensure_git_excluded_skips_worktree_git_file() {
-        // In a linked worktree, .git is a *file* pointing at the common dir.
+    fn ensure_git_excluded_noop_when_gitdir_unresolvable() {
+        // A linked worktree's .git file that points at a nonexistent gitdir
+        // (no HEAD reachable) must resolve to no common dir → no write, no panic.
         let tmp = TempDir::new().unwrap();
         fs::write(
             tmp.path().join(".git"),
@@ -831,6 +838,40 @@ mod tests {
         .unwrap();
         ensure_git_excluded(tmp.path());
         assert!(tmp.path().join(".git").is_file(), ".git file untouched");
+    }
+
+    #[test]
+    fn ensure_git_excluded_writes_common_dir_for_linked_worktree() {
+        // A linked worktree's exclude line must land in the PRIMARY checkout's
+        // shared .git/info/exclude (resolved via the worktree's commondir), so a
+        // session running inside the worktree still silences registry noise
+        // repo-wide (#130). Pure-fs fixture — no git spawn.
+        let tmp = TempDir::new().unwrap();
+        let primary_git = tmp.path().join("primary").join(".git");
+        fs::create_dir_all(primary_git.join("info")).unwrap();
+        fs::write(primary_git.join("HEAD"), "ref: refs/heads/main\n").unwrap();
+        let wt_admin = primary_git.join("worktrees").join("wt");
+        fs::create_dir_all(&wt_admin).unwrap();
+        // commondir is relative to the worktree admin dir: ../.. → primary/.git
+        fs::write(wt_admin.join("commondir"), "../..\n").unwrap();
+        fs::write(wt_admin.join("HEAD"), "ref: refs/heads/feat\n").unwrap();
+
+        let linked = tmp.path().join("linked");
+        fs::create_dir_all(&linked).unwrap();
+        fs::write(
+            linked.join(".git"),
+            format!("gitdir: {}\n", wt_admin.display()),
+        )
+        .unwrap();
+
+        ensure_git_excluded(&linked);
+
+        let exclude = fs::read_to_string(primary_git.join("info").join("exclude"))
+            .expect("exclude written under the primary common dir");
+        assert!(
+            exclude.lines().any(|l| l.trim() == ".claude/sessions/"),
+            "exclude line lands in the primary .git/info/exclude: {exclude}"
+        );
     }
 
     // --- env config ---

--- a/tests/session_markers.rs
+++ b/tests/session_markers.rs
@@ -54,14 +54,21 @@ fn init_main_repo() -> tempfile::TempDir {
 
 /// A payload unique per run so markers from prior test runs (which persist in
 /// the temp marker dir) never mask the assertion.
+///
+/// Built with a JSON serializer, NOT `format!`: on Windows the repo/file paths
+/// carry backslashes (`C:\Users\...`), and a raw `\U`/`\r` in a JSON string is an
+/// invalid escape — a hand-built payload fails `HookInput::from_stdin`, the hook
+/// fails open (exit 0, silent), and invocation 1 never nudges. Serializing
+/// escapes the backslashes so the payload parses on every platform.
 fn edit_payload(repo: &std::path::Path, session_id: &str) -> String {
     let file = repo.join("f.txt");
-    format!(
-        r#"{{"session_id":"{}","cwd":"{}","tool_name":"Edit","tool_input":{{"file_path":"{}"}}}}"#,
-        session_id,
-        repo.display(),
-        file.display()
-    )
+    serde_json::json!({
+        "session_id": session_id,
+        "cwd": repo.to_string_lossy(),
+        "tool_name": "Edit",
+        "tool_input": { "file_path": file.to_string_lossy() },
+    })
+    .to_string()
 }
 
 #[test]

--- a/tests/session_markers.rs
+++ b/tests/session_markers.rs
@@ -1,0 +1,102 @@
+//! Cross-process integration tests for the session-scoped marker family (CP0).
+//!
+//! The honest RED for session scoping must run the binary in **two separate
+//! processes**: an in-process double-invoke passes today because
+//! `process::id()` is stable within one test process. Two real invocations get
+//! two pids under the pre-CP0 code, so the pid-keyed marker never matches and
+//! the once-per-session nudge fires twice — exactly the bug CP0 closes (#133).
+
+use std::io::Write;
+use std::process::Command;
+
+fn cadence_hooks() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cadence-hooks"));
+    // Don't inherit enforcement toggles from the test runner's session.
+    cmd.env_remove("CADENCE_BYPASS");
+    cmd.env_remove("CADENCE_DISABLE");
+    cmd.env_remove("CLAUDECODE");
+    // PPID is the pre-CP0 session key; remove it so the fallback path is
+    // exercised deterministically. CADENCE_ALLOW_MAIN would silence the nudge.
+    cmd.env_remove("PPID");
+    cmd.env_remove("CADENCE_ALLOW_MAIN");
+    cmd
+}
+
+/// Spawn the binary with JSON on stdin and return the completed output. A
+/// BrokenPipe on write is expected when the child exits before draining stdin.
+fn run_with_stdin(mut cmd: Command, input: &str) -> std::process::Output {
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to execute binary");
+    if let Some(ref mut stdin) = child.stdin {
+        match stdin.write_all(input.as_bytes()) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(e) => panic!("failed to write to child stdin: {e}"),
+        }
+    }
+    child.wait_with_output().expect("failed to wait on binary")
+}
+
+/// Build a throwaway git repo on `main` (unborn branch — no commit needed).
+fn init_main_repo() -> tempfile::TempDir {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let ok = Command::new("git")
+        .args(["init", "-q", "-b", "main"])
+        .current_dir(dir.path())
+        .status()
+        .expect("git init");
+    assert!(ok.success(), "git init failed");
+    dir
+}
+
+/// A payload unique per run so markers from prior test runs (which persist in
+/// the temp marker dir) never mask the assertion.
+fn edit_payload(repo: &std::path::Path, session_id: &str) -> String {
+    let file = repo.join("f.txt");
+    format!(
+        r#"{{"session_id":"{}","cwd":"{}","tool_name":"Edit","tool_input":{{"file_path":"{}"}}}}"#,
+        session_id,
+        repo.display(),
+        file.display()
+    )
+}
+
+#[test]
+fn warn_main_branch_nudges_once_per_session() {
+    let repo = init_main_repo();
+    let session_id = format!(
+        "cp0-red-{}-{}",
+        std::process::id(),
+        std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let payload = edit_payload(repo.path(), &session_id);
+
+    // Invocation 1: same session, first edit on main → nudge.
+    let mut cmd1 = cadence_hooks();
+    cmd1.args(["guardrails", "warn-main-branch"]);
+    let out1 = run_with_stdin(cmd1, &payload);
+    let stdout1 = String::from_utf8_lossy(&out1.stdout);
+    assert_eq!(out1.status.code(), Some(0), "invocation 1 exits 0");
+    assert!(
+        stdout1.contains("feature branch"),
+        "invocation 1 must nudge (a separate process): {stdout1}"
+    );
+
+    // Invocation 2: same session id, distinct process (distinct pid) → the
+    // marker written by invocation 1 must suppress this one.
+    let mut cmd2 = cadence_hooks();
+    cmd2.args(["guardrails", "warn-main-branch"]);
+    let out2 = run_with_stdin(cmd2, &payload);
+    let stdout2 = String::from_utf8_lossy(&out2.stdout);
+    assert_eq!(out2.status.code(), Some(0), "invocation 2 exits 0");
+    assert!(
+        stdout2.trim().is_empty(),
+        "invocation 2 must be silent — the session already nudged: {stdout2}"
+    );
+}


### PR DESCRIPTION
CP0 of the engine-cohesion critical path: the session-marker family gets a shared, hardened, session-scoped primitive, and worktree state resolution learns to follow `.git`-file indirection. This is the foundation the CP2 transition guards build on.

## What

**New `core::markers` module** — the one hardening surface for the whole marker family:
- `marker_dir()` — private per-user 0700 directory (fails open to the plain temp dir if perms can't be guaranteed; markers are advisory)
- `session_marker(input, kind, repo_root: Option<&str>)` — session-scoped marker paths; session id and repo root are always hashed, never embedded as path components (a crafted `--session-id ../../x` is inert)
- `write_marker()` — symlink-safe `create_new` + rename (never a bare `fs::write` on a marker path)

**New `paths::resolve_git_common_dir()`** — pure-fs resolution of `.git`-file indirection (linked worktrees, submodules), validated against a real git dir (`HEAD` exists) before returning — the `.git` file is repo-controlled data and downstream writes into the result.

**Migrated consumers:**
- `warn-main-branch` — the PPID-keyed marker (PPID is a shell builtin, never exported → pid-per-invocation → re-warned on every edit) becomes session-scoped: one nudge per session, cross-process (closes #133)
- `check-idle-return` — marker now keyed per session, so a peer session's activity no longer masks this session's idle gap (closes #132)
- `warn-subagent-worktree` — same PPID bug, same migration (the #147 "whole marker family" scope)
- `guard-browser-device` — path alignment onto the shared primitive only; its block ordering is untouched and #134 stays deliberately open
- `dismiss-main-branch-warn` — snooze is now session-scoped (consent doesn't transfer to peers) with the 24h cap enforced on the read path via mtime clamp (closes #135). Bonus fix: the old `.git/cadence-hooks/` snooze location was unwritable from linked worktrees, so dismissal there was silently broken — the migration fixes it incidentally.

**`ensure_git_excluded`** now resolves the common dir, so `.claude/sessions/` exclusion works from linked worktrees — one write to the shared `info/exclude` covers every worktree (closes #130).

## Deviation from the reviewed plan (flagged, not silent)

The plan repurposed `dismiss_main_branch_warn::marker_path(repo_root)` to a session-keyed signature — but the frozen `dismiss_enforce_worktree` contract (v0.43.0) exercises that exact signature in its distinctness test. Resolution: the legacy function is retained as the distinctness reference; session scoping lands via a new primitive-backed helper. Intent preserved, frozen contract untouched.

## Verification

- TDD RED-first: the cross-process double-invoke test re-nudged before the fix; the linked-worktree exclude fixture panicked NotFound; all now green. 16 new primitive tests (markers hardening: pre-planted-symlink no-clobber, 0700 dir, no-raw-session-id; common-dir resolution incl. garbage `.git` file → None).
- fmt, clippy `-D warnings`, full workspace tests: clean (653 guardrails / 731 core / 344 session / integration).
- Frozen contracts: `enforce_worktree` suite passes unmodified (two pre-existing env-sensitive tests fail identically on unmodified `main` in the same sandbox — proven via stash); `registry_matches_clap_dispatch` untouched and passing; no CLI surface change.

## Behavior deltas

- `warn-main-branch` warns once per session (previously every edit)
- idle-return and snooze become per-session
- `dismiss-main-branch-warn` now requires a session id at write time (`CLAUDE_CODE_SESSION_ID`, exported in hook/tool environments; clear guidance on exit 1)
- stale legacy markers are orphaned harmlessly

Closes #133. Closes #132. Closes #130. Closes #135. Closes #147.
Refs #164 (this common-dir resolver is the classifier's future primitive). Refs #134 (deliberately open — guard-browser-device was migrated path-only; reversing its write-before-block ordering is a behavior change out of CP0's scope).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
