### PR TITLE
feat(metrics): sessions.jsonl — per-session cost at SessionEnd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,21 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   dir, unreadable file, fresh install, bad env value, or marker IO error all
   resolve to silence or a plain nudge — never a block. The SessionStart hook
   wiring ships in the companion cadence-metrics plugin PR.
+- **`metrics log-session` — per-session cost at `SessionEnd`
+  (`sessions.jsonl`).** A fifth `log-*` logger that scans the whole transcript
+  once at session end, prices it per-model, and appends one row with
+  `sessionId`, `repo`, `branch`, `reason`, `durationApproxMs`, `tokens`,
+  `costUsd`, `byModel[]`, `unpricedModels[]`, `messagesScanned`,
+  `lastMessageId`, `agentId`, `parentSessionId`. Where `log-commit` prices the
+  range since the last commit marker, `log-session` prices the whole transcript,
+  so `sum(commits) ≤ session` — the gap is uncommitted-work cost, and each
+  `/clear` segment writes its own row. Adds `MetricsInput.reason` (the
+  SessionEnd exit reason) and extracts the `byModel[]` / `unpricedModels[]`
+  builders into a shared `model_breakdown` module so `log-commit` and
+  `log-session` emit identical shapes. Gated on
+  `hook_event_name == "SessionEnd"` and fail-open (ADR-0001); the SessionEnd
+  hook wiring ships in the companion cadence-metrics plugin PR. Refs
+  cameronsjo/cadence#141.
 
 ### Added
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -439,6 +439,10 @@ pub struct MetricsInput {
     pub parent_agent_id: Option<String>,
     pub source_agent_id: Option<String>,
     pub duration_ms: Option<u64>,
+    /// SessionEnd exit reason (e.g. `other`, `prompt_input_exit`, `resume`),
+    /// when the payload carries it. Recorded on the `sessions.jsonl` row so a
+    /// session's terminal cause is greppable; deserializes to `None` when absent.
+    pub reason: Option<String>,
     /// Model id for the session (e.g. `claude-opus-4-8`), when the payload
     /// carries it (SessionStart and some Pre/PostToolUse payloads). Mirrors
     /// [`HookInput::model`]; deserializes to `None` when absent.
@@ -1774,7 +1778,17 @@ mod tests {
         assert_eq!(input.transcript_path, None);
         assert_eq!(input.agent_id, None);
         assert_eq!(input.duration_ms, None);
+        assert_eq!(input.reason, None);
         assert_eq!(input.command(), None);
+    }
+
+    #[test]
+    fn metrics_input_parses_session_end_reason() {
+        // The SessionEnd payload carries `reason`; it lands on the
+        // `sessions.jsonl` row so a session's terminal cause is greppable.
+        let json = r#"{"session_id":"s1","hook_event_name":"SessionEnd","reason":"prompt_input_exit"}"#;
+        let input = MetricsInput::from_json(json).unwrap();
+        assert_eq!(input.reason.as_deref(), Some("prompt_input_exit"));
     }
 
     #[test]

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1786,7 +1786,8 @@ mod tests {
     fn metrics_input_parses_session_end_reason() {
         // The SessionEnd payload carries `reason`; it lands on the
         // `sessions.jsonl` row so a session's terminal cause is greppable.
-        let json = r#"{"session_id":"s1","hook_event_name":"SessionEnd","reason":"prompt_input_exit"}"#;
+        let json =
+            r#"{"session_id":"s1","hook_event_name":"SessionEnd","reason":"prompt_input_exit"}"#;
         let input = MetricsInput::from_json(json).unwrap();
         assert_eq!(input.reason.as_deref(), Some("prompt_input_exit"));
     }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -16,8 +16,12 @@ pub mod log_askuserquestion;
 pub mod log_commit;
 /// Append polish-nudge (`gh pr create`) records to `polish_nudges.jsonl`.
 pub mod log_polish_nudge;
+/// Append per-session cost records to `sessions.jsonl` at `SessionEnd`.
+pub mod log_session;
 /// Append subagent lifecycle records to `subagents.jsonl`.
 pub mod log_subagent;
+/// Shared per-model breakdown builders for `byModel[]` / `unpricedModels[]`.
+pub mod model_breakdown;
 /// Embedded + overridable model price table.
 pub mod prices;
 /// Sum transcript token usage over a range.
@@ -30,6 +34,7 @@ pub mod warn_stale;
 pub use log_askuserquestion::LogAskUserQuestion;
 pub use log_commit::LogCommit;
 pub use log_polish_nudge::LogPolishNudge;
+pub use log_session::LogSession;
 pub use log_subagent::LogSubagent;
 pub use snapshot::Snapshot;
 pub use warn_stale::WarnStale;

--- a/crates/metrics/src/log_commit.rs
+++ b/crates/metrics/src/log_commit.rs
@@ -5,7 +5,8 @@
 //! Port of `log-commit.sh`. Silent no-op on any failure — never blocks.
 
 use crate::common;
-use crate::compute_cost::{compute_cost, compute_cost_by_model};
+use crate::compute_cost::compute_cost_by_model;
+use crate::model_breakdown::{by_model_json, unpriced_models};
 use crate::prices::Prices;
 use crate::scan_tokens::{ScanResult, scan_tokens};
 use cadence_hooks_core::{Logger, MetricsInput};
@@ -146,35 +147,11 @@ fn build_commit_record(
     since_marker: &str,
     prices: &Prices,
 ) -> Value {
-    // Per-model breakdown for the byModel field.
-    let by_model: Vec<Value> = scan
-        .by_model
-        .iter()
-        .map(|(model, tokens)| {
-            let bucket_cost = compute_cost(tokens, model, prices);
-            json!({
-                "model": model,
-                "tokens": {
-                    "input": tokens.input,
-                    "cacheCreate": tokens.cache_create,
-                    "cacheRead": tokens.cache_read,
-                    "output": tokens.output,
-                },
-                "costUsd": bucket_cost,
-            })
-        })
-        .collect();
-
-    // Models absent from the price table compute to $0 silently (#95). Record
-    // them so an unknown/unpriced model is loud in the data — a non-empty array
-    // means costUsd is understated and a reprocessing pass can recompute once
-    // the table is patched. Empty in the normal (all-priced) case.
-    let unpriced: Vec<&str> = scan
-        .by_model
-        .iter()
-        .filter(|(model, _)| prices.get(model).is_none())
-        .map(|(model, _)| model.as_str())
-        .collect();
+    // Per-model breakdown + unpriced-model flags, shared verbatim with
+    // `log_session` so the two loggers' shapes cannot drift (see
+    // `crate::model_breakdown`).
+    let by_model = by_model_json(&scan.by_model, prices);
+    let unpriced = unpriced_models(&scan.by_model, prices);
 
     json!({
         "ts": ts,

--- a/crates/metrics/src/log_session.rs
+++ b/crates/metrics/src/log_session.rs
@@ -1,0 +1,317 @@
+//! `SessionEnd` — scan the whole transcript for token usage, compute cost, and
+//! append one line to `<metrics_dir>/sessions.jsonl`.
+//!
+//! Sibling of [`crate::log_commit`]: where `log-commit` scans the range since
+//! the last commit marker, `log-session` scans the *whole* transcript once at
+//! session end. `sum(commits) ≤ session` — the gap is uncommitted-work cost;
+//! each `/clear` segment mints a new session id and so writes its own row.
+//!
+//! Fire-and-forget: silent no-op on any failure, never blocks.
+
+use crate::common;
+use crate::compute_cost::compute_cost_by_model;
+use crate::model_breakdown::{by_model_json, unpriced_models};
+use crate::prices::Prices;
+use crate::scan_tokens::{ScanResult, scan_tokens};
+use cadence_hooks_core::{Logger, MetricsInput};
+use serde_json::{Value, json};
+use std::io::Write;
+
+/// Appends a per-session cost line to `sessions.jsonl` at `SessionEnd`. Holds
+/// the optional price table override path supplied via `--prices`.
+pub struct LogSession {
+    pub prices_path: Option<String>,
+}
+
+impl Logger for LogSession {
+    fn name(&self) -> &str {
+        "log-session"
+    }
+
+    fn run(&self, input: &MetricsInput) {
+        // Belt-and-suspenders gate: only write on SessionEnd. This fn never
+        // deletes state, but the gate keeps a misrouted event from writing a
+        // spurious row (mirrors `crates/session/src/end.rs`).
+        if input.hook_event_name.as_deref() != Some("SessionEnd") {
+            return;
+        }
+
+        let Some(session_id) = input
+            .session_id
+            .as_deref()
+            .filter(|s| common::is_safe_session_id(s))
+        else {
+            return;
+        };
+        let Some(transcript_path) = input.transcript_path.as_deref() else {
+            return;
+        };
+        if !std::path::Path::new(transcript_path).is_file() {
+            return;
+        }
+
+        let Ok(transcript) = std::fs::read_to_string(transcript_path) else {
+            return;
+        };
+        // Whole transcript, no marker. `None` scan → nothing to price → skip.
+        let Some(scan) = scan_tokens(&transcript, None) else {
+            return;
+        };
+
+        let prices = Prices::load(self.prices_path.as_deref());
+        let cost = compute_cost_by_model(&scan.by_model, &prices);
+
+        let branch = common::branch(input.cwd.as_deref());
+        let repo = common::repo_basename(input.cwd.as_deref());
+
+        let record = build_session_record(
+            &common::utc_timestamp(),
+            input,
+            session_id,
+            &branch,
+            &repo,
+            &scan,
+            cost,
+            &prices,
+        );
+
+        let dir = common::metrics_dir();
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let sessions_path = dir.join("sessions.jsonl");
+
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(&sessions_path)
+        {
+            // Build the whole line (record + newline) and write it in a single
+            // `write_all`, so concurrent appends from other sessions can't
+            // interleave a record with its trailing newline. `record` is compact
+            // JSON, so this is one line with no embedded newlines.
+            let mut line = record.to_string();
+            line.push('\n');
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+/// Build the `sessions.jsonl` record. Pure — no I/O. The `byModel`/`unpricedModels`
+/// shapes come from [`crate::model_breakdown`], shared verbatim with `log_commit`.
+#[allow(clippy::too_many_arguments)]
+fn build_session_record(
+    ts: &str,
+    input: &MetricsInput,
+    session_id: &str,
+    branch: &str,
+    repo: &str,
+    scan: &ScanResult,
+    cost: f64,
+    prices: &Prices,
+) -> Value {
+    let by_model = by_model_json(&scan.by_model, prices);
+    let unpriced = unpriced_models(&scan.by_model, prices);
+
+    json!({
+        "ts": ts,
+        "sessionId": session_id,
+        "transcriptPath": input.transcript_path,
+        "repo": repo,
+        "branch": branch,
+        "reason": input.reason,
+        "durationApproxMs": input.duration_ms,
+        "model": scan.model,
+        "tokens": {
+            "input": scan.tokens.input,
+            "cacheCreate": scan.tokens.cache_create,
+            "cacheRead": scan.tokens.cache_read,
+            "output": scan.tokens.output,
+        },
+        "costUsd": cost,
+        "byModel": by_model,
+        "unpricedModels": unpriced,
+        "messagesScanned": scan.messages_scanned,
+        "lastMessageId": scan.last_message_id,
+        "agentId": input.agent_id,
+        "parentSessionId": input.parent_session_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::scan_tokens::Tokens;
+
+    #[test]
+    fn name_is_log_session() {
+        assert_eq!(LogSession { prices_path: None }.name(), "log-session");
+    }
+
+    fn sample_scan() -> ScanResult {
+        ScanResult {
+            tokens: Tokens {
+                input: 100,
+                cache_create: 50,
+                cache_read: 200,
+                output: 30,
+            },
+            last_message_id: "m9".into(),
+            messages_scanned: 3,
+            model: "claude-opus-4-7".into(),
+            by_model: vec![(
+                "claude-opus-4-7".into(),
+                Tokens {
+                    input: 100,
+                    cache_create: 50,
+                    cache_read: 200,
+                    output: 30,
+                },
+            )],
+        }
+    }
+
+    fn sample_input() -> MetricsInput {
+        MetricsInput {
+            session_id: Some("s1".into()),
+            transcript_path: Some("/tmp/t.jsonl".into()),
+            hook_event_name: Some("SessionEnd".into()),
+            reason: Some("prompt_input_exit".into()),
+            duration_ms: Some(4567),
+            agent_id: Some("a1".into()),
+            parent_session_id: Some("ps1".into()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn session_record_has_full_schema() {
+        let prices = Prices::embedded();
+        let record = build_session_record(
+            "2026-07-02T00:00:00Z",
+            &sample_input(),
+            "s1",
+            "feat/x",
+            "myrepo",
+            &sample_scan(),
+            0.001234,
+            &prices,
+        );
+        assert_eq!(record["sessionId"], "s1");
+        assert_eq!(record["transcriptPath"], "/tmp/t.jsonl");
+        assert_eq!(record["repo"], "myrepo");
+        assert_eq!(record["branch"], "feat/x");
+        assert_eq!(record["reason"], "prompt_input_exit");
+        assert_eq!(record["durationApproxMs"], 4567);
+        assert_eq!(record["model"], "claude-opus-4-7");
+        assert_eq!(record["tokens"]["input"], 100);
+        assert_eq!(record["tokens"]["cacheCreate"], 50);
+        assert_eq!(record["tokens"]["cacheRead"], 200);
+        assert_eq!(record["tokens"]["output"], 30);
+        assert_eq!(record["costUsd"], 0.001234);
+        assert_eq!(record["messagesScanned"], 3);
+        assert_eq!(record["lastMessageId"], "m9");
+        assert_eq!(record["agentId"], "a1");
+        assert_eq!(record["parentSessionId"], "ps1");
+        // byModel is always present and non-empty for a scanned range.
+        assert!(record["byModel"].is_array());
+        assert_eq!(record["byModel"].as_array().unwrap().len(), 1);
+        assert_eq!(record["byModel"][0]["model"], "claude-opus-4-7");
+        // Priced model → empty unpriced array.
+        assert!(record["unpricedModels"].as_array().unwrap().is_empty());
+    }
+
+    #[test]
+    fn session_record_absent_optional_fields_are_null() {
+        let prices = Prices::embedded();
+        let input = MetricsInput {
+            session_id: Some("s1".into()),
+            transcript_path: Some("/tmp/t.jsonl".into()),
+            hook_event_name: Some("SessionEnd".into()),
+            ..Default::default()
+        };
+        let record = build_session_record(
+            "2026-07-02T00:00:00Z",
+            &input,
+            "s1",
+            "",
+            "myrepo",
+            &sample_scan(),
+            0.0,
+            &prices,
+        );
+        // Absent → null, not omitted.
+        assert!(record["reason"].is_null());
+        assert!(record["durationApproxMs"].is_null());
+        assert!(record["agentId"].is_null());
+        assert!(record["parentSessionId"].is_null());
+        assert_eq!(record["branch"], "");
+    }
+
+    #[test]
+    fn session_record_flags_unpriced_model_never_silently_zero() {
+        // #95: an unpriced model id must land in unpricedModels rather than
+        // silently costing $0 with no trace.
+        let prices = Prices::embedded();
+        let scan = ScanResult {
+            tokens: Tokens {
+                input: 100,
+                ..Default::default()
+            },
+            last_message_id: "m9".into(),
+            messages_scanned: 1,
+            model: "gpt-9".into(),
+            by_model: vec![(
+                "gpt-9".into(),
+                Tokens {
+                    input: 100,
+                    ..Default::default()
+                },
+            )],
+        };
+        let record = build_session_record(
+            "ts",
+            &sample_input(),
+            "s1",
+            "main",
+            "r",
+            &scan,
+            0.0,
+            &prices,
+        );
+        let unpriced = record["unpricedModels"].as_array().unwrap();
+        assert_eq!(unpriced.len(), 1);
+        assert_eq!(unpriced[0], "gpt-9");
+    }
+
+    /// Whole ≥ parts: a session scan of the full transcript costs at least as
+    /// much as any commit scanning a proper sub-range of the same transcript.
+    #[test]
+    fn session_cost_ge_subrange_commit_cost() {
+        let transcript = [
+            r#"{"message":{"id":"m1","role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":100,"output_tokens":10}}}"#,
+            r#"{"message":{"id":"m2","role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":200,"output_tokens":20}}}"#,
+            r#"{"message":{"id":"m3","role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":300,"output_tokens":30}}}"#,
+        ]
+        .join("\n");
+        let prices = Prices::embedded();
+
+        // Whole transcript (what log-session records).
+        let whole = scan_tokens(&transcript, None).unwrap();
+        let whole_cost = compute_cost_by_model(&whole.by_model, &prices);
+
+        // A commit scanning only the range after m1 (sums m2 + m3) — a proper
+        // subrange of the same transcript.
+        let part = scan_tokens(&transcript, Some("m1")).unwrap();
+        let part_cost = compute_cost_by_model(&part.by_model, &prices);
+
+        assert!(part_cost > 0.0, "subrange must have a positive cost");
+        assert!(
+            whole_cost >= part_cost,
+            "whole session cost {whole_cost} must be >= subrange commit cost {part_cost}"
+        );
+        // And the session's recorded tokens equal the whole-transcript sum.
+        assert_eq!(whole.tokens.input, 600);
+        assert_eq!(whole.tokens.output, 60);
+    }
+}

--- a/crates/metrics/src/model_breakdown.rs
+++ b/crates/metrics/src/model_breakdown.rs
@@ -1,0 +1,82 @@
+//! Shared per-model breakdown builders for cost-bearing JSONL rows.
+//!
+//! Both `log_commit` (`commits.jsonl`) and `log_session` (`sessions.jsonl`)
+//! emit an identical `byModel[]` array and `unpricedModels[]` list. Extracting
+//! the two builders here keeps the shapes mechanically identical across loggers
+//! — the "verbatim from log-commit" contract — so they cannot drift.
+
+use crate::compute_cost::compute_cost;
+use crate::prices::Prices;
+use crate::scan_tokens::Tokens;
+use serde_json::{Value, json};
+
+/// Per-model token + cost breakdown for the `byModel` field. Each bucket is
+/// billed at its own model's rates; buckets whose model is absent from the
+/// price table contribute `costUsd: 0.0` (and appear in [`unpriced_models`]).
+pub fn by_model_json(by_model: &[(String, Tokens)], prices: &Prices) -> Vec<Value> {
+    by_model
+        .iter()
+        .map(|(model, tokens)| {
+            let bucket_cost = compute_cost(tokens, model, prices);
+            json!({
+                "model": model,
+                "tokens": {
+                    "input": tokens.input,
+                    "cacheCreate": tokens.cache_create,
+                    "cacheRead": tokens.cache_read,
+                    "output": tokens.output,
+                },
+                "costUsd": bucket_cost,
+            })
+        })
+        .collect()
+}
+
+/// Models absent from the price table (#95). Such a model computes to `$0`
+/// silently, so recording it here makes the understated `costUsd` loud in the
+/// data — a non-empty array means a reprocessing pass can recompute once the
+/// table is patched. Empty in the normal (all-priced) case.
+pub fn unpriced_models<'a>(by_model: &'a [(String, Tokens)], prices: &Prices) -> Vec<&'a str> {
+    by_model
+        .iter()
+        .filter(|(model, _)| prices.get(model).is_none())
+        .map(|(model, _)| model.as_str())
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn scan(model: &str) -> Vec<(String, Tokens)> {
+        vec![(
+            model.into(),
+            Tokens {
+                input: 100,
+                cache_create: 50,
+                cache_read: 200,
+                output: 30,
+            },
+        )]
+    }
+
+    #[test]
+    fn by_model_json_emits_model_tokens_cost() {
+        let prices = Prices::embedded();
+        let arr = by_model_json(&scan("claude-opus-4-7"), &prices);
+        assert_eq!(arr.len(), 1);
+        assert_eq!(arr[0]["model"], "claude-opus-4-7");
+        assert_eq!(arr[0]["tokens"]["input"], 100);
+        assert_eq!(arr[0]["tokens"]["cacheCreate"], 50);
+        assert_eq!(arr[0]["tokens"]["cacheRead"], 200);
+        assert_eq!(arr[0]["tokens"]["output"], 30);
+        assert!(arr[0]["costUsd"].as_f64().unwrap() > 0.0);
+    }
+
+    #[test]
+    fn unpriced_models_flags_unknown_and_skips_known() {
+        let prices = Prices::embedded();
+        assert!(unpriced_models(&scan("claude-opus-4-7"), &prices).is_empty());
+        assert_eq!(unpriced_models(&scan("gpt-9"), &prices), vec!["gpt-9"]);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -248,6 +248,13 @@ enum MetricsCommands {
     },
     /// Log subagent lifecycle (SubagentStart / SubagentStop)
     LogSubagent,
+    /// Log per-session cost at SessionEnd (SessionEnd)
+    LogSession {
+        /// Override path to the model price table (JSON). Falls back to the
+        /// embedded default; `CADENCE_METRICS_PRICES` env takes precedence.
+        #[arg(long, value_name = "PATH")]
+        prices: Option<String>,
+    },
     /// Log polish-nudge skips: `gh pr create` + whether /polish ran (PostToolUse)
     LogPolishNudge,
     /// Log AskUserQuestion stance + shape on every call (PreToolUse)
@@ -363,6 +370,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::Snapshot => "snapshot",
             MetricsCommands::LogCommit { .. } => "log-commit",
             MetricsCommands::LogSubagent => "log-subagent",
+            MetricsCommands::LogSession { .. } => "log-session",
             MetricsCommands::LogPolishNudge => "log-polish-nudge",
             MetricsCommands::LogAskUserQuestion => "log-ask-user-question",
             MetricsCommands::WarnStale => "warn-stale",
@@ -812,6 +820,12 @@ fn main() {
             MetricsCommands::LogSubagent => run_logger_from_stdin(
                 &cadence_hooks_metrics::LogSubagent,
                 registry::sample_for("metrics", "log-subagent"),
+            ),
+            MetricsCommands::LogSession { prices } => run_logger_from_stdin(
+                &cadence_hooks_metrics::LogSession {
+                    prices_path: prices,
+                },
+                registry::sample_for("metrics", "log-session"),
             ),
             MetricsCommands::LogPolishNudge => run_logger_from_stdin(
                 &cadence_hooks_metrics::LogPolishNudge,

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -291,6 +291,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: None,
     },
     HookEntry {
+        name: "log-session",
+        description: "Log per-session cost at SessionEnd (SessionEnd)",
+        plugin: "metrics",
+        event: None,
+    },
+    HookEntry {
         name: "log-polish-nudge",
         description: "Log polish-nudge skips: gh pr create + whether /polish ran (PostToolUse)",
         plugin: "metrics",
@@ -397,6 +403,12 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         // log-subagent only reacts to SubagentStart / SubagentStop
         ("metrics", "log-subagent") => Some(
             r#"{"session_id":"test","hook_event_name":"SubagentStop","agent_id":"agent-1","agent_type":"Explore","duration_ms":1234}"#,
+        ),
+        // log-session gates on hook_event_name == "SessionEnd" and scans the
+        // transcript; the generic logger sample carries a different event and
+        // no transcript, so it would no-op before writing a row.
+        ("metrics", "log-session") => Some(
+            r#"{"session_id":"test","hook_event_name":"SessionEnd","transcript_path":"/tmp/transcript.jsonl","cwd":"/tmp","reason":"prompt_input_exit"}"#,
         ),
         // log-polish-nudge gates on a `gh pr create` command (the nudge denominator)
         ("metrics", "log-polish-nudge") => Some(
@@ -509,9 +521,9 @@ mod tests {
 
     #[test]
     fn sample_overrides_exist_for_event_gated_loggers() {
-        // These three loggers gate on specific hook_event_name values or
-        // command shapes — the generic fallback would no-op them.
-        for name in ["snapshot", "log-commit", "log-subagent"] {
+        // These loggers gate on specific hook_event_name values or command
+        // shapes — the generic fallback would no-op them.
+        for name in ["snapshot", "log-commit", "log-subagent", "log-session"] {
             assert!(
                 sample_for("metrics", name).is_some(),
                 "{name} needs a sample override"
@@ -553,6 +565,7 @@ mod tests {
             "snapshot",
             "log-commit",
             "log-subagent",
+            "log-session",
             "log-polish-nudge",
             "log-ask-user-question",
             "heartbeat",

--- a/tests/session_log.rs
+++ b/tests/session_log.rs
@@ -1,0 +1,163 @@
+//! Integration tests for `metrics log-session` — the `sessions.jsonl` writer
+//! that fires at `SessionEnd` (O3).
+//!
+//! The binary is spawned as a child process with `CADENCE_METRICS_DIR` pointed
+//! at a per-test tempdir, so the write lands nowhere real and the env override
+//! is isolated (never touches the test runner's process-global env).
+
+use std::io::Write;
+use std::process::Command;
+
+fn cadence_hooks() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cadence-hooks"));
+    // Don't inherit env that would bypass, disable, or re-price the logger.
+    cmd.env_remove("CADENCE_BYPASS");
+    cmd.env_remove("CADENCE_DISABLE");
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CADENCE_METRICS_PRICES");
+    cmd
+}
+
+/// Spawn the binary with JSON on stdin and return the completed output.
+fn run_with_stdin(mut cmd: Command, input: &str) -> std::process::Output {
+    cmd.stdin(std::process::Stdio::piped())
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::piped());
+    let mut child = cmd.spawn().expect("failed to execute binary");
+    if let Some(ref mut stdin) = child.stdin {
+        match stdin.write_all(input.as_bytes()) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(e) => panic!("failed to write to child stdin: {e}"),
+        }
+    }
+    child.wait_with_output().expect("failed to wait on binary")
+}
+
+/// A transcript with two priced assistant messages. Written to `path`.
+fn write_transcript(path: &std::path::Path) {
+    let transcript = [
+        r#"{"type":"user","message":{"role":"user","content":"hi"}}"#,
+        r#"{"message":{"id":"m1","role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":1000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":100}}}"#,
+        r#"{"message":{"id":"m2","role":"assistant","model":"claude-opus-4-7","usage":{"input_tokens":2000,"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"output_tokens":200}}}"#,
+    ]
+    .join("\n");
+    std::fs::write(path, transcript).expect("write transcript");
+}
+
+// ── RED-first: no row without a SessionEnd event ─────────────────────────
+
+#[test]
+fn non_session_end_event_writes_no_row() {
+    // The gate: a PostToolUse payload (wrong event) must not write a session
+    // row. This is the RED assertion — the absence the writer must respect.
+    let dir = tempfile::tempdir().expect("tempdir");
+    let transcript = dir.path().join("transcript.jsonl");
+    write_transcript(&transcript);
+
+    let mut cmd = cadence_hooks();
+    cmd.env("CADENCE_METRICS_DIR", dir.path());
+    cmd.args(["metrics", "log-session"]);
+    let payload = format!(
+        r#"{{"session_id":"sess-1","hook_event_name":"PostToolUse","transcript_path":"{}","cwd":"/tmp"}}"#,
+        transcript.display()
+    );
+    let output = run_with_stdin(cmd, &payload);
+
+    assert_eq!(output.status.code(), Some(0), "loggers always exit 0");
+    assert!(
+        !dir.path().join("sessions.jsonl").exists(),
+        "no row for a non-SessionEnd event"
+    );
+}
+
+// ── GREEN: one row at SessionEnd, with the full schema ───────────────────
+
+#[test]
+fn session_end_writes_one_priced_row() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let transcript = dir.path().join("transcript.jsonl");
+    write_transcript(&transcript);
+
+    let mut cmd = cadence_hooks();
+    cmd.env("CADENCE_METRICS_DIR", dir.path());
+    cmd.args(["metrics", "log-session"]);
+    let payload = format!(
+        r#"{{"session_id":"sess-1","hook_event_name":"SessionEnd","transcript_path":"{}","cwd":"/tmp","reason":"prompt_input_exit"}}"#,
+        transcript.display()
+    );
+    let output = run_with_stdin(cmd, &payload);
+    assert_eq!(output.status.code(), Some(0), "loggers always exit 0");
+
+    let contents = std::fs::read_to_string(dir.path().join("sessions.jsonl"))
+        .expect("sessions.jsonl must exist after SessionEnd");
+    let lines: Vec<&str> = contents.lines().filter(|l| !l.is_empty()).collect();
+    assert_eq!(lines.len(), 1, "exactly one row, got: {contents}");
+
+    let row: serde_json::Value = serde_json::from_str(lines[0]).expect("row parses as JSON");
+    assert_eq!(row["sessionId"], "sess-1");
+    assert_eq!(row["reason"], "prompt_input_exit");
+    assert_eq!(row["model"], "claude-opus-4-7");
+    // tokens == whole-transcript sum (m1 + m2).
+    assert_eq!(row["tokens"]["input"], 3000);
+    assert_eq!(row["tokens"]["output"], 300);
+    assert_eq!(row["messagesScanned"], 2);
+    // A priced model → positive cost, non-empty byModel, empty unpricedModels.
+    assert!(row["costUsd"].as_f64().unwrap() > 0.0, "priced model costs > 0");
+    assert!(!row["byModel"].as_array().unwrap().is_empty());
+    assert!(row["unpricedModels"].as_array().unwrap().is_empty());
+}
+
+#[test]
+fn unpriced_model_lands_in_unpriced_never_silently_zero() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let transcript = dir.path().join("transcript.jsonl");
+    // `gpt-9` is absent from the embedded price table (#95).
+    std::fs::write(
+        &transcript,
+        r#"{"message":{"id":"m1","role":"assistant","model":"gpt-9","usage":{"input_tokens":100,"output_tokens":10}}}"#,
+    )
+    .expect("write transcript");
+
+    let mut cmd = cadence_hooks();
+    cmd.env("CADENCE_METRICS_DIR", dir.path());
+    cmd.args(["metrics", "log-session"]);
+    let payload = format!(
+        r#"{{"session_id":"sess-2","hook_event_name":"SessionEnd","transcript_path":"{}","cwd":"/tmp"}}"#,
+        transcript.display()
+    );
+    let output = run_with_stdin(cmd, &payload);
+    assert_eq!(output.status.code(), Some(0));
+
+    let contents = std::fs::read_to_string(dir.path().join("sessions.jsonl")).expect("row written");
+    let row: serde_json::Value =
+        serde_json::from_str(contents.lines().next().unwrap()).expect("parse");
+    let unpriced = row["unpricedModels"].as_array().unwrap();
+    assert_eq!(unpriced.len(), 1);
+    assert_eq!(unpriced[0], "gpt-9");
+    assert!(row["reason"].is_null(), "absent reason → null");
+}
+
+// ── Fail-open: an unwritable metrics dir never perturbs the exit code ─────
+
+#[test]
+fn unwritable_metrics_dir_fails_open() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let transcript = dir.path().join("transcript.jsonl");
+    write_transcript(&transcript);
+
+    // Point CADENCE_METRICS_DIR at a *file* — create_dir_all fails, the write
+    // is skipped, and the logger still exits 0 without panicking.
+    let blocker = dir.path().join("not-a-dir");
+    std::fs::write(&blocker, "x").expect("write blocker file");
+
+    let mut cmd = cadence_hooks();
+    cmd.env("CADENCE_METRICS_DIR", &blocker);
+    cmd.args(["metrics", "log-session"]);
+    let payload = format!(
+        r#"{{"session_id":"sess-3","hook_event_name":"SessionEnd","transcript_path":"{}","cwd":"/tmp"}}"#,
+        transcript.display()
+    );
+    let output = run_with_stdin(cmd, &payload);
+    assert_eq!(output.status.code(), Some(0), "fail-open: still exits 0");
+}

--- a/tests/session_log.rs
+++ b/tests/session_log.rs
@@ -103,7 +103,10 @@ fn session_end_writes_one_priced_row() {
     assert_eq!(row["tokens"]["output"], 300);
     assert_eq!(row["messagesScanned"], 2);
     // A priced model → positive cost, non-empty byModel, empty unpricedModels.
-    assert!(row["costUsd"].as_f64().unwrap() > 0.0, "priced model costs > 0");
+    assert!(
+        row["costUsd"].as_f64().unwrap() > 0.0,
+        "priced model costs > 0"
+    );
     assert!(!row["byModel"].as_array().unwrap().is_empty());
     assert!(row["unpricedModels"].as_array().unwrap().is_empty());
 }

--- a/tests/session_log.rs
+++ b/tests/session_log.rs
@@ -34,6 +34,32 @@ fn run_with_stdin(mut cmd: Command, input: &str) -> std::process::Output {
     child.wait_with_output().expect("failed to wait on binary")
 }
 
+/// Build a SessionEnd payload with **structural** JSON escaping.
+///
+/// The transcript path is a tempdir path — on Windows that's `C:\Users\...`,
+/// whose backslashes are invalid JSON escapes. Interpolating it into a raw
+/// string template with `format!` would produce unparseable JSON, `MetricsInput`
+/// would fail to deserialize, and the logger would silently fail open (no row).
+/// Building the payload with `serde_json::json!` escapes the path correctly on
+/// every platform (#170).
+fn session_payload(
+    session_id: &str,
+    event: &str,
+    transcript: &std::path::Path,
+    reason: Option<&str>,
+) -> String {
+    let mut obj = serde_json::json!({
+        "session_id": session_id,
+        "hook_event_name": event,
+        "transcript_path": transcript.to_string_lossy(),
+        "cwd": "/tmp",
+    });
+    if let Some(r) = reason {
+        obj["reason"] = serde_json::Value::String(r.to_string());
+    }
+    obj.to_string()
+}
+
 /// A transcript with two priced assistant messages. Written to `path`.
 fn write_transcript(path: &std::path::Path) {
     let transcript = [
@@ -58,10 +84,7 @@ fn non_session_end_event_writes_no_row() {
     let mut cmd = cadence_hooks();
     cmd.env("CADENCE_METRICS_DIR", dir.path());
     cmd.args(["metrics", "log-session"]);
-    let payload = format!(
-        r#"{{"session_id":"sess-1","hook_event_name":"PostToolUse","transcript_path":"{}","cwd":"/tmp"}}"#,
-        transcript.display()
-    );
+    let payload = session_payload("sess-1", "PostToolUse", &transcript, None);
     let output = run_with_stdin(cmd, &payload);
 
     assert_eq!(output.status.code(), Some(0), "loggers always exit 0");
@@ -82,9 +105,11 @@ fn session_end_writes_one_priced_row() {
     let mut cmd = cadence_hooks();
     cmd.env("CADENCE_METRICS_DIR", dir.path());
     cmd.args(["metrics", "log-session"]);
-    let payload = format!(
-        r#"{{"session_id":"sess-1","hook_event_name":"SessionEnd","transcript_path":"{}","cwd":"/tmp","reason":"prompt_input_exit"}}"#,
-        transcript.display()
+    let payload = session_payload(
+        "sess-1",
+        "SessionEnd",
+        &transcript,
+        Some("prompt_input_exit"),
     );
     let output = run_with_stdin(cmd, &payload);
     assert_eq!(output.status.code(), Some(0), "loggers always exit 0");
@@ -125,10 +150,7 @@ fn unpriced_model_lands_in_unpriced_never_silently_zero() {
     let mut cmd = cadence_hooks();
     cmd.env("CADENCE_METRICS_DIR", dir.path());
     cmd.args(["metrics", "log-session"]);
-    let payload = format!(
-        r#"{{"session_id":"sess-2","hook_event_name":"SessionEnd","transcript_path":"{}","cwd":"/tmp"}}"#,
-        transcript.display()
-    );
+    let payload = session_payload("sess-2", "SessionEnd", &transcript, None);
     let output = run_with_stdin(cmd, &payload);
     assert_eq!(output.status.code(), Some(0));
 
@@ -157,10 +179,7 @@ fn unwritable_metrics_dir_fails_open() {
     let mut cmd = cadence_hooks();
     cmd.env("CADENCE_METRICS_DIR", &blocker);
     cmd.args(["metrics", "log-session"]);
-    let payload = format!(
-        r#"{{"session_id":"sess-3","hook_event_name":"SessionEnd","transcript_path":"{}","cwd":"/tmp"}}"#,
-        transcript.display()
-    );
+    let payload = session_payload("sess-3", "SessionEnd", &transcript, None);
     let output = run_with_stdin(cmd, &payload);
     assert_eq!(output.status.code(), Some(0), "fail-open: still exits 0");
 }


### PR DESCRIPTION
Cost is sampled only at `git commit` today, so a session that researches, plans, reviews, or is abandoned is never priced, and downstream tooling falls back to re-derived estimates — exactly where the 3× price-table bug lived. This adds the first-party answer: one `sessions.jsonl` row per session close.

## What

- New `metrics log-session` fire-and-forget Logger, gated on `hook_event_name == "SessionEnd"`: whole-transcript `scan_tokens` over `transcriptPath`, priced via the existing prices table, one compact-JSON `write_all` append (fail-open per ADR-0001).
- Fields: `ts, sessionId, transcriptPath, repo, branch, reason, durationApproxMs, model, tokens{input,cacheCreate,cacheRead,output}, costUsd, byModel[], unpricedModels[], messagesScanned, lastMessageId, agentId, parentSessionId`. `MetricsInput` gains an additive `reason`.
- `byModel`/`unpricedModels` builders extracted from `log_commit` into a shared `model_breakdown` module consumed by both loggers — the shapes cannot drift, and the existing `commit_record_*` tests pass unchanged as the verbatim-contract proof.
- Relationship to `commits.jsonl`: commits stay per-commit attribution; sessions are the total. `sum(commits) ≤ session` per session — the gap is the uncommitted-work cost, newly measurable.
- Full registry wiring: clap variant, `hook_name` arm, dispatch arm, `HOOKS` entry, sample override, and the `only_loggers_have_no_event` loggers list.

## Evidence

- `cargo test`: all suites green — unit/lib 66 passed, metrics 83 passed (incl. `log_session` + `model_breakdown`), `hook_registration_audit` 14 passed, `session_log` integration 4 passed (SessionEnd writes one priced row; non-SessionEnd writes none; an unpriced model id lands in `unpricedModels`, never silently zero; unwritable dir fails open). `cargo clippy --all-targets -- -D warnings` clean.
- Companion PRs: cadence monorepo (hooks.json SessionEnd wiring + schema/README) and the consumer-side cost-tier fallback. `plan-phases.jsonl` stays deferred until an ExitPlanMode hook exists.

Refs cameronsjo/cadence#141 (delivers the sessions.jsonl row; SessionStart bounds, per-session commit counts, and the load_pg join remain open there).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
