### PR TITLE
feat(metrics): warn-stale — telemetry staleness alarm at SessionStart + doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,24 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [0.43.0] - 2026-07-02
+## [Unreleased]
+
+### Added
+
+- **`metrics warn-stale` — telemetry staleness alarm at SessionStart + a
+  `doctor` surface (#161).** Warns once per day when the newest cadence-metrics
+  JSONL write is older than a threshold (`CADENCE_METRICS_STALE_DAYS`, default
+  4 days) — the signal the "second death" incident lacked, where the metrics
+  dir went silently quiet while sessions kept running (mis-wired hooks or a
+  disabled plugin). The pure `staleness()` core watches only top-level
+  `*.jsonl` mtimes (the `state/` marker dir never counts), and a dated
+  `state/stale_warn.date` marker throttles the nudge to once per calendar day.
+  `cadence-hooks doctor` reports the same staleness as a `Warning` (exit 1) in
+  its default scan — skipped under `--root` so a fixture run never reads the
+  dev machine's live telemetry. Fail-open everywhere (ADR-0001): a missing
+  dir, unreadable file, fresh install, bad env value, or marker IO error all
+  resolve to silence or a plain nudge — never a block. The SessionStart hook
+  wiring ships in the companion cadence-metrics plugin PR.
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,7 @@ dependencies = [
  "regex",
  "serde",
  "serde_json",
+ "tempfile",
 ]
 
 [[package]]

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -14,3 +14,4 @@ regex.workspace = true
 
 [dev-dependencies]
 cadence-hooks-core = { workspace = true, features = ["test-builders"] }
+tempfile = "3"

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -24,9 +24,12 @@ pub mod prices;
 pub mod scan_tokens;
 /// Snapshot HEAD before a `git commit`.
 pub mod snapshot;
+/// Warn at SessionStart when metrics telemetry has gone stale.
+pub mod warn_stale;
 
 pub use log_askuserquestion::LogAskUserQuestion;
 pub use log_commit::LogCommit;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_subagent::LogSubagent;
 pub use snapshot::Snapshot;
+pub use warn_stale::WarnStale;

--- a/crates/metrics/src/warn_stale.rs
+++ b/crates/metrics/src/warn_stale.rs
@@ -23,6 +23,12 @@ const DEFAULT_STALE_DAYS: u64 = 4;
 
 const SECS_PER_DAY: u64 = 86_400;
 
+/// Slack past `now` before a file's mtime is treated as future-dated and
+/// excluded from the newest-write selection. Absorbs benign clock skew (NTP
+/// jitter, mtime-vs-`now` rounding) while still discarding a wildly
+/// future-stamped file that would otherwise mask a genuinely stale dir.
+const FUTURE_SLACK: Duration = Duration::from_secs(300);
+
 /// A staleness verdict: the dir's newest JSONL write is older than the
 /// threshold. Names the newest file so the message points at real telemetry.
 #[derive(Debug, PartialEq, Eq)]
@@ -68,12 +74,21 @@ pub fn metrics_dir() -> PathBuf {
 ///   `state/` subdir (markers) is never seen; the extension filter drops any
 ///   other file. The once-per-day marker therefore can never freshen the
 ///   signal it gates.
-/// - A file whose mtime is in the future (clock skew) is treated as fresh.
+/// - Files stamped more than [`FUTURE_SLACK`] into the future are **excluded**
+///   from the newest-write selection. A single clock-skewed or hostile
+///   future-dated file must not become a perpetual "newest" whose age underflows
+///   and silently reports the whole dir fresh — the exact blind spot the alarm
+///   exists to avoid. Staleness is computed from the newest *non-future* file.
+/// - Residual case: when *every* `*.jsonl` is future-dated (all excluded), there
+///   is no non-future write to judge, so the result is `None` (fail-open). A
+///   wholly future-stamped dir is a broken clock, not evidence of staleness, and
+///   silence is the safe direction.
 /// - Missing dir, unreadable dir, or no `*.jsonl` → `None` (fail-open: a fresh
 ///   install is indistinguishable from a healthy one, so it stays silent).
 pub fn staleness(dir: &Path, threshold: Duration, now: SystemTime) -> Option<StaleReport> {
     let entries = std::fs::read_dir(dir).ok()?;
 
+    let future_cutoff = now + FUTURE_SLACK;
     let mut newest: Option<(SystemTime, String)> = None;
     for entry in entries.flatten() {
         let path = entry.path();
@@ -89,6 +104,11 @@ pub fn staleness(dir: &Path, threshold: Duration, now: SystemTime) -> Option<Sta
         let Ok(mtime) = meta.modified() else {
             continue;
         };
+        // Skip a far-future file so it can never mask a stale dir by winning the
+        // newest-write race.
+        if mtime > future_cutoff {
+            continue;
+        }
         let is_newer = newest.as_ref().is_none_or(|(seen, _)| mtime > *seen);
         if is_newer {
             let name = path
@@ -100,8 +120,9 @@ pub fn staleness(dir: &Path, threshold: Duration, now: SystemTime) -> Option<Sta
     }
 
     let (mtime, name) = newest?;
-    // A future mtime (clock skew) makes `duration_since` err → treat as fresh.
-    let age = now.duration_since(mtime).ok()?;
+    // The newest file is within `FUTURE_SLACK` of now, so a within-slack skew
+    // makes `duration_since` err → clamp to zero (fresh), never underflow.
+    let age = now.duration_since(mtime).unwrap_or(Duration::ZERO);
     if age <= threshold {
         return None;
     }
@@ -317,6 +338,59 @@ mod tests {
             matches!(r.outcome, Outcome::Allow | Outcome::Nudge),
             "warn-stale must never block: {:?}",
             r.outcome
+        );
+    }
+
+    /// Stamp `name`'s mtime `secs` into the future — the clock-skew fixture.
+    fn write_future_jsonl(dir: &Path, name: &str, secs: u64) {
+        let path = dir.join(name);
+        fs::write(&path, "{}\n").unwrap();
+        fs::File::options()
+            .write(true)
+            .open(&path)
+            .unwrap()
+            .set_modified(SystemTime::now() + Duration::from_secs(secs))
+            .unwrap();
+    }
+
+    // 10. A future-dated file must not mask a genuinely stale dir: staleness is
+    //     computed from the newest NON-future file, so the alarm still fires and
+    //     names that file, not the future one.
+    #[test]
+    fn future_mtime_ignored_uses_non_future_file() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(tmp.path(), "subagents.jsonl"); // ~now → stale under ZERO
+        write_future_jsonl(tmp.path(), "commits.jsonl", 10 * SECS_PER_DAY);
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(
+            r.outcome,
+            Outcome::Nudge,
+            "future file must not mask staleness"
+        );
+        let msg = r.message.unwrap();
+        assert!(
+            msg.contains("subagents.jsonl"),
+            "reports the non-future file: {msg}"
+        );
+        assert!(
+            !msg.contains("commits.jsonl"),
+            "future file excluded: {msg}"
+        );
+    }
+
+    // 11. When EVERY .jsonl is future-dated, there is no non-future write to
+    //     judge → fail-open silent (a broken clock is not evidence of staleness).
+    #[test]
+    fn all_future_silent() {
+        let tmp = TempDir::new().unwrap();
+        write_future_jsonl(tmp.path(), "subagents.jsonl", 10 * SECS_PER_DAY);
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(
+            r.outcome,
+            Outcome::Allow,
+            "all-future dir is fail-open silent"
         );
     }
 }

--- a/crates/metrics/src/warn_stale.rs
+++ b/crates/metrics/src/warn_stale.rs
@@ -1,0 +1,322 @@
+//! `metrics warn-stale` — telemetry staleness alarm at SessionStart.
+//!
+//! Fires once per day when the newest cadence-metrics JSONL write is older than
+//! a threshold (default 4 days). A stale metrics dir means the plugin's
+//! PostToolUse/Stop loggers stopped firing — usually mis-wired hooks or a
+//! disabled plugin — so telemetry silently flatlines while sessions keep
+//! running. This is the alarm the "second death" incident (cadence#146) lacked:
+//! the dir went quiet and nothing surfaced it.
+//!
+//! Fail-open everywhere (ADR-0001): a missing dir, an unreadable file, a fresh
+//! install with no JSONL, a bad env value, a marker IO error — all resolve to
+//! silence or a plain nudge, never a block, never a panic. The result is only
+//! ever `Allow` or `Nudge`.
+
+use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
+
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+
+/// Default staleness threshold in days when `CADENCE_METRICS_STALE_DAYS` is
+/// unset, zero, or unparseable.
+const DEFAULT_STALE_DAYS: u64 = 4;
+
+const SECS_PER_DAY: u64 = 86_400;
+
+/// A staleness verdict: the dir's newest JSONL write is older than the
+/// threshold. Names the newest file so the message points at real telemetry.
+#[derive(Debug, PartialEq, Eq)]
+pub struct StaleReport {
+    /// Basename of the newest `*.jsonl` file — the one defining dir freshness.
+    pub newest_file: String,
+    /// Whole days since that newest write.
+    pub age_days: u64,
+}
+
+/// Staleness threshold from `CADENCE_METRICS_STALE_DAYS`, default 4 days.
+///
+/// Mirrors `registry::stale_minutes`: trims, parses `u64`, rejects zero and
+/// junk. A pure resolver ([`stale_days_from`]) does the work so the fallbacks
+/// are unit-testable without process-global env.
+pub fn stale_days() -> u64 {
+    stale_days_from(std::env::var("CADENCE_METRICS_STALE_DAYS").ok())
+}
+
+/// Pure resolver behind [`stale_days`]. `None`, zero, or an unparseable value
+/// all fall back to [`DEFAULT_STALE_DAYS`].
+fn stale_days_from(raw: Option<String>) -> u64 {
+    raw.and_then(|v| v.trim().parse::<u64>().ok())
+        .filter(|&d| d > 0)
+        .unwrap_or(DEFAULT_STALE_DAYS)
+}
+
+/// The configured staleness threshold as a [`Duration`].
+pub fn stale_threshold() -> Duration {
+    Duration::from_secs(stale_days() * SECS_PER_DAY)
+}
+
+/// The metrics root directory. Re-exported from `common` so callers outside the
+/// crate — the `doctor` surface — can resolve it without reaching a private mod.
+pub fn metrics_dir() -> PathBuf {
+    crate::common::metrics_dir()
+}
+
+/// Pure staleness core: is `dir`'s newest top-level `*.jsonl` write older than
+/// `threshold` as of `now`?
+///
+/// - Only top-level `*.jsonl` files count. `read_dir` does not recurse, so the
+///   `state/` subdir (markers) is never seen; the extension filter drops any
+///   other file. The once-per-day marker therefore can never freshen the
+///   signal it gates.
+/// - A file whose mtime is in the future (clock skew) is treated as fresh.
+/// - Missing dir, unreadable dir, or no `*.jsonl` → `None` (fail-open: a fresh
+///   install is indistinguishable from a healthy one, so it stays silent).
+pub fn staleness(dir: &Path, threshold: Duration, now: SystemTime) -> Option<StaleReport> {
+    let entries = std::fs::read_dir(dir).ok()?;
+
+    let mut newest: Option<(SystemTime, String)> = None;
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
+            continue;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(mtime) = meta.modified() else {
+            continue;
+        };
+        let is_newer = newest.as_ref().is_none_or(|(seen, _)| mtime > *seen);
+        if is_newer {
+            let name = path
+                .file_name()
+                .map(|n| n.to_string_lossy().into_owned())
+                .unwrap_or_default();
+            newest = Some((mtime, name));
+        }
+    }
+
+    let (mtime, name) = newest?;
+    // A future mtime (clock skew) makes `duration_since` err → treat as fresh.
+    let age = now.duration_since(mtime).ok()?;
+    if age <= threshold {
+        return None;
+    }
+    Some(StaleReport {
+        newest_file: name,
+        age_days: age.as_secs() / SECS_PER_DAY,
+    })
+}
+
+/// One-line staleness summary shared by the SessionStart nudge and the `doctor`
+/// finding: names the newest file and its age. Says nothing about *how* to fix
+/// it — the caller appends its own remediation framing.
+pub fn staleness_summary(report: &StaleReport) -> String {
+    format!(
+        "cadence-metrics telemetry is stale: newest metrics `*.jsonl` write is {}d old ({}).",
+        report.age_days, report.newest_file
+    )
+}
+
+/// The SessionStart nudge: the staleness summary plus the cross-machine
+/// compare-wiring remediation. Never says "reinstall" — the likely cause is a
+/// mis-wired hook or a disabled plugin, diagnosable by comparing against a
+/// healthy machine.
+fn nudge_message(report: &StaleReport) -> String {
+    format!(
+        "{} Hooks may be mis-wired or the metrics plugin disabled — run \
+         `cadence-hooks doctor` and compare wiring against a healthy machine.",
+        staleness_summary(report)
+    )
+}
+
+/// The once-per-day marker file: `<dir>/state/stale_warn.date`, holding a UTC
+/// `YYYY-MM-DD`. When today's date already sits there, the check stays silent so
+/// the alarm fires at most once per calendar day. Not a `*.jsonl`, and inside
+/// `state/`, so it can never freshen the staleness signal it gates.
+fn marker_path(dir: &Path) -> PathBuf {
+    dir.join("state").join("stale_warn.date")
+}
+
+/// Today's UTC date, `YYYY-MM-DD` — the marker's freshness token. Sliced from
+/// the canonical jiff-backed timestamp so it shares the ledger's clock.
+fn today_utc() -> String {
+    crate::common::utc_timestamp()[..10].to_string()
+}
+
+/// Register-time alarm: warn once per day when metrics telemetry has gone stale.
+pub struct WarnStale;
+
+impl Check for WarnStale {
+    fn name(&self) -> &str {
+        "warn-stale"
+    }
+
+    fn run(&self, _input: &HookInput) -> CheckResult {
+        run_warn_stale(&metrics_dir(), stale_threshold(), SystemTime::now())
+    }
+}
+
+/// Testable core: dir, threshold, and clock injected. Reads the staleness
+/// verdict, consults the once-per-day marker, and returns `Nudge` (first stale
+/// sighting today) or `Allow` (fresh, already warned today, or any fail-open
+/// path). Never blocks — the ADR-0001 lock.
+pub fn run_warn_stale(dir: &Path, threshold: Duration, now: SystemTime) -> CheckResult {
+    let Some(report) = staleness(dir, threshold, now) else {
+        return CheckResult::allow();
+    };
+
+    let marker = marker_path(dir);
+    let today = today_utc();
+    if let Ok(existing) = std::fs::read_to_string(&marker)
+        && existing.trim() == today
+    {
+        // Already warned today — stay silent until tomorrow.
+        return CheckResult::allow();
+    }
+
+    // Record today's warning. Fail-open: a marker write error must not suppress
+    // the nudge (a repeat warning beats a missed one) and must never crash.
+    if let Some(parent) = marker.parent() {
+        let _ = std::fs::create_dir_all(parent);
+    }
+    let _ = std::fs::write(&marker, &today);
+
+    CheckResult::nudge(nudge_message(&report))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use std::fs;
+    use tempfile::TempDir;
+
+    /// A threshold far larger than any test file's age — nothing is ever stale.
+    const HUGE: Duration = Duration::from_secs(3650 * SECS_PER_DAY);
+
+    fn write_jsonl(dir: &Path, name: &str) {
+        fs::write(dir.join(name), "{}\n").unwrap();
+    }
+
+    // 1. A dir whose newest .jsonl is older than the threshold warns, names the
+    //    file, and points at the doctor.
+    #[test]
+    fn stale_dir_warns() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(tmp.path(), "subagents.jsonl");
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let msg = r.message.unwrap();
+        assert!(msg.contains("subagents.jsonl"), "names the file: {msg}");
+        assert!(msg.contains("stale"), "says stale: {msg}");
+        assert!(
+            msg.contains("cadence-hooks doctor"),
+            "doctor pointer: {msg}"
+        );
+    }
+
+    // 2. A huge threshold makes a fresh file non-stale → silent.
+    #[test]
+    fn fresh_dir_silent() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(tmp.path(), "subagents.jsonl");
+
+        let r = run_warn_stale(tmp.path(), HUGE, SystemTime::now());
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    // 3. A missing dir is fail-open silent.
+    #[test]
+    fn missing_dir_silent() {
+        let tmp = TempDir::new().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+
+        let r = run_warn_stale(&missing, Duration::ZERO, SystemTime::now());
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    // 4. An existing dir with no .jsonl is silent (fresh install is
+    //    indistinguishable from healthy).
+    #[test]
+    fn empty_dir_silent() {
+        let tmp = TempDir::new().unwrap();
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    // 5. A fresh non-.jsonl file and a stale .jsonl still warns, naming the
+    //    .jsonl; state/ contents never count toward freshness.
+    #[test]
+    fn non_jsonl_ignored() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(tmp.path(), "subagents.jsonl");
+        fs::write(tmp.path().join("notes.txt"), "fresh\n").unwrap();
+        // A .jsonl buried in state/ must not be picked up (non-recursion).
+        fs::create_dir_all(tmp.path().join("state")).unwrap();
+        write_jsonl(&tmp.path().join("state"), "buried.jsonl");
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let msg = r.message.unwrap();
+        assert!(msg.contains("subagents.jsonl"), "names the jsonl: {msg}");
+        assert!(!msg.contains("notes.txt"), "ignores non-jsonl: {msg}");
+        assert!(!msg.contains("buried.jsonl"), "ignores state/ jsonl: {msg}");
+    }
+
+    // 6. A marker already stamped with today's date suppresses the warning.
+    #[test]
+    fn marker_today_suppresses() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(tmp.path(), "subagents.jsonl");
+        fs::create_dir_all(tmp.path().join("state")).unwrap();
+        fs::write(marker_path(tmp.path()), today_utc()).unwrap();
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(r.outcome, Outcome::Allow, "today's marker suppresses");
+    }
+
+    // 7. A marker stamped with an old date warns and is rewritten to today.
+    #[test]
+    fn marker_stale_warns_and_updates() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(tmp.path(), "subagents.jsonl");
+        fs::create_dir_all(tmp.path().join("state")).unwrap();
+        fs::write(marker_path(tmp.path()), "2000-01-01").unwrap();
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert_eq!(r.outcome, Outcome::Nudge, "yesterday's marker still warns");
+        let stamped = fs::read_to_string(marker_path(tmp.path())).unwrap();
+        assert_eq!(stamped.trim(), today_utc(), "marker rewritten to today");
+    }
+
+    // 8. The pure env resolver: None/zero/junk → 4; a valid value passes through
+    //    (with trimming).
+    #[test]
+    fn stale_days_env_resolution() {
+        assert_eq!(stale_days_from(None), 4);
+        assert_eq!(stale_days_from(Some("7".into())), 7);
+        assert_eq!(stale_days_from(Some("0".into())), 4);
+        assert_eq!(stale_days_from(Some("junk".into())), 4);
+        assert_eq!(stale_days_from(Some("  5  ".into())), 5);
+    }
+
+    // 9. ADR-0001 lock: the result is only ever Nudge or Allow, never a block.
+    #[test]
+    fn never_blocks() {
+        let tmp = TempDir::new().unwrap();
+        write_jsonl(tmp.path(), "subagents.jsonl");
+
+        let r = run_warn_stale(tmp.path(), Duration::ZERO, SystemTime::now());
+        assert!(
+            matches!(r.outcome, Outcome::Allow | Outcome::Nudge),
+            "warn-stale must never block: {:?}",
+            r.outcome
+        );
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -89,6 +89,7 @@ kept unprefixed because it's a cross-tool convention.
 | `CADENCE_METRICS_PRICES` | `log-commit` | Path to a model price-table JSON; takes precedence over the `--prices` flag and the embedded default |
 | `CADENCE_METRICS_DIR` | metrics loggers | When set non-empty, the metrics root (JSONL files and the `state/` subdir live directly inside it); otherwise `<config_dir>/metrics` (honoring `CLAUDE_CONFIG_DIR`) |
 | `CADENCE_METRICS_DEBUG` | `log-subagent` | Set to `1` to append a `_keys` array of the raw payload's top-level keys to subagent records — surfaces schema additions across Claude Code releases |
+| `CADENCE_METRICS_STALE_DAYS` | `warn-stale` | Days of metrics-write silence before the SessionStart alarm fires and `doctor` reports staleness (default 4); zero or unparseable falls back to the default |
 | `CADENCE_SESSION_STALE_MINUTES` | `session` hooks | Minutes of heartbeat silence before a session is presumed dead (default 10) |
 | `GH_AUTOCLOSE_WAIT_SECONDS` | `verify-pr-autoclose` | Seconds to wait after `gh pr merge` before checking for straggler issues (default 10) |
 | `OBSIDIAN_VAULT` | `trash-guard`, `warn-overshare` | Absolute path to Obsidian vault — the trash guard scopes `rm` blocking to it, and the overshare audit treats it as the safe destination for personal context |

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -14,6 +14,7 @@
 //! one-shot diagnostic.
 
 use std::path::{Path, PathBuf};
+use std::time::{Duration, SystemTime};
 
 use crate::registry;
 
@@ -433,6 +434,30 @@ fn scan_root(root: &Path, channel: InstallChannel) -> Vec<Finding> {
     findings
 }
 
+/// Telemetry staleness as a doctor [`Finding`], or `None` when the metrics dir
+/// is fresh, missing, or empty (fail-open — a fresh install stays silent).
+///
+/// This is the diagnostic twin of the `metrics warn-stale` SessionStart check:
+/// same `staleness` core, but doctor consults no once-per-day marker — a
+/// diagnostic always reports the current state. A stale dir is a `Warning`
+/// (exit 1), never an `Error` — telemetry going quiet is advisory, not a
+/// shell bug.
+fn staleness_finding(dir: &Path, threshold: Duration, now: SystemTime) -> Option<Finding> {
+    let report = cadence_hooks_metrics::warn_stale::staleness(dir, threshold, now)?;
+    Some(Finding {
+        severity: Severity::Warning,
+        plugin: "cadence-metrics".to_string(),
+        file: dir.to_path_buf(),
+        line: None,
+        snippet: report.newest_file.clone(),
+        diagnosis: cadence_hooks_metrics::warn_stale::staleness_summary(&report),
+        remediation: "compare wiring against a healthy machine — the metrics \
+                      plugin may be disabled or its hooks mis-wired \
+                      (`cadence-hooks list` shows what should be firing)"
+            .to_string(),
+    })
+}
+
 /// Entry point for the `doctor` subcommand. Returns the process exit code.
 ///
 /// Exit codes:
@@ -459,7 +484,7 @@ pub fn run(root_override: Option<&Path>, quiet: bool) -> u8 {
     // Resolve the install channel once — it's process-invariant, so the scan
     // below shouldn't re-probe current_exe() per hook entry.
     let channel = install_channel();
-    let (findings, scanned) = match root_override {
+    let (mut findings, scanned) = match root_override {
         Some(root) => {
             if !root.exists() {
                 // Configuration error, not "clean" — exit 2 so a misconfigured
@@ -505,6 +530,19 @@ pub fn run(root_override: Option<&Path>, quiet: bool) -> u8 {
         }
     };
 
+    // Telemetry staleness is a live-machine signal, not a hooks.json scan, so it
+    // belongs to default mode only. Under `--root` (the CI/fixture path) it would
+    // read *this* dev machine's real metrics dir and taint a fixture-scoped run.
+    if root_override.is_none()
+        && let Some(finding) = staleness_finding(
+            &cadence_hooks_metrics::warn_stale::metrics_dir(),
+            cadence_hooks_metrics::warn_stale::stale_threshold(),
+            SystemTime::now(),
+        )
+    {
+        findings.push(finding);
+    }
+
     let (errors, warnings): (Vec<&Finding>, Vec<&Finding>) =
         findings.iter().partition(|f| f.severity == Severity::Error);
 
@@ -520,9 +558,12 @@ pub fn run(root_override: Option<&Path>, quiet: bool) -> u8 {
             return 2;
         }
         // Warnings only in quiet mode: one summary line to stdout, exit 0.
+        // Warnings are now version skew (missing subcommands) and/or stale
+        // telemetry, so the summary stays generic and defers the specifics to a
+        // full `cadence-hooks doctor` run.
         let version = env!("CARGO_PKG_VERSION");
         println!(
-            "cadence-hooks {version} is missing {} subcommand(s) referenced by installed plugins — {}",
+            "cadence-hooks {version}: {} plugin warning(s) — run 'cadence-hooks doctor' for details ({})",
             warnings.len(),
             upgrade_hint_short(channel)
         );
@@ -557,6 +598,45 @@ pub fn run(root_override: Option<&Path>, quiet: bool) -> u8 {
 mod tests {
     use super::*;
     use std::fs;
+
+    // ── staleness_finding tests ─────────────────────────────────────────────
+
+    #[test]
+    fn staleness_finding_stale_dir_is_warning() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("subagents.jsonl"), "{}\n").unwrap();
+
+        let f = staleness_finding(tmp.path(), Duration::ZERO, SystemTime::now())
+            .expect("a stale dir must yield a finding");
+        assert_eq!(f.severity, Severity::Warning);
+        assert_eq!(f.plugin, "cadence-metrics");
+        assert_eq!(f.snippet, "subagents.jsonl");
+        assert!(
+            f.diagnosis.contains("stale"),
+            "diagnosis names staleness: {}",
+            f.diagnosis
+        );
+        assert!(
+            f.remediation.contains("healthy machine"),
+            "remediation frames the compare-wiring fix: {}",
+            f.remediation
+        );
+    }
+
+    #[test]
+    fn staleness_finding_fresh_dir_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        fs::write(tmp.path().join("subagents.jsonl"), "{}\n").unwrap();
+        let huge = Duration::from_secs(3650 * 86_400);
+        assert!(staleness_finding(tmp.path(), huge, SystemTime::now()).is_none());
+    }
+
+    #[test]
+    fn staleness_finding_missing_dir_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        let missing = tmp.path().join("does-not-exist");
+        assert!(staleness_finding(&missing, Duration::ZERO, SystemTime::now()).is_none());
+    }
 
     // ── extract_invocation table tests ──────────────────────────────────────
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -243,6 +243,8 @@ enum MetricsCommands {
     LogPolishNudge,
     /// Log AskUserQuestion stance + shape on every call (PreToolUse)
     LogAskUserQuestion,
+    /// Warn at SessionStart when metrics telemetry has gone stale (SessionStart)
+    WarnStale,
 }
 
 #[derive(Subcommand)]
@@ -350,6 +352,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::LogSubagent => "log-subagent",
             MetricsCommands::LogPolishNudge => "log-polish-nudge",
             MetricsCommands::LogAskUserQuestion => "log-ask-user-question",
+            MetricsCommands::WarnStale => "warn-stale",
         }),
         Commands::Lab(l) => Some(match l {
             LabCommands::PersonaNudge => "persona-nudge",
@@ -798,6 +801,11 @@ fn main() {
                 &cadence_hooks_metrics::LogAskUserQuestion,
                 registry::sample_for("metrics", "log-ask-user-question"),
             ),
+            // warn-stale is a SessionStart *check*, not a logger — it reads the
+            // metrics dir's mtimes rather than reacting to a tool event.
+            MetricsCommands::WarnStale => {
+                run_check_from_stdin(&cadence_hooks_metrics::WarnStale, session)
+            }
         },
         Commands::Lab(cmd) => match cmd {
             LabCommands::PersonaNudge => {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -302,6 +302,12 @@ pub const HOOKS: &[HookEntry] = &[
         plugin: "metrics",
         event: None,
     },
+    HookEntry {
+        name: "warn-stale",
+        description: "Warn at SessionStart when metrics telemetry has gone stale",
+        plugin: "metrics",
+        event: Some(HookEvent::SessionStart),
+    },
     // lab
     HookEntry {
         name: "persona-nudge",

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -495,6 +495,46 @@ fn doctor_default_scan_clean_on_fresh_metrics() {
 }
 
 #[test]
+fn doctor_root_scan_ignores_stale_metrics_env() {
+    // --root is the fixture/CI path: it must NEVER read live telemetry, even when
+    // CADENCE_METRICS_DIR points at a genuinely stale dir. Pins the
+    // "fixture scans never read live telemetry" guard (staleness skipped under
+    // --root) — the counterpart to the default-scan warning above.
+    let root = tempfile::tempdir().unwrap(); // empty scan root → clean
+    let metrics = tempfile::tempdir().unwrap();
+    let jsonl = metrics.path().join("subagents.jsonl");
+    std::fs::write(&jsonl, "{}\n").unwrap();
+    let old = SystemTime::now() - Duration::from_secs(10 * 86_400);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&jsonl)
+        .unwrap()
+        .set_modified(old)
+        .unwrap();
+
+    let output = cadence_hooks()
+        .args(["doctor", "--root"])
+        .arg(root.path())
+        .env("CADENCE_METRICS_DIR", metrics.path())
+        .env_remove("CADENCE_METRICS_STALE_DAYS")
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "--root scan must ignore live telemetry staleness → exit 0.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("telemetry is stale"),
+        "no staleness finding under --root: {stdout}"
+    );
+}
+
+#[test]
 fn doctor_default_scan_falls_back_to_cache_walk_without_manifest() {
     // No installed_plugins.json — recursively walk the cache dir instead.
     let tmp = tempfile::tempdir().unwrap();

--- a/tests/doctor.rs
+++ b/tests/doctor.rs
@@ -4,9 +4,19 @@
 //! `--root`, and assert exit code + stderr/stdout content.
 
 use std::process::Command;
+use std::time::{Duration, SystemTime};
 
 fn cadence_hooks() -> Command {
     Command::new(env!("CARGO_BIN_EXE_cadence-hooks"))
+}
+
+/// A HOME tempdir carrying an empty plugin cache, so the default (no-`--root`)
+/// doctor scan finds zero hooks.json findings and only the telemetry-staleness
+/// check can move the exit code.
+fn home_with_empty_cache() -> tempfile::TempDir {
+    let home = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(home.path().join(".claude/plugins/cache")).unwrap();
+    home
 }
 
 /// Create `<root>/<plugin>/hooks/hooks.json` with the given JSON body.
@@ -175,8 +185,8 @@ fn doctor_quiet_warnings_print_summary_to_stdout() {
         "quiet mode with warnings must print a one-line summary to stdout"
     );
     assert!(
-        stdout.contains("missing"),
-        "summary should describe the skew: {stdout}"
+        stdout.contains("warning"),
+        "summary should describe the plugin warning(s): {stdout}"
     );
 }
 
@@ -404,6 +414,83 @@ fn doctor_default_scan_reads_installed_plugins_manifest() {
     assert!(
         stdout.contains("buggy-plugin@workbench"),
         "finding must be labeled with the manifest key: {stdout}"
+    );
+}
+
+// ── Telemetry staleness surface (default scan only) ────────────────────────
+
+#[test]
+fn doctor_default_scan_warns_on_stale_metrics() {
+    // A metrics dir whose newest .jsonl is older than the 4-day default must
+    // surface as a Warning (exit 1) in the default scan, even with a clean
+    // plugin cache.
+    let home = home_with_empty_cache();
+    let metrics = tempfile::tempdir().unwrap();
+    let jsonl = metrics.path().join("subagents.jsonl");
+    std::fs::write(&jsonl, "{}\n").unwrap();
+    // Backdate the mtime well past the default threshold.
+    let old = SystemTime::now() - Duration::from_secs(10 * 86_400);
+    std::fs::OpenOptions::new()
+        .write(true)
+        .open(&jsonl)
+        .unwrap()
+        .set_modified(old)
+        .unwrap();
+
+    let output = cadence_hooks()
+        .arg("doctor")
+        .env("HOME", home.path())
+        .env("CADENCE_METRICS_DIR", metrics.path())
+        .env_remove("CADENCE_METRICS_STALE_DAYS")
+        .env_remove("CLAUDE_CONFIG_DIR")
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(
+        output.status.code(),
+        Some(1),
+        "stale telemetry is a warning → exit 1.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains("telemetry is stale"),
+        "diagnosis names staleness: {stdout}"
+    );
+    assert!(
+        stdout.contains("cadence-metrics"),
+        "finding is attributed to cadence-metrics: {stdout}"
+    );
+}
+
+#[test]
+fn doctor_default_scan_clean_on_fresh_metrics() {
+    // A fresh metrics write (mtime ~now) is well within the threshold → clean.
+    let home = home_with_empty_cache();
+    let metrics = tempfile::tempdir().unwrap();
+    std::fs::write(metrics.path().join("subagents.jsonl"), "{}\n").unwrap();
+
+    let output = cadence_hooks()
+        .arg("doctor")
+        .env("HOME", home.path())
+        .env("CADENCE_METRICS_DIR", metrics.path())
+        .env_remove("CADENCE_METRICS_STALE_DAYS")
+        .env_remove("CLAUDE_CONFIG_DIR")
+        .output()
+        .expect("failed to execute");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "fresh telemetry + clean cache → exit 0.\nstdout: {}\nstderr: {}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("clean"),
+        "clean run reports clean: {}",
+        String::from_utf8_lossy(&output.stdout)
     );
 }
 


### PR DESCRIPTION
Telemetry death is currently silent: when a metrics stream stops writing (hook mis-wiring, plugin disabled), nothing notices until an analysis session reads dead data weeks later — the commits.jsonl outage ran a month undetected (cameronsjo/cadence#146 is the incident record; this alarm is the detector that was missing, not the root-cause fix).

## What

New `metrics warn-stale` check — SessionStart, nudge-only, fail-open everywhere (ADR-0001):

- Watches the newest mtime across `<metrics_dir>/*.jsonl` (all four streams; `state/` excluded); warns when it exceeds the threshold — default **4 days**, `CADENCE_METRICS_STALE_DAYS` override (the issue said ~7; the later measurement-sequencing spec says 4 and wins — flagged deliberately)
- Once-per-day suppression via a dated marker in `state/` (not `.jsonl`, so the marker can never freshen the signal it guards)
- Message names the newest file + age and points at `cadence-hooks doctor` with compare-wiring framing (never "reinstall")
- Doctor surface: the same staleness check as a Warning finding in default-mode scans (skipped under `--root` so fixture/CI scans stay hermetic); the quiet-mode summary line generalized from its hardcoded "missing subcommand(s)" wording
- Fail-open enumerated: missing dir, unreadable dir/file, zero jsonl (fresh-install indistinguishable), future mtimes (clock skew), marker IO errors, unparsable env — every path degrades to allow/nudge, never block

## Verification

- TDD RED-first: 9 unit tests written against a stubbed resolver (warn-path tests observed failing), then 9/9 green; includes an ADR-0001 lock test asserting the result is only ever allow/nudge
- Doctor: 3 unit + 2 integration tests (stale fixture → warning + exit 1; fresh → clean exit 0)
- fmt / clippy `-D warnings` / workspace tests clean on the touch-set; the only failures are two pre-existing `enforce_worktree` env-sensitive tests, proven identical on pristine `main` in the same sandbox (temp-rooted clones hit the guard's scratch-repo exemption; they pass in real CI)
- Functional smoke: 10-day-stale dir → correct SessionStart nudge; same-day re-run silent; `list`/`--help` show the new check

## Sequencing

Companion wiring PR on the cadence monorepo adds the SessionStart hook block for `plugins/cadence-metrics`. This binary PR merges first — wired-but-missing binary support is a doctor warning for users; the reverse is inert.

Follow-up (deliberate): migrate the dated marker to the shared session-marker primitive once the marker-integrity PR (#170) merges.

Closes #161. Refs cameronsjo/cadence#146 (incident context — root cause is tracked separately; do not close).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
