### PR TITLE
feat(cadence): branch-scoped polish marker — record-polish CLI + marker-based PR gate

### DIFF
--- a/crates/cadence/src/lib.rs
+++ b/crates/cadence/src/lib.rs
@@ -15,10 +15,10 @@ pub mod memory_guard;
 pub mod nudge_polish_before_pr;
 /// Block reading secrets (.env, credentials, private keys) into context.
 pub mod prevent_secret_leaks;
-/// Record that `/polish` ran on this branch (writes a branch-scoped marker). CLI action.
-pub mod record_polish;
 /// Block writing or deleting secrets (.env, credentials, private keys).
 pub mod prevent_secret_writes;
+/// Record that `/polish` ran on this branch (writes a branch-scoped marker). CLI action.
+pub mod record_polish;
 /// Nudge before internal harness vocabulary leaks into an external post.
 pub mod redact_external_content;
 /// Shared secret file patterns for both secret guards.

--- a/crates/cadence/src/lib.rs
+++ b/crates/cadence/src/lib.rs
@@ -15,6 +15,8 @@ pub mod memory_guard;
 pub mod nudge_polish_before_pr;
 /// Block reading secrets (.env, credentials, private keys) into context.
 pub mod prevent_secret_leaks;
+/// Record that `/polish` ran on this branch (writes a branch-scoped marker). CLI action.
+pub mod record_polish;
 /// Block writing or deleting secrets (.env, credentials, private keys).
 pub mod prevent_secret_writes;
 /// Nudge before internal harness vocabulary leaks into an external post.

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -1,35 +1,38 @@
 //! Gate `/polish` before creating a pull request.
 //!
-//! Fires on `gh pr create`. Polish is mandatory before a PR, so this check is
-//! transcript-aware: it scans the session transcript for a real
-//! [cadence-forge:polish](https://github.com/cameronsjo/cadence-forge) Skill
-//! invocation and routes a 3-way, fail-open outcome:
+//! Fires on `gh pr create`. Polish is mandatory before a PR, so this check reads
+//! a **branch-scoped marker** the polish skill records when it completes
+//! (`cadence-hooks cadence record-polish`), keyed on `(repo_root, branch)`. It
+//! routes a 2-way, fail-open outcome:
 //!
-//! - transcript **shows** a polish Skill run → **allow** (silent — no nag after
-//!   a real polish run);
-//! - transcript is readable with **no** polish run → **block** (an evidenced
-//!   skip — the teeth);
-//! - no transcript / unreadable / parse error → **nudge** (ADR-0001 fail-open;
-//!   never block on our own missing data).
+//! - a polish marker exists for the PR's branch → **allow** (silent — no nag
+//!   after a real polish run);
+//! - no marker for this branch (or the repo/branch can't be resolved) → **nudge**
+//!   (ADR-0001 fail-open; CP1 never blocks on our own missing data).
+//!
+//! This replaces the earlier session-transcript scan, which false-blocked a
+//! `/polish` slash-command (no `Skill` `tool_use` block to find, #154) and was
+//! branch-blind — a polish on branch A satisfied a PR on branch B (#146). The
+//! marker is invocation-agnostic (Skill call, slash-command, or a delegated
+//! subagent all end by recording it) and branch-scoped by key construction.
 //!
 //! `/polish` runs a branch-scoped pass over the changes vs `origin/main` —
 //! simplify, logging, tests, docs, security, and code review. Skill, agent,
 //! command, and rule markdown (and CLAUDE.md) are behavior, not documentation,
 //! so they are in scope; literal documentation (prose about the system) routes
 //! to `/polish docs`. A skip is legitimate only for a trivial one-liner or a
-//! branch already taken through `/polish` — and the model may not self-approve
-//! one: it surfaces the decision to Cameron. (The subcommand id stays
-//! `nudge-polish-before-pr` for wiring stability even though it now can block.)
+//! branch already taken through `/polish`.
+//!
+//! CP1 is nudge-only during rollout (the marker restores reliable *detection*);
+//! CP2 escalates the absent-marker nudge to a block once the skill's marker
+//! write has propagated.
 
-use cadence_hooks_core::shell::is_gh_pr_create;
-use cadence_hooks_core::transcript::{
-    subagent_transcripts_have_polish_run, transcript_has_polish_run,
-};
+use cadence_hooks_core::markers::polish_marker;
+use cadence_hooks_core::shell::{git_command, is_gh_pr_create, parse_work_dir};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
-use std::path::Path;
 
-/// Gates `/polish` (cadence-forge:polish) before opening a PR — conditional on
-/// transcript evidence of a real polish run.
+/// Gates `/polish` (cadence-forge:polish) before opening a PR — conditional on a
+/// branch-scoped polish marker recorded by a completed polish pass.
 pub struct NudgePolishBeforePr;
 
 impl Check for NudgePolishBeforePr {
@@ -41,249 +44,227 @@ impl Check for NudgePolishBeforePr {
         let Some(command) = input.command() else {
             return CheckResult::allow();
         };
-        // Read the session transcript when the payload names one and it is
-        // readable. A missing path, a non-file, or a read error all collapse to
-        // `None`, and `decide` then fails open to a nudge — we never block on
-        // our own missing data (ADR-0001).
-        let tp = input.transcript_path().filter(|p| Path::new(p).is_file());
-        let transcript = tp.and_then(|p| std::fs::read_to_string(p).ok());
-        // Polish run inside a *subagent* lives in a child transcript the parent
-        // scan above never sees (#247). Only scan those children on the path
-        // that would otherwise block — a gh-pr-create whose parent transcript is
-        // readable, non-empty, and shows no polish — so the common allow/nudge
-        // paths pay no directory-walk cost.
-        let subagent_polish = match transcript.as_deref() {
-            Some(t)
-                if is_gh_pr_create(command)
-                    && !t.trim().is_empty()
-                    && !transcript_has_polish_run(t) =>
-            {
-                tp.map(Path::new)
-                    .is_some_and(subagent_transcripts_have_polish_run)
-            }
-            _ => false,
-        };
-        decide(command, transcript.as_deref(), subagent_polish)
+        // Only a `gh pr create` pays the git-resolution cost; every other
+        // command short-circuits to allow inside `decide`.
+        let marker_present = is_gh_pr_create(command) && marker_present_for(command, input);
+        decide(command, marker_present)
     }
 }
 
-/// The pure 3-way conditional — no I/O, so the gate logic is unit-tested
-/// without the filesystem. `run()` reads the transcript and hands the content
-/// (or `None`) in.
+/// Resolve the PR's `(repo_root, branch)` and report whether a polish marker
+/// exists for it. Mirrors the record side's resolution (`parse_work_dir` for a
+/// `cd`-prefixed command, then `git rev-parse --show-toplevel` + `git branch
+/// --show-current`) so a subdir cwd normalizes to the same key on both sides.
+///
+/// Any missing piece — no cwd, not a repo, detached HEAD — yields `false`, and
+/// `decide` then fails open to a nudge (ADR-0001); we never block on our own
+/// missing data.
+fn marker_present_for(command: &str, input: &HookInput) -> bool {
+    let Some(cwd) = input.cwd.as_deref() else {
+        return false;
+    };
+    let dir = parse_work_dir(command, cwd);
+    let Some(repo_root) = git_command(&dir, &["rev-parse", "--show-toplevel"]) else {
+        return false;
+    };
+    let Some(branch) = git_command(&dir, &["branch", "--show-current"]) else {
+        return false;
+    };
+    polish_marker(&repo_root, &branch).is_file()
+}
+
+/// The pure 2-way conditional — no I/O, so the gate logic is unit-tested without
+/// the filesystem. `run()` resolves the marker and hands the boolean in.
 ///
 /// - non-`gh pr create` → allow.
-/// - `gh pr create` + transcript showing a polish Skill run → allow (silent).
-/// - `gh pr create` + parent shows no polish but a subagent did → allow (delegated flow, #247).
-/// - `gh pr create` + readable, **non-empty** transcript without a polish run → block.
-/// - `gh pr create` + `None` / empty / whitespace-only transcript → nudge (fail-open floor).
-///
-/// `subagent_polish` is the caller's pre-computed verdict on whether a child
-/// subagent transcript shows polish; it is kept out of `decide` so this stays
-/// pure (no I/O) and unit-testable.
-fn decide(command: &str, transcript: Option<&str>, subagent_polish: bool) -> CheckResult {
+/// - `gh pr create` + a branch-scoped polish marker present → allow (silent).
+/// - `gh pr create` + no marker (or unresolved repo/branch/cwd) → nudge
+///   (fail-open floor, ADR-0001 — CP1 never blocks).
+fn decide(command: &str, marker_present: bool) -> CheckResult {
     if !is_gh_pr_create(command) {
         return CheckResult::allow();
     }
-    match transcript {
-        // No transcript — fail open to the soft nudge, never block.
-        None => CheckResult::nudge(nudge_message()),
-        // An empty or whitespace-only readable transcript is "no evidence", not
-        // an evidenced skip — a 0-byte / not-yet-flushed file must fail open too,
-        // never block on our own missing data (ADR-0001).
-        Some(t) if t.trim().is_empty() => CheckResult::nudge(nudge_message()),
-        // Polish actually ran — silent allow. Kills the nag-after-polish noise.
-        Some(t) if transcript_has_polish_run(t) => CheckResult::allow(),
-        // Parent shows no polish, but a subagent of this session ran it — the
-        // delegated-flow case (#247). Silent allow, same as a parent-side run.
-        Some(_) if subagent_polish => CheckResult::allow(),
-        // Readable, non-empty transcript with no polish run — an evidenced skip.
-        // The teeth.
-        Some(_) => CheckResult::block(block_message()),
+    if marker_present {
+        // Polish recorded a marker for this branch — silent allow. Kills the
+        // nag-after-polish noise and honors every invocation shape.
+        CheckResult::allow()
+    } else {
+        // No marker for this branch — fail open to the soft nudge, never block.
+        CheckResult::nudge(nudge_message())
     }
 }
 
-/// The loophole-closing clauses both the block and the nudge carry, so the
-/// "it's just markdown" and "TDD/attune already covered it" skips can't survive
-/// either path.
+/// The loophole-closing clauses the nudge carries, so the "it's just markdown"
+/// and "TDD/attune already covered it" skips can't survive it.
 const SCOPE_CLAUSES: &str = "Skill / agent / command / rule markdown and \
     CLAUDE.md are behavior, not documentation — IN scope; only *literal* docs \
     (prose about the system) route to `/polish docs`. Planning, TDD, attune, or \
     a code-review precede polish — they don't replace it.";
 
-/// Today's soft nudge — the fail-open message when there is no transcript
-/// evidence either way. Allow + warn; the model proceeds.
+/// The soft nudge — fires when no polish marker exists for the PR's branch.
+/// Allow + warn; the model proceeds (CP1 fail-open floor, ADR-0001).
 fn nudge_message() -> String {
     format!(
-        "Before opening this PR, consider `/polish` (cadence-forge:polish) — a \
-         branch-scoped pass vs `origin/main`: simplify, logging, tests, docs, \
-         security, code review. {SCOPE_CLAUSES} Skip ONLY if it's a trivial \
-         one-liner or already went through `/polish`. If you skip, say so and \
-         why — don't skip silently."
-    )
-}
-
-/// The block message — fires when the transcript proves polish was skipped.
-/// Reassigns authority: the model runs `/polish`, or if it believes the skip is
-/// legitimate it stops and surfaces the decision to Cameron. It deliberately
-/// does not advertise a self-serve bypass token.
-fn block_message() -> String {
-    format!(
-        "Polish was NOT run on this branch — the session transcript shows no \
-         `cadence-forge:polish` Skill invocation, and polish is mandatory before \
-         opening a PR. Run `/polish` now, then retry `gh pr create`. \
-         {SCOPE_CLAUSES} If you believe this skip is legitimate — a trivial \
-         one-liner, or polish performed outside a Skill call — you may NOT \
-         self-approve it: stop and surface the decision to Cameron, who decides."
+        "Before opening this PR, consider `/polish` (cadence-forge:polish) — no \
+         polish has been recorded for this branch this session (`/polish` records \
+         a marker when it completes). It's a branch-scoped pass vs `origin/main`: \
+         simplify, logging, tests, docs, security, code review. {SCOPE_CLAUSES} \
+         Skip ONLY if it's a trivial one-liner or already went through `/polish`. \
+         If you skip, say so and why — don't skip silently."
     )
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cadence_hooks_core::{Outcome, test_builders::make_bash};
+    use cadence_hooks_core::markers::{polish_marker, write_marker};
+    use cadence_hooks_core::shell::git_command;
+    use cadence_hooks_core::test_builders::{make_bash, make_bash_with_cwd};
+    use cadence_hooks_core::{Outcome, ToolInput};
+    use std::process::Command;
+
+    fn nudge_msg_has_loophole_clauses(msg: &str) {
+        // The nudge MUST keep telling the model that skill / agent / command /
+        // rule markdown is behavior — the clause that stops "it's just markdown".
+        assert!(
+            msg.contains("behavior, not documentation"),
+            "message should name behavioral markdown as in scope: {msg}"
+        );
+        // Planning / TDD / attune / review must not read as polish-equivalent.
+        assert!(
+            msg.contains("they don't replace it"),
+            "message should deny that upstream process substitutes for polish: {msg}"
+        );
+        // A skip must be surfaced, never silent — so the user can veto it.
+        assert!(
+            msg.contains("don't skip silently"),
+            "message should require the model to state why it is skipping: {msg}"
+        );
+    }
 
     #[test]
     fn gh_pr_create_nudges() {
+        // No cwd → marker unresolved → fail-open nudge.
         let result = NudgePolishBeforePr.run(&make_bash("gh pr create --title test"));
         assert_eq!(result.outcome, Outcome::Nudge);
         let msg = result.message.unwrap_or_default();
         assert!(msg.contains("/polish"), "message should mention /polish");
-        // Loophole guard: the nudge MUST keep telling the model that skill /
-        // agent / command / rule markdown is behavior, not documentation — that
-        // clause is what stops the "it's just markdown, skip polish" skip.
-        assert!(
-            msg.contains("behavior, not documentation"),
-            "message should name behavioral markdown as in scope"
-        );
-        // Loophole guard: planning / TDD / attune / review must not read as a
-        // polish-equivalent — the skip is only trivial-one-liner or already-polished.
-        assert!(
-            msg.contains("they don't replace it"),
-            "message should deny that upstream process substitutes for polish"
-        );
-        // Loophole guard: a skip must be surfaced, never silent — so the user
-        // can veto a rationalized skip.
-        assert!(
-            msg.contains("don't skip silently"),
-            "message should require the model to state why it is skipping"
-        );
+        nudge_msg_has_loophole_clauses(&msg);
     }
 
-    // --- decide(): the pure 3-way conditional (no filesystem) ---
-
-    /// A transcript line carrying a real `cadence-forge:polish` Skill invocation.
-    fn polish_transcript() -> &'static str {
-        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"tool_use","name":"Skill","input":{"skill":"cadence-forge:polish"}}]}}"#
-    }
-
-    /// A readable transcript with NO polish Skill run — only prose. The evidenced
-    /// skip the block path is meant to catch.
-    fn no_polish_transcript() -> &'static str {
-        r#"{"type":"assistant","message":{"role":"assistant","content":[{"type":"text","text":"opening the PR now"}]}}"#
-    }
+    // --- decide(): the pure 2-way conditional (no filesystem) ---
 
     #[test]
-    fn decide_pr_create_with_polish_run_allows_silently() {
-        // Polish actually ran → silent allow. This is the noise-kill: today the
-        // nudge fires even after a real polish run.
-        let result = decide(
-            "gh pr create --title test",
-            Some(polish_transcript()),
-            false,
-        );
+    fn decide_pr_create_with_marker_allows_silently() {
+        // A branch-scoped marker present → silent allow. #154 regression: this
+        // holds with NO transcript involvement — a slash-command polish that
+        // recorded a marker is honored.
+        let result = decide("gh pr create --title test", true);
         assert_eq!(result.outcome, Outcome::Allow);
         assert!(
             result.message.is_none(),
-            "a real polish run must allow silently, no nag"
+            "a recorded polish must allow silently, no nag"
         );
     }
 
     #[test]
-    fn decide_pr_create_without_polish_run_blocks() {
-        // The teeth: a readable transcript with no polish Skill run is an
-        // evidenced skip → hard block.
-        let result = decide(
-            "gh pr create --title test",
-            Some(no_polish_transcript()),
-            false,
-        );
-        assert_eq!(result.outcome, Outcome::Block);
-        let msg = result.message.unwrap_or_default();
-        // The block carries the same loophole-closing clauses the nudge does.
-        assert!(
-            msg.contains("behavior, not documentation"),
-            "block must keep the behavioral-markdown clause: {msg}"
-        );
-        assert!(
-            msg.contains("they don't replace it"),
-            "block must deny upstream-process substitution: {msg}"
-        );
-        // It states polish was NOT run...
-        assert!(
-            msg.to_lowercase().contains("not run"),
-            "block must state polish was not run: {msg}"
-        );
-        // ...directs the model to run /polish...
-        assert!(msg.contains("/polish"), "block must name the remedy: {msg}");
-        // ...and reassigns authority: the model may not self-approve a skip, it
-        // surfaces the decision to Cameron.
-        assert!(
-            msg.contains("Cameron"),
-            "block must name Cameron as the decider: {msg}"
-        );
-        assert!(
-            msg.to_lowercase().contains("surface"),
-            "block must tell the model to surface the decision: {msg}"
-        );
-        // The block must NOT advertise a self-serve bypass — that would re-hand
-        // the model a one-line loophole.
-        assert!(
-            !msg.contains("CADENCE_BYPASS"),
-            "block must not promote a self-serve skip token: {msg}"
-        );
-    }
-
-    #[test]
-    fn decide_pr_create_empty_transcript_nudges() {
-        // Fail-open: an empty or whitespace-only readable transcript is "no
-        // evidence", not an evidenced skip — it must nudge, never block. Guards
-        // the 0-byte / not-yet-flushed file case (security review finding 1).
-        assert_eq!(
-            decide("gh pr create --title x", Some(""), false).outcome,
-            Outcome::Nudge
-        );
-        assert_eq!(
-            decide("gh pr create --title x", Some("   \n\t  "), false).outcome,
-            Outcome::Nudge
-        );
-    }
-
-    #[test]
-    fn decide_pr_create_no_transcript_nudges() {
-        // Fail-open floor (ADR-0001): no transcript evidence → today's soft
-        // nudge, never a block. Preserves the pre-teeth behavior exactly.
-        let result = decide("gh pr create --title test", None, false);
+    fn decide_pr_create_without_marker_nudges() {
+        // #146 RED (pure): no marker → nudge, never block. CP1 is fail-open.
+        let result = decide("gh pr create --title x", false);
         assert_eq!(result.outcome, Outcome::Nudge);
         let msg = result.message.unwrap_or_default();
         assert!(msg.contains("/polish"));
-        assert!(msg.contains("behavior, not documentation"));
-        assert!(msg.contains("they don't replace it"));
-        assert!(msg.contains("don't skip silently"));
+        nudge_msg_has_loophole_clauses(&msg);
     }
 
     #[test]
-    fn decide_non_pr_create_allows_regardless_of_transcript() {
+    fn decide_non_pr_create_allows_regardless_of_marker() {
         // The matcher only scopes the process spawn; decide() still guards
         // against a non-create gh command slipping through.
         assert_eq!(
-            decide("gh pr list", Some(no_polish_transcript()), false).outcome,
+            decide("gh pr list", false).outcome,
             Outcome::Allow
         );
-        assert_eq!(
-            decide("git commit -m x", None, false).outcome,
-            Outcome::Allow
-        );
+        assert_eq!(decide("git commit -m x", true).outcome, Outcome::Allow);
     }
+
+    // --- integration through run() with a real temp git repo (#146 fixture) ---
+
+    /// Init a git repo in a fresh tempdir, checked out on `branch` (no commit
+    /// needed — `branch --show-current` reports an unborn branch, and the gate
+    /// only reads `--show-toplevel` + `--show-current`). Returns the tempdir and
+    /// the git-resolved repo root (canonicalized, so it matches what `run()`
+    /// resolves — critical on macOS where `/tmp` → `/private/tmp`).
+    fn init_repo_on_branch(branch: &str) -> (tempfile::TempDir, String) {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_str().unwrap().to_string();
+        let git = |args: &[&str]| {
+            let ok = Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        git(&["checkout", "-q", "-b", branch]);
+        let root = git_command(&dir, &["rev-parse", "--show-toplevel"])
+            .expect("temp repo resolves a toplevel");
+        (tmp, root)
+    }
+
+    #[test]
+    fn run_different_branch_marker_does_not_satisfy() {
+        // #146 RED (integration): repo is on branch B, but the only marker is for
+        // branch A → the different-branch marker must NOT satisfy → Nudge.
+        let (tmp, root) = init_repo_on_branch("branch-b");
+        write_marker(&polish_marker(&root, "branch-a"), "{}").unwrap();
+
+        let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
+        assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn run_same_branch_marker_allows_silently() {
+        // #146 GREEN companion: a marker for the *current* branch satisfies →
+        // Allow, silent. Also the #154 regression end-to-end: no transcript at
+        // all is involved, purely the marker.
+        let (tmp, root) = init_repo_on_branch("feat/thing");
+        write_marker(&polish_marker(&root, "feat/thing"), "{}").unwrap();
+
+        let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
+        let result = NudgePolishBeforePr.run(&input);
+        assert_eq!(result.outcome, Outcome::Allow);
+        assert!(result.message.is_none(), "a recorded polish allows silently");
+    }
+
+    #[test]
+    fn run_no_marker_in_real_repo_nudges() {
+        // Fail-open: a resolvable repo/branch but no marker → Nudge, never Block.
+        let (tmp, _root) = init_repo_on_branch("feat/unmarked");
+        let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
+        let result = NudgePolishBeforePr.run(&input);
+        assert_eq!(result.outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn run_unresolved_cwd_nudges_never_blocks() {
+        // No cwd at all → marker unresolved → fail-open nudge (never Block).
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: Some(ToolInput {
+                command: Some("gh pr create --title x".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Nudge);
+    }
+
+    // --- preserved matcher tests (is_gh_pr_create unchanged) ---
 
     #[test]
     fn gh_pr_create_with_heredoc_body_nudges() {
@@ -294,35 +275,50 @@ mod tests {
 
     #[test]
     fn gh_pr_list_allowed() {
-        let result = NudgePolishBeforePr.run(&make_bash("gh pr list"));
-        assert_eq!(result.outcome, Outcome::Allow);
+        assert_eq!(
+            NudgePolishBeforePr.run(&make_bash("gh pr list")).outcome,
+            Outcome::Allow
+        );
     }
 
     #[test]
     fn gh_pr_view_allowed() {
-        let result = NudgePolishBeforePr.run(&make_bash("gh pr view 123"));
-        assert_eq!(result.outcome, Outcome::Allow);
+        assert_eq!(
+            NudgePolishBeforePr.run(&make_bash("gh pr view 123")).outcome,
+            Outcome::Allow
+        );
     }
 
     #[test]
     fn gh_pr_review_allowed() {
-        let result = NudgePolishBeforePr.run(&make_bash("gh pr review 123 --approve"));
-        assert_eq!(result.outcome, Outcome::Allow);
+        assert_eq!(
+            NudgePolishBeforePr
+                .run(&make_bash("gh pr review 123 --approve"))
+                .outcome,
+            Outcome::Allow
+        );
     }
 
     #[test]
     fn gh_issue_create_allowed() {
-        let result = NudgePolishBeforePr.run(&make_bash("gh issue create --title test"));
-        assert_eq!(result.outcome, Outcome::Allow);
+        assert_eq!(
+            NudgePolishBeforePr
+                .run(&make_bash("gh issue create --title test"))
+                .outcome,
+            Outcome::Allow
+        );
     }
 
     #[test]
     fn git_command_allowed() {
-        let result = NudgePolishBeforePr.run(&make_bash("git commit -m 'gh pr create'"));
-        // Token detection: "gh pr create" appears as substring inside a single-quoted
-        // arg but split_whitespace yields ["git", "commit", "-m", "'gh", "pr", "create'"].
-        // The window check requires exact "gh", "pr", "create" — quoted tokens fail.
-        assert_eq!(result.outcome, Outcome::Allow);
+        // "gh pr create" appears only inside a single-quoted arg, so the token
+        // window never lines up → not a gh-pr-create.
+        assert_eq!(
+            NudgePolishBeforePr
+                .run(&make_bash("git commit -m 'gh pr create'"))
+                .outcome,
+            Outcome::Allow
+        );
     }
 
     #[test]
@@ -333,57 +329,17 @@ mod tests {
             cwd: None,
             ..Default::default()
         };
-        let result = NudgePolishBeforePr.run(&input);
-        assert_eq!(result.outcome, Outcome::Allow);
+        assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Allow);
     }
 
     #[test]
     fn branch_name_with_pr_create_substring_allowed() {
         // Branch named gh-pr-create-experiments shouldn't fire.
-        let result = NudgePolishBeforePr.run(&make_bash("git checkout gh-pr-create-experiments"));
-        assert_eq!(result.outcome, Outcome::Allow);
-    }
-
-    // --- the delegated-flow case (#247) ---
-
-    #[test]
-    fn decide_pr_create_subagent_polish_allows() {
-        // Parent transcript shows no polish, but a subagent did (subagent_polish
-        // = true) → allow, not block. This is the delegated-PR-flow fix: polish
-        // run inside a child satisfies the gate.
-        let result = decide(
-            "gh pr create --title test",
-            Some(no_polish_transcript()),
-            true,
+        assert_eq!(
+            NudgePolishBeforePr
+                .run(&make_bash("git checkout gh-pr-create-experiments"))
+                .outcome,
+            Outcome::Allow
         );
-        assert_eq!(result.outcome, Outcome::Allow);
-        assert!(
-            result.message.is_none(),
-            "a subagent polish run must allow silently, same as a parent run"
-        );
-    }
-
-    #[test]
-    fn run_allows_when_only_subagent_polished() {
-        // End-to-end through `run()`: a real gh-pr-create payload whose parent
-        // transcript shows no polish, but a sibling `<stem>/subagents/agent-*.jsonl`
-        // does → Allow. Proves run() reads the child transcripts, not just decide().
-        let tmp = tempfile::tempdir().unwrap();
-        let parent = tmp.path().join("sess.jsonl");
-        std::fs::write(&parent, no_polish_transcript()).unwrap();
-        let subagents = tmp.path().join("sess").join("subagents");
-        std::fs::create_dir_all(&subagents).unwrap();
-        std::fs::write(subagents.join("agent-a1.jsonl"), polish_transcript()).unwrap();
-
-        let input = HookInput {
-            tool_name: Some("Bash".into()),
-            tool_input: Some(cadence_hooks_core::ToolInput {
-                command: Some("gh pr create --title test".into()),
-                ..Default::default()
-            }),
-            transcript_path: Some(parent.to_str().unwrap().into()),
-            ..Default::default()
-        };
-        assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Allow);
     }
 }

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -181,10 +181,7 @@ mod tests {
     fn decide_non_pr_create_allows_regardless_of_marker() {
         // The matcher only scopes the process spawn; decide() still guards
         // against a non-create gh command slipping through.
-        assert_eq!(
-            decide("gh pr list", false).outcome,
-            Outcome::Allow
-        );
+        assert_eq!(decide("gh pr list", false).outcome, Outcome::Allow);
         assert_eq!(decide("git commit -m x", true).outcome, Outcome::Allow);
     }
 
@@ -238,7 +235,10 @@ mod tests {
         let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
         let result = NudgePolishBeforePr.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);
-        assert!(result.message.is_none(), "a recorded polish allows silently");
+        assert!(
+            result.message.is_none(),
+            "a recorded polish allows silently"
+        );
     }
 
     #[test]
@@ -284,7 +284,9 @@ mod tests {
     #[test]
     fn gh_pr_view_allowed() {
         assert_eq!(
-            NudgePolishBeforePr.run(&make_bash("gh pr view 123")).outcome,
+            NudgePolishBeforePr
+                .run(&make_bash("gh pr view 123"))
+                .outcome,
             Outcome::Allow
         );
     }

--- a/crates/cadence/src/record_polish.rs
+++ b/crates/cadence/src/record_polish.rs
@@ -1,0 +1,144 @@
+//! Record that `/polish` (cadence-forge:polish) ran on this branch.
+//!
+//! A **CLI action**, not a hook: the polish skill's Wrap-up shells out to
+//! `cadence-hooks cadence record-polish` after a completed pass, which writes a
+//! branch-scoped marker under the private [`markers::marker_dir`]. The pre-PR
+//! gate ([`crate::nudge_polish_before_pr`]) then reads that marker instead of
+//! scanning the session transcript.
+//!
+//! The marker key is `(repo_root, branch)` (see [`markers::polish_marker`]), so
+//! detection is invocation-agnostic (Skill call, `/polish` slash-command, or a
+//! delegated subagent all end by running this) and branch-scoped (a marker for
+//! branch A cannot satisfy a PR on branch B).
+//!
+//! Advisory, always — this must never fail the user's polish pass. Every error
+//! path (not a repo, detached HEAD, unwritable marker dir) prints one stderr
+//! line and exits 0 (ADR-0001).
+
+use cadence_hooks_core::markers::{polish_marker, write_marker};
+use cadence_hooks_core::shell::git_command;
+use cadence_hooks_core::time::utc_timestamp;
+use serde_json::json;
+
+/// Resolve `repo_root`, `branch`, and `head_sha` from `dir` via git, letting
+/// explicit overrides bypass the shell-out so tests need no real repository.
+///
+/// `head_sha` is best-effort: a repo with no commits yet has no `HEAD`, so it
+/// resolves to `None` and the field is recorded as an empty string rather than
+/// failing the record. `repo_root` and `branch` are the load-bearing key; when
+/// either can't be resolved the caller degrades to a no-op (exit 0).
+fn resolve(
+    dir: &str,
+    repo_root: Option<String>,
+    branch: Option<String>,
+) -> Option<(String, String, String)> {
+    let repo_root =
+        repo_root.or_else(|| git_command(dir, &["rev-parse", "--show-toplevel"]))?;
+    let branch = branch.or_else(|| git_command(dir, &["branch", "--show-current"]))?;
+    // Polish does not commit (SKILL.md), so this is the pre-polish base SHA — a
+    // provenance breadcrumb for CP2, never an exact-match key. Empty when the
+    // repo has no HEAD yet.
+    let head_sha = git_command(dir, &["rev-parse", "HEAD"]).unwrap_or_default();
+    Some((repo_root, branch, head_sha))
+}
+
+/// Build the marker payload. Presence is what CP1 gates on; the fields are
+/// stored now so CP2's freshness/scope escalation needs no format change.
+fn marker_content(branch: &str, head_sha: &str, scope: &str) -> String {
+    json!({
+        "branch": branch,
+        "head_sha": head_sha,
+        "recorded_at": utc_timestamp(),
+        "scope": scope,
+    })
+    .to_string()
+}
+
+/// Write the branch-scoped polish marker, resolving repo/branch/HEAD from the
+/// current directory unless overridden. Fail-open: any missing context or write
+/// error prints one stderr line and returns without error — a CLI action must
+/// never fail the polish pass it is recording (ADR-0001).
+pub fn run_record(repo_root: Option<String>, branch: Option<String>, scope: Option<String>) {
+    let cwd = std::env::current_dir()
+        .ok()
+        .and_then(|p| p.to_str().map(str::to_string))
+        .unwrap_or_else(|| ".".to_string());
+
+    let Some((repo_root, branch, head_sha)) = resolve(&cwd, repo_root, branch) else {
+        eprintln!(
+            "cadence-hooks record-polish: could not resolve repo root / branch \
+             (not a git repo, or detached HEAD) — no marker recorded."
+        );
+        return;
+    };
+
+    let scope = scope.unwrap_or_else(|| "full".to_string());
+    let content = marker_content(&branch, &head_sha, &scope);
+    let path = polish_marker(&repo_root, &branch);
+    if let Err(e) = write_marker(&path, &content) {
+        eprintln!("cadence-hooks record-polish: marker write failed ({e}) — pre-PR gate may re-nudge.");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::markers::polish_marker;
+
+    #[test]
+    fn marker_content_is_parseable_json_with_all_fields() {
+        let content = marker_content("feat/x", "abc123", "full");
+        let v: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+        assert_eq!(v["branch"], "feat/x");
+        assert_eq!(v["head_sha"], "abc123");
+        assert_eq!(v["scope"], "full");
+        // recorded_at is an ISO-8601 UTC instant (jiff `utc_timestamp`).
+        let ts = v["recorded_at"].as_str().unwrap();
+        assert!(ts.ends_with('Z'), "recorded_at should be UTC: {ts}");
+    }
+
+    #[test]
+    fn resolve_uses_explicit_overrides_without_touching_git() {
+        // Explicit repo_root + branch bypass the git shell-out, so a bogus dir
+        // still resolves — the property the write test below relies on.
+        let resolved = resolve(
+            "/nonexistent/not-a-repo",
+            Some("/tmp/repo".into()),
+            Some("main".into()),
+        );
+        let (repo_root, branch, _head) = resolved.expect("overrides resolve");
+        assert_eq!(repo_root, "/tmp/repo");
+        assert_eq!(branch, "main");
+    }
+
+    #[test]
+    fn run_record_writes_marker_at_expected_path_with_parseable_content() {
+        // With explicit overrides the write path is `polish_marker(repo, branch)`
+        // — the same value this test recomputes, since both calls resolve
+        // `marker_dir()` from the same environment. No env mutation needed: the
+        // marker lands in the real private dir at a hashed, unique name; we read
+        // it back and clean up. A repo/branch unlikely to collide with any peer.
+        let repo = "/tmp/record-polish-test-repo";
+        let branch = "feat/record-polish-y";
+        let path = polish_marker(repo, branch);
+        let _ = std::fs::remove_file(&path); // ensure a clean slate
+
+        run_record(Some(repo.into()), Some(branch.into()), Some("code".into()));
+
+        assert!(path.is_file(), "marker should exist at {path:?}");
+        let content = std::fs::read_to_string(&path).unwrap();
+        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(v["branch"], branch);
+        assert_eq!(v["scope"], "code");
+
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn run_record_degrades_to_noop_when_repo_unresolved() {
+        // No overrides + a non-repo cwd → resolve returns None → no panic, no
+        // marker. Asserts the call simply returns (fail-open) without unwinding;
+        // a bad marker dir would likewise exit via the write_marker arm.
+        run_record(None, None, Some("full".into()));
+    }
+}

--- a/crates/cadence/src/record_polish.rs
+++ b/crates/cadence/src/record_polish.rs
@@ -32,8 +32,7 @@ fn resolve(
     repo_root: Option<String>,
     branch: Option<String>,
 ) -> Option<(String, String, String)> {
-    let repo_root =
-        repo_root.or_else(|| git_command(dir, &["rev-parse", "--show-toplevel"]))?;
+    let repo_root = repo_root.or_else(|| git_command(dir, &["rev-parse", "--show-toplevel"]))?;
     let branch = branch.or_else(|| git_command(dir, &["branch", "--show-current"]))?;
     // Polish does not commit (SKILL.md), so this is the pre-polish base SHA — a
     // provenance breadcrumb for CP2, never an exact-match key. Empty when the
@@ -76,7 +75,9 @@ pub fn run_record(repo_root: Option<String>, branch: Option<String>, scope: Opti
     let content = marker_content(&branch, &head_sha, &scope);
     let path = polish_marker(&repo_root, &branch);
     if let Err(e) = write_marker(&path, &content) {
-        eprintln!("cadence-hooks record-polish: marker write failed ({e}) — pre-PR gate may re-nudge.");
+        eprintln!(
+            "cadence-hooks record-polish: marker write failed ({e}) — pre-PR gate may re-nudge."
+        );
     }
 }
 

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -122,6 +122,24 @@ pub fn session_marker(input: &HookInput, kind: &str, repo_root: Option<&str>) ->
     marker_dir().join(name)
 }
 
+/// A repo+branch-keyed marker path under the private [`marker_dir`], session-
+/// independent so a delegated (subagent) polish and the parent PR resolve the
+/// same path. Both `repo_root` and `branch` are payload/git-derived strings, so
+/// they are ALWAYS hashed, never used as path components — a crafted branch name
+/// like `../../x` is inert (the result is a direct child of [`marker_dir`]).
+///
+/// Keyed per-`(repo, branch)` on purpose: two sessions polishing two branches of
+/// one repo don't clobber each other's marker, and a different-branch marker is a
+/// key-miss by construction — the property the pre-PR gate keys its branch
+/// scoping on.
+pub fn polish_marker(repo_root: &str, branch: &str) -> PathBuf {
+    marker_dir().join(format!(
+        "polish-{:x}-{:x}",
+        hash_of(repo_root),
+        hash_of(branch)
+    ))
+}
+
 /// Write `contents` to a marker path symlink-safely.
 ///
 /// Stage to a uniquely-named `.{name}.{pid}.tmp` sibling with `create_new`
@@ -218,6 +236,44 @@ mod tests {
         // result is always a direct child of marker_dir(), never an escape.
         let input = input_with_session("../../evil");
         let p = session_marker(&input, "test-kind", None);
+        assert_eq!(
+            p.parent(),
+            Some(marker_dir().as_path()),
+            "marker must be a direct child of the private dir: {p:?}"
+        );
+        let name = p.file_name().unwrap().to_string_lossy();
+        assert!(
+            !name.contains('/') && !name.contains(".."),
+            "filename must carry no traversal: {name}"
+        );
+    }
+
+    #[test]
+    fn polish_marker_differs_per_branch() {
+        let a = polish_marker("/tmp/repo", "branch-a");
+        let b = polish_marker("/tmp/repo", "branch-b");
+        assert_ne!(a, b, "distinct branches must not share a marker");
+    }
+
+    #[test]
+    fn polish_marker_differs_per_repo() {
+        let a = polish_marker("/tmp/repo-a", "main");
+        let b = polish_marker("/tmp/repo-b", "main");
+        assert_ne!(a, b, "distinct repos must not share a marker");
+    }
+
+    #[test]
+    fn polish_marker_stable_for_same_inputs() {
+        let a = polish_marker("/tmp/repo", "main");
+        let b = polish_marker("/tmp/repo", "main");
+        assert_eq!(a, b, "same inputs must produce the same marker");
+    }
+
+    #[test]
+    fn polish_marker_never_embeds_raw_branch_or_repo() {
+        // A path-traversal branch/repo must be hashed to a plain filename — the
+        // result is always a direct child of marker_dir(), never an escape.
+        let p = polish_marker("../../evil-repo", "../../evil-branch");
         assert_eq!(
             p.parent(),
             Some(marker_dir().as_path()),

--- a/src/main.rs
+++ b/src/main.rs
@@ -144,6 +144,15 @@ enum CadenceCommands {
     MarkdownLint,
     /// Nudge when an external post mentions internal harness vocabulary
     RedactExternalContent,
+    /// Record that /polish ran on this branch (writes a branch-scoped marker). CLI action.
+    RecordPolish {
+        #[arg(long, value_name = "PATH")]
+        repo_root: Option<String>,
+        #[arg(long, value_name = "NAME")]
+        branch: Option<String>,
+        #[arg(long, value_name = "SCOPE")]
+        scope: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]
@@ -305,6 +314,10 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             CadenceCommands::NudgePolishBeforePr => "nudge-polish-before-pr",
             CadenceCommands::MarkdownLint => "markdown-lint",
             CadenceCommands::RedactExternalContent => "redact-external-content",
+            // record-polish is a CLI action, not a hook — no hooks.json wiring
+            // and not subject to CADENCE_DISABLE (same treatment as declare /
+            // status / dismiss-*).
+            CadenceCommands::RecordPolish { .. } => return None,
         }),
         Commands::Guardrails(g) => Some(match g {
             GuardrailsCommands::GuardPushRemote => "guard-push-remote",
@@ -654,6 +667,13 @@ fn main() {
                 &cadence_hooks_cadence::redact_external_content::RedactExternalContent,
                 pre,
             ),
+            CadenceCommands::RecordPolish {
+                repo_root,
+                branch,
+                scope,
+            } => {
+                cadence_hooks_cadence::record_polish::run_record(repo_root, branch, scope);
+            }
         },
         Commands::Guardrails(cmd) => match cmd {
             GuardrailsCommands::GuardPushRemote => run_check_from_stdin(
@@ -882,6 +902,7 @@ mod tests {
             "dismiss-enforce-worktree",
             "declare",
             "status",
+            "record-polish",
         ];
 
         let mut clap_pairs: Vec<(String, String)> = Vec::new();


### PR DESCRIPTION
Replaces the polish-run detector's session-scan with a branch-scoped marker, fixing two live defects in `nudge-polish-before-pr`:

- **#154 (severe):** detection required a `Skill` `tool_use` block (`crates/core/src/transcript.rs` — `line_is_polish_skill_use`), so a typed `/polish` slash command was invisible to the gate, which then **hard-blocked a session that had genuinely polished**. High blast radius — the slash command is a common invocation shape.
- **#146 (live in a new costume):** `transcript_has_polish_run` scanned the whole session branch-blind, so a polish on branch A silently satisfied a PR from branch B. The originally-filed matcher/marker defect no longer exists, but this is its successor — and the planned polish-required escalation can't key a branch-matched gate on a branch-blind detector.

## Mechanism

- `core::markers::polish_marker(repo_root, branch)` — repo+branch-keyed (session-independent, so a delegated polish satisfies the parent's PR), built on the hardened marker primitives from #170.
- New `cadence record-polish` **CLI action** (not a hook — no HOOKS entry; added to the `non_hooks` test list) writes the marker with `branch`, `head_sha`, `recorded_at`, `scope` from cwd git state. `head_sha` is deliberate: a future escalating consumer must validate marker **content** (branch + sha), never mere presence.
- The gate now reads the current branch's marker: present → silent allow; absent/unresolvable → **nudge, never block**. The block path and the subagent transcript-walk are removed. Nudge-only is the rollout posture: today's teeth were false-blocking real polish runs, and correct teeth return with the planned escalation once markers are the evidence trail.

The companion cadence-monorepo PR makes the polish skill's Wrap-up run `record-polish`; until it lands, the absent marker degrades to a nudge (fail-open, non-fatal).

## Evidence

- `cargo test`: 147 passed / 0 failed; `cargo clippy --all-targets -- -D warnings` clean.
- #146 fixture: branch-A marker + HEAD on branch B → Nudge (does NOT satisfy); branch-B marker → Allow.
- #154 regression: marker present, no session data at all → silent Allow.
- Fail-open (no marker, unresolvable cwd) → Nudge; `is_gh_pr_create` matcher tests preserved.

Closes #154. Refs #146 (closed by the companion PR that wires the marker write).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `record-polish` CLI command to capture when `/polish` has run on a branch.
  * Branch-scoped markers now persist across sessions, helping the app recognize previous `/polish` activity.

* **Bug Fixes**
  * Improved `/polish` checks before PR creation so they use the current repository and branch more reliably.
  * Prevented markers from being confused across different branches or repositories.
  * Kept checks fail-open, so unresolved repo context won’t block progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->