### PR TITLE
feat(metrics): denials.jsonl — guard-fire audit log at the dispatch seam

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,20 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `hook_event_name == "SessionEnd"` and fail-open (ADR-0001); the SessionEnd
   hook wiring ships in the companion cadence-metrics plugin PR. Refs
   cameronsjo/cadence#141.
+- **`denials.jsonl` — guard-denial audit log at the dispatch outcome→exit-code
+  seam.** Records one append-only line per guard `deny` (a hard block, exit 2),
+  and per `nudge` when `CADENCE_LOG_NUDGES` is set — fields `ts`, `hook`,
+  `event`, `decision`, `tool`, `repo`, `sessionId`, `agentId`. A PreToolUse
+  block was previously prose-only, invisible to attachment counting and leaving
+  zero on-disk trace when a false positive fired. The write lives at the single
+  `run_check` seam (split into `decide_check` + `emit_and_exit`) via a
+  binary-level `run_logged_check` wrapper that threads the canonical registry
+  hook name; every block-capable check arm routes through it, loggers are
+  untouched. **Privacy by construction:** the record names which guard fired on
+  which tool in which repo, never the command text, file path, or edited
+  content. Fail-open (ADR-0001): a full disk or unwritable metrics dir degrades
+  to a no-op and the block still exits 2 with byte-identical stderr. Consumer:
+  `claude-configurations` `profiler_tally.py` renders a denies-by-hook table.
 
 ### Added
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -161,6 +161,11 @@ pub struct HookInput {
     pub source: Option<String>,
     /// Model id for the session (e.g. `claude-opus-4-8`), when supplied.
     pub model: Option<String>,
+    /// Subagent id for a dispatched agent, when the payload carries it. Mirrors
+    /// [`MetricsInput::agent_id`]; deserializes to `None` on the main thread and
+    /// on payloads that omit it. Carried so the denial audit log can attribute a
+    /// guard fire to the subagent that triggered it.
+    pub agent_id: Option<String>,
 }
 
 /// Tool-specific fields from the hook input.
@@ -401,6 +406,11 @@ impl HookInput {
     /// The session model id, if present.
     pub fn model(&self) -> Option<&str> {
         self.model.as_deref()
+    }
+
+    /// The subagent id, if the payload carried one (`None` on the main thread).
+    pub fn agent_id(&self) -> Option<&str> {
+        self.agent_id.as_deref()
     }
 
     /// The stdout from the tool response (PostToolUse only).
@@ -743,12 +753,35 @@ fn render_output(
 ///   `fix` is folded into the stderr text instead (see [`render_output`]).
 /// - Allow → silent exit 0.
 pub fn run_check(check: &dyn Check, input: &HookInput, event: HookEvent) -> ! {
+    match decide_check(check, input) {
+        None => process::exit(Outcome::Allow.code()),
+        Some(result) => emit_and_exit(&result, event),
+    }
+}
+
+/// The decide half of [`run_check`]: honor `skip_at_effort()`, then run the
+/// check. `None` means the check was short-circuited to Allow for the current
+/// `$CLAUDE_EFFORT` and `check.run()` was **not** called — the caller must treat
+/// it as a silent Allow. `Some(result)` carries the check's outcome.
+///
+/// Split out so a caller (the binary's logged-dispatch wrapper) can observe the
+/// [`CheckResult`] — e.g. to record a denial — between deciding and exiting,
+/// without changing what [`run_check`] itself does.
+pub fn decide_check(check: &dyn Check, input: &HookInput) -> Option<CheckResult> {
     let current_effort = std::env::var("CLAUDE_EFFORT").ok();
     if should_skip_for_effort(check.skip_at_effort(), current_effort.as_deref()) {
-        process::exit(Outcome::Allow.code());
+        return None;
     }
+    Some(check.run(input))
+}
 
-    let result = check.run(input);
+/// The emit-and-exit half of [`run_check`]: render the outcome to stdout/stderr
+/// per Claude Code's exit-code contract, then `process::exit` with the outcome's
+/// code. Never returns.
+///
+/// Behaviourally identical to the tail of the pre-split [`run_check`], so the
+/// `render_output` matrix tests remain the safety net for the output shape.
+pub fn emit_and_exit(result: &CheckResult, event: HookEvent) -> ! {
     let rendered = render_output(
         result.outcome,
         result.message.as_deref(),
@@ -830,7 +863,10 @@ pub fn interactive_terminal_help(
 /// misuse is not a hook context, and a hook's own non-hook situation must
 /// never block (ADR-0001). Invisible in production: Claude Code always pipes,
 /// so `is_terminal()` is false there.
-fn guard_interactive_terminal(
+///
+/// `pub` so the binary's logged-dispatch wrapper ([`crate`] consumers in `src/`)
+/// can reuse the same interactive-terminal guard as [`run_check_from_stdin`].
+pub fn guard_interactive_terminal(
     hook_name: &str,
     event: Option<HookEvent>,
     sample_override: Option<&str>,

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -14,6 +14,8 @@ pub mod compute_cost;
 pub mod log_askuserquestion;
 /// Append cost-per-commit records to `commits.jsonl`.
 pub mod log_commit;
+/// Append guard-denial audit records to `denials.jsonl`.
+pub mod log_denial;
 /// Append polish-nudge (`gh pr create`) records to `polish_nudges.jsonl`.
 pub mod log_polish_nudge;
 /// Append per-session cost records to `sessions.jsonl` at `SessionEnd`.
@@ -33,6 +35,7 @@ pub mod warn_stale;
 
 pub use log_askuserquestion::LogAskUserQuestion;
 pub use log_commit::LogCommit;
+pub use log_denial::log_denial;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_session::LogSession;
 pub use log_subagent::LogSubagent;

--- a/crates/metrics/src/log_denial.rs
+++ b/crates/metrics/src/log_denial.rs
@@ -1,0 +1,296 @@
+//! Append-only audit log for guard fires at the dispatch outcome→exit-code
+//! seam: one line per hard `deny` to `<metrics_dir>/denials.jsonl` (and per
+//! `nudge` when `CADENCE_LOG_NUDGES` is set).
+//!
+//! Called from the **binary** (`src/dispatch.rs`), not from a `Logger`: the
+//! denial is a side effect of an *enforcement* check, and only the binary knows
+//! the canonical registry hook name (`check.name()` diverges from it). The write
+//! must never perturb the block it is recording — every step is fail-open per
+//! ADR-0001, so a full disk or a read-only metrics dir degrades to a no-op and
+//! the guard still exits 2 with its unchanged stderr.
+//!
+//! **Privacy by construction:** the record names *which guard fired on which
+//! tool in which repo* — never *what was blocked*. It never reads the command
+//! text, file path, or edited content off the [`HookInput`]; a unit test asserts
+//! those keys are absent.
+
+use crate::common;
+use cadence_hooks_core::{HookEvent, HookInput, Outcome};
+use serde_json::{Value, json};
+use std::io::Write;
+
+/// Record a guard's decision at the dispatch seam.
+///
+/// - `Block` → always logged as `decision: "deny"`.
+/// - `Nudge` / `LoopBlock` → logged as `decision: "nudge"` **only** when
+///   `CADENCE_LOG_NUDGES` is set to a non-empty value (default OFF, so the
+///   common advisory path adds zero hot-path I/O).
+/// - `Allow` → never logged.
+///
+/// `hook` is the canonical registry name threaded from the binary (e.g.
+/// `terminology`, not the `Check::name()` value `terminology-guard`).
+pub fn log_denial(hook: &str, event: HookEvent, input: &HookInput, outcome: Outcome) {
+    let Some(decision) = decision_for(outcome, nudges_enabled()) else {
+        return;
+    };
+
+    let record = build_denial_record(hook, event, input, decision);
+
+    let dir = common::metrics_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join("denials.jsonl");
+
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        // One `write_all` of the record + newline, so a concurrent append from
+        // another session can't interleave a record with its trailing newline.
+        // `record` is compact JSON — one line, no embedded newlines.
+        let mut line = record.to_string();
+        line.push('\n');
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+/// True when `CADENCE_LOG_NUDGES` is set to a non-empty value.
+fn nudges_enabled() -> bool {
+    std::env::var("CADENCE_LOG_NUDGES")
+        .map(|v| !v.is_empty())
+        .unwrap_or(false)
+}
+
+/// Map an [`Outcome`] to the `decision` field, or `None` when nothing should be
+/// logged. Pure — `nudges_on` is passed in so the env read stays out of the
+/// mapping and the mapping is unit-testable. `LoopBlock` (advisory, exit 0) maps
+/// to `"nudge"` alongside `Nudge`.
+fn decision_for(outcome: Outcome, nudges_on: bool) -> Option<&'static str> {
+    match outcome {
+        Outcome::Block => Some("deny"),
+        Outcome::Nudge | Outcome::LoopBlock => nudges_on.then_some("nudge"),
+        Outcome::Allow => None,
+    }
+}
+
+/// Build the `denials.jsonl` record. Pure — no I/O beyond the git query behind
+/// [`common::repo_basename`]. Reads only non-sensitive context off the input
+/// (tool name, session id, agent id, cwd→repo) — never the command, file path,
+/// or edited content.
+fn build_denial_record(hook: &str, event: HookEvent, input: &HookInput, decision: &str) -> Value {
+    json!({
+        "ts": common::utc_timestamp(),
+        "hook": hook,
+        "event": event.name(),
+        "decision": decision,
+        "tool": input.tool_name(),
+        "repo": common::repo_basename(input.cwd.as_deref()),
+        "sessionId": input.session_id(),
+        "agentId": input.agent_id(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::ToolInput;
+
+    fn edit_input() -> HookInput {
+        // A payload carrying sensitive fields (command, file_path, content) — the
+        // record must expose none of them.
+        HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(ToolInput {
+                file_path: Some("/secret/path/notes.md".into()),
+                command: Some("rm -rf /secret".into()),
+                new_string: Some("whitelist the host".into()),
+                ..Default::default()
+            }),
+            cwd: Some("/tmp".into()),
+            session_id: Some("sess-1".into()),
+            agent_id: Some("agent-9".into()),
+            ..Default::default()
+        }
+    }
+
+    // --- decision_for ---
+
+    #[test]
+    fn block_always_denies() {
+        assert_eq!(decision_for(Outcome::Block, false), Some("deny"));
+        assert_eq!(decision_for(Outcome::Block, true), Some("deny"));
+    }
+
+    #[test]
+    fn allow_never_logs() {
+        assert_eq!(decision_for(Outcome::Allow, false), None);
+        assert_eq!(decision_for(Outcome::Allow, true), None);
+    }
+
+    #[test]
+    fn nudge_and_loop_block_gated_on_env() {
+        assert_eq!(decision_for(Outcome::Nudge, false), None);
+        assert_eq!(decision_for(Outcome::Nudge, true), Some("nudge"));
+        assert_eq!(decision_for(Outcome::LoopBlock, false), None);
+        assert_eq!(decision_for(Outcome::LoopBlock, true), Some("nudge"));
+    }
+
+    // --- build_denial_record ---
+
+    #[test]
+    fn record_has_expected_fields() {
+        let rec = build_denial_record("terminology", HookEvent::PreToolUse, &edit_input(), "deny");
+        assert_eq!(rec["hook"], "terminology");
+        assert_eq!(rec["event"], "PreToolUse");
+        assert_eq!(rec["decision"], "deny");
+        assert_eq!(rec["tool"], "Edit");
+        assert_eq!(rec["sessionId"], "sess-1");
+        assert_eq!(rec["agentId"], "agent-9");
+        assert!(rec["ts"].is_string());
+        assert!(rec["repo"].is_string());
+    }
+
+    #[test]
+    fn record_omits_sensitive_keys() {
+        // Privacy by construction: the record must never carry command content,
+        // file paths, or edited text — only which guard fired on which tool.
+        let rec = build_denial_record("git-safety", HookEvent::PreToolUse, &edit_input(), "deny");
+        let obj = rec.as_object().expect("record is an object");
+        for forbidden in ["command", "file_path", "filePath", "content", "new_string"] {
+            assert!(
+                !obj.contains_key(forbidden),
+                "record must not carry '{forbidden}': {rec}"
+            );
+        }
+        // And no *value* in the record leaks the sensitive strings.
+        let serialized = rec.to_string();
+        assert!(
+            !serialized.contains("/secret/path"),
+            "leaked file path: {serialized}"
+        );
+        assert!(
+            !serialized.contains("rm -rf"),
+            "leaked command: {serialized}"
+        );
+        assert!(
+            !serialized.contains("whitelist"),
+            "leaked content: {serialized}"
+        );
+    }
+
+    #[test]
+    fn record_main_thread_agent_id_is_null() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            cwd: Some("/tmp".into()),
+            session_id: Some("s".into()),
+            ..Default::default()
+        };
+        let rec = build_denial_record("guard-push-remote", HookEvent::PreToolUse, &input, "deny");
+        assert!(rec["agentId"].is_null());
+    }
+
+    // --- log_denial end-to-end (tempdir) ---
+
+    /// Serialize the env-mutating tests: `CADENCE_METRICS_DIR` and
+    /// `CADENCE_LOG_NUDGES` are process-global.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_metrics_dir<F: FnOnce()>(dir: &std::path::Path, nudges: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test in this module.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", dir);
+            match nudges {
+                Some(v) => std::env::set_var("CADENCE_LOG_NUDGES", v),
+                None => std::env::remove_var("CADENCE_LOG_NUDGES"),
+            }
+        }
+        f();
+        // SAFETY: serialized against every other env-mutating test in this module.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+            std::env::remove_var("CADENCE_LOG_NUDGES");
+        }
+    }
+
+    fn read_lines(dir: &std::path::Path) -> Vec<Value> {
+        let path = dir.join("denials.jsonl");
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str(l).expect("each line is valid JSON"))
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    #[test]
+    fn block_writes_one_deny_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), None, || {
+            log_denial(
+                "terminology",
+                HookEvent::PreToolUse,
+                &edit_input(),
+                Outcome::Block,
+            );
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["decision"], "deny");
+        assert_eq!(rows[0]["hook"], "terminology");
+    }
+
+    #[test]
+    fn allow_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), None, || {
+            log_denial(
+                "terminology",
+                HookEvent::PreToolUse,
+                &edit_input(),
+                Outcome::Allow,
+            );
+        });
+        assert!(
+            read_lines(tmp.path()).is_empty(),
+            "Allow must not write a row"
+        );
+        assert!(!tmp.path().join("denials.jsonl").exists());
+    }
+
+    #[test]
+    fn nudge_skipped_without_env_logged_with_env() {
+        let tmp = tempfile::tempdir().unwrap();
+        // Env unset → no row.
+        with_metrics_dir(tmp.path(), None, || {
+            log_denial(
+                "warn-main-branch",
+                HookEvent::PreToolUse,
+                &edit_input(),
+                Outcome::Nudge,
+            );
+        });
+        assert!(
+            read_lines(tmp.path()).is_empty(),
+            "nudge without env must not write"
+        );
+
+        // Env set → exactly one nudge row.
+        with_metrics_dir(tmp.path(), Some("1"), || {
+            log_denial(
+                "warn-main-branch",
+                HookEvent::PreToolUse,
+                &edit_input(),
+                Outcome::Nudge,
+            );
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["decision"], "nudge");
+    }
+}

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,0 +1,51 @@
+//! Logged check dispatch: the binary-level bridge that records a guard's
+//! decision to `denials.jsonl` between deciding and exiting.
+//!
+//! `core` decides (it holds the [`Check`] trait) but cannot reach the metrics
+//! crate's writer (metrics depends on core, not the reverse); the binary depends
+//! on both **and** is the only layer that knows the canonical registry hook name
+//! (`Check::name()` diverges from it — e.g. `terminology-guard` vs the registry
+//! `terminology`). So the denial write lives here, calling
+//! [`cadence_hooks_metrics::log_denial`] with the name threaded from
+//! `main::hook_name`.
+//!
+//! This mirrors [`cadence_hooks_core::run_check_from_stdin`] step for step — the
+//! interactive-terminal guard, fail-open stdin parse, effort-skip — and adds
+//! exactly one call (the denial write) on the decided-outcome path, so the block
+//! the guard emits and its exit code are byte-for-byte unchanged.
+
+use cadence_hooks_core::{
+    Check, HookEvent, HookInput, Outcome, decide_check, emit_and_exit, guard_interactive_terminal,
+};
+use std::process;
+
+/// Run a single check from stdin, record its decision to `denials.jsonl`, then
+/// emit and exit exactly as [`cadence_hooks_core::run_check_from_stdin`] would.
+///
+/// `hook` is the canonical registry name from `main::hook_name`; when `None`
+/// (e.g. a subcommand with no registry mapping) it falls back to `check.name()`.
+pub fn run_logged_check(check: &dyn Check, event: HookEvent, hook: Option<&str>) -> ! {
+    guard_interactive_terminal(check.name(), Some(event), None);
+    let input = match HookInput::from_stdin() {
+        Ok(input) => input,
+        Err(e) => {
+            eprintln!("cadence-hooks: {e}");
+            process::exit(0); // Fail open on parse errors (ADR-0001)
+        }
+    };
+    match decide_check(check, &input) {
+        // Effort-skipped → silent Allow, nothing to record.
+        None => process::exit(Outcome::Allow.code()),
+        Some(result) => {
+            // Record before emitting. The write is fully fail-open, so it cannot
+            // perturb the block message or the exit code that follows.
+            cadence_hooks_metrics::log_denial(
+                hook.unwrap_or_else(|| check.name()),
+                event,
+                &input,
+                result.outcome,
+            );
+            emit_and_exit(&result, event);
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,7 +5,7 @@
 //! with 0 (allow), 1 (warn), or 2 (block). The CLI commands (`list`, `doctor`,
 //! `configure`, `try`, `session declare`/`status`) take no stdin.
 
-use cadence_hooks_core::{HookEvent, run_check_from_stdin, run_logger_from_stdin};
+use cadence_hooks_core::{HookEvent, run_logger_from_stdin};
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
 use std::process;
 
@@ -18,6 +18,7 @@ fn under_claude_code() -> bool {
 }
 
 mod configure;
+mod dispatch;
 mod doctor;
 mod registry;
 mod try_hook;
@@ -586,6 +587,15 @@ fn main() {
         }
     }
 
+    // The canonical registry hook name for the dispatched subcommand, threaded
+    // into the logged-dispatch wrapper so `denials.jsonl` records the name that
+    // cross-references `registry::HOOKS` / `hookFiredTotal` — not the divergent
+    // `Check::name()` (e.g. `terminology`, not `terminology-guard`). `Copy`
+    // (`Option<&'static str>`), so binding it here borrows `&cli.command` before
+    // the `match` below moves it. `None` for the CLI-action subcommands, which
+    // never dispatch a check.
+    let canonical_hook = hook_name(&cli.command);
+
     // Event type aliases for readability at callsites.
     let pre = HookEvent::PreToolUse;
     let post = HookEvent::PostToolUse;
@@ -629,51 +639,70 @@ fn main() {
             process::exit(doctor::run(root.as_deref(), quiet).into());
         }
         Commands::Cadence(cmd) => match cmd {
-            CadenceCommands::Terminology => {
-                run_check_from_stdin(&cadence_hooks_cadence::terminology::TerminologyGuard, pre)
-            }
-            CadenceCommands::OrphanedTodos => run_check_from_stdin(
+            CadenceCommands::Terminology => dispatch::run_logged_check(
+                &cadence_hooks_cadence::terminology::TerminologyGuard,
+                pre,
+                canonical_hook,
+            ),
+            CadenceCommands::OrphanedTodos => dispatch::run_logged_check(
                 &cadence_hooks_cadence::block_orphaned_todos::OrphanedTodoGuard,
                 pre,
+                canonical_hook,
             ),
-            CadenceCommands::PreventSecretLeaks => run_check_from_stdin(
+            CadenceCommands::PreventSecretLeaks => dispatch::run_logged_check(
                 &cadence_hooks_cadence::prevent_secret_leaks::SecretLeaksGuard,
                 pre,
+                canonical_hook,
             ),
-            CadenceCommands::PreventSecretWrites => run_check_from_stdin(
+            CadenceCommands::PreventSecretWrites => dispatch::run_logged_check(
                 &cadence_hooks_cadence::prevent_secret_writes::SecretWritesGuard,
                 pre,
+                canonical_hook,
             ),
-            CadenceCommands::MemoryGuard => {
-                run_check_from_stdin(&cadence_hooks_cadence::memory_guard::MemoryGuard, pre)
-            }
-            CadenceCommands::GitSafety => {
-                run_check_from_stdin(&cadence_hooks_cadence::git_safety::GitSafetyGuard, pre)
-            }
-            CadenceCommands::LineEndings => run_check_from_stdin(
+            CadenceCommands::MemoryGuard => dispatch::run_logged_check(
+                &cadence_hooks_cadence::memory_guard::MemoryGuard,
+                pre,
+                canonical_hook,
+            ),
+            CadenceCommands::GitSafety => dispatch::run_logged_check(
+                &cadence_hooks_cadence::git_safety::GitSafetyGuard,
+                pre,
+                canonical_hook,
+            ),
+            CadenceCommands::LineEndings => dispatch::run_logged_check(
                 &cadence_hooks_cadence::validate_line_endings::LineEndingsGuard,
                 pre,
+                canonical_hook,
             ),
-            CadenceCommands::EnvVars => {
-                run_check_from_stdin(&cadence_hooks_cadence::validate_env_vars::EnvVarGuard, pre)
-            }
-            CadenceCommands::WarnDocsUpdate => run_check_from_stdin(
+            CadenceCommands::EnvVars => dispatch::run_logged_check(
+                &cadence_hooks_cadence::validate_env_vars::EnvVarGuard,
+                pre,
+                canonical_hook,
+            ),
+            CadenceCommands::WarnDocsUpdate => dispatch::run_logged_check(
                 &cadence_hooks_cadence::warn_docs_update::WarnDocsUpdate,
                 pre,
+                canonical_hook,
             ),
-            CadenceCommands::WarnOvershare => {
-                run_check_from_stdin(&cadence_hooks_cadence::warn_overshare::WarnOvershare, pre)
-            }
-            CadenceCommands::NudgePolishBeforePr => run_check_from_stdin(
+            CadenceCommands::WarnOvershare => dispatch::run_logged_check(
+                &cadence_hooks_cadence::warn_overshare::WarnOvershare,
+                pre,
+                canonical_hook,
+            ),
+            CadenceCommands::NudgePolishBeforePr => dispatch::run_logged_check(
                 &cadence_hooks_cadence::nudge_polish_before_pr::NudgePolishBeforePr,
                 pre,
+                canonical_hook,
             ),
-            CadenceCommands::MarkdownLint => {
-                run_check_from_stdin(&cadence_hooks_cadence::markdown_lint::MarkdownLint, pre)
-            }
-            CadenceCommands::RedactExternalContent => run_check_from_stdin(
+            CadenceCommands::MarkdownLint => dispatch::run_logged_check(
+                &cadence_hooks_cadence::markdown_lint::MarkdownLint,
+                pre,
+                canonical_hook,
+            ),
+            CadenceCommands::RedactExternalContent => dispatch::run_logged_check(
                 &cadence_hooks_cadence::redact_external_content::RedactExternalContent,
                 pre,
+                canonical_hook,
             ),
             CadenceCommands::RecordPolish {
                 repo_root,
@@ -684,96 +713,120 @@ fn main() {
             }
         },
         Commands::Guardrails(cmd) => match cmd {
-            GuardrailsCommands::GuardPushRemote => run_check_from_stdin(
+            GuardrailsCommands::GuardPushRemote => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_push_remote::PushRemoteGuard,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::GuardGhDangerous => run_check_from_stdin(
+            GuardrailsCommands::GuardGhDangerous => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_gh_dangerous::GhDangerousGuard,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::GuardGhWrite => {
-                run_check_from_stdin(&cadence_hooks_guardrails::guard_gh_write::GhWriteGuard, pre)
-            }
-            GuardrailsCommands::GuardGitInit => run_check_from_stdin(
+            GuardrailsCommands::GuardGhWrite => dispatch::run_logged_check(
+                &cadence_hooks_guardrails::guard_gh_write::GhWriteGuard,
+                pre,
+                canonical_hook,
+            ),
+            GuardrailsCommands::GuardGitInit => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_git_init::GuardGitInit,
                 post,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnMainBranch => run_check_from_stdin(
+            GuardrailsCommands::WarnMainBranch => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_main_branch::WarnMainBranch,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnSubagentWorktree => run_check_from_stdin(
+            GuardrailsCommands::WarnSubagentWorktree => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_subagent_worktree::WarnSubagentWorktree,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::CheckIdleReturn => run_check_from_stdin(
+            GuardrailsCommands::CheckIdleReturn => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::check_idle_return::CheckIdleReturn,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnBranchBase => run_check_from_stdin(
+            GuardrailsCommands::WarnBranchBase => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_branch_base::WarnBranchBase,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnCronDatetime => run_check_from_stdin(
+            GuardrailsCommands::WarnCronDatetime => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_cron_datetime::WarnCronDatetime,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::NudgeUpgradeAfterPush => run_check_from_stdin(
+            GuardrailsCommands::NudgeUpgradeAfterPush => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::nudge_upgrade_after_push::NudgeUpgradeAfterPush,
                 post,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnUntracked => run_check_from_stdin(
+            GuardrailsCommands::WarnUntracked => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_untracked::WarnUntrackedFiles,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::GuardDotfiles => run_check_from_stdin(
+            GuardrailsCommands::GuardDotfiles => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_dotfiles::GuardDotfiles,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnPrIssueLink => run_check_from_stdin(
+            GuardrailsCommands::WarnPrIssueLink => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_pr_issue_link::WarnPrIssueLink,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnIssueTracker => run_check_from_stdin(
+            GuardrailsCommands::WarnIssueTracker => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_issue_tracker::WarnIssueTracker,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::VerifyPrAutoclose => run_check_from_stdin(
+            GuardrailsCommands::VerifyPrAutoclose => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::verify_pr_autoclose::VerifyPrAutoclose,
                 post,
+                canonical_hook,
             ),
-            GuardrailsCommands::GuardOpVaultScan => run_check_from_stdin(
+            GuardrailsCommands::GuardOpVaultScan => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_op_vault_scan::OpVaultScanGuard,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnCurlAlias => run_check_from_stdin(
+            GuardrailsCommands::WarnCurlAlias => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_curl_alias::WarnCurlAlias,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnGhMergePreflight => run_check_from_stdin(
+            GuardrailsCommands::WarnGhMergePreflight => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_gh_merge_preflight::WarnGhMergePreflight,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnCoderabbitRetrigger => run_check_from_stdin(
+            GuardrailsCommands::WarnCoderabbitRetrigger => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_coderabbit_retrigger::WarnCoderabbitRetrigger,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::WarnAliasParsing => run_check_from_stdin(
+            GuardrailsCommands::WarnAliasParsing => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::warn_alias_parsing::WarnAliasParsing,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::GuardBrowserDevice => run_check_from_stdin(
+            GuardrailsCommands::GuardBrowserDevice => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_browser_device::GuardBrowserDevice,
                 pre,
+                canonical_hook,
             ),
-            GuardrailsCommands::InjectGhContext => run_check_from_stdin(
+            GuardrailsCommands::InjectGhContext => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::inject_gh_context::InjectGhContext,
                 session,
+                canonical_hook,
             ),
-            GuardrailsCommands::EnforceWorktree => run_check_from_stdin(
+            GuardrailsCommands::EnforceWorktree => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::enforce_worktree::EnforceWorktree,
                 pre,
+                canonical_hook,
             ),
             GuardrailsCommands::DismissMainBranchWarn { for_ } => {
                 cadence_hooks_guardrails::dismiss_main_branch_warn::run_dismiss(&for_);
@@ -783,27 +836,32 @@ fn main() {
             }
         },
         Commands::Rules(cmd) => match cmd {
-            RulesCommands::ValidateFrontmatter => run_check_from_stdin(
+            RulesCommands::ValidateFrontmatter => dispatch::run_logged_check(
                 &cadence_hooks_rules::validate_skill_frontmatter::ValidateSkillFrontmatter,
                 pre,
+                canonical_hook,
             ),
-            RulesCommands::SecurityPatterns => run_check_from_stdin(
+            RulesCommands::SecurityPatterns => dispatch::run_logged_check(
                 &cadence_hooks_rules::check_security_patterns::SecurityPatternScanner,
                 post,
+                canonical_hook,
             ),
-            RulesCommands::WarnRecommendedOption => run_check_from_stdin(
+            RulesCommands::WarnRecommendedOption => dispatch::run_logged_check(
                 &cadence_hooks_rules::askuserquestion::WarnRecommendedOption,
                 pre,
+                canonical_hook,
             ),
-            RulesCommands::WarnEmptyAnswers => run_check_from_stdin(
+            RulesCommands::WarnEmptyAnswers => dispatch::run_logged_check(
                 &cadence_hooks_rules::askuserquestion::WarnEmptyAnswers,
                 post,
+                canonical_hook,
             ),
         },
         Commands::Obsidian(cmd) => match cmd {
-            ObsidianCommands::TrashGuard => run_check_from_stdin(
+            ObsidianCommands::TrashGuard => dispatch::run_logged_check(
                 &cadence_hooks_obsidian::trash_guard::ObsidianTrashGuard,
                 pre,
+                canonical_hook,
             ),
         },
         Commands::Metrics(cmd) => match cmd {
@@ -837,32 +895,44 @@ fn main() {
             ),
             // warn-stale is a SessionStart *check*, not a logger — it reads the
             // metrics dir's mtimes rather than reacting to a tool event.
-            MetricsCommands::WarnStale => {
-                run_check_from_stdin(&cadence_hooks_metrics::WarnStale, session)
-            }
+            MetricsCommands::WarnStale => dispatch::run_logged_check(
+                &cadence_hooks_metrics::WarnStale,
+                session,
+                canonical_hook,
+            ),
         },
         Commands::Lab(cmd) => match cmd {
-            LabCommands::PersonaNudge => {
-                run_check_from_stdin(&cadence_hooks_lab::nudge::PersonaNudge, session)
-            }
-            LabCommands::PersonaGate => {
-                run_check_from_stdin(&cadence_hooks_lab::gate::PersonaGate, post)
-            }
+            LabCommands::PersonaNudge => dispatch::run_logged_check(
+                &cadence_hooks_lab::nudge::PersonaNudge,
+                session,
+                canonical_hook,
+            ),
+            LabCommands::PersonaGate => dispatch::run_logged_check(
+                &cadence_hooks_lab::gate::PersonaGate,
+                post,
+                canonical_hook,
+            ),
         },
         Commands::Session(cmd) => match cmd {
-            SessionCommands::Start => {
-                run_check_from_stdin(&cadence_hooks_session::start::Start, session)
-            }
+            SessionCommands::Start => dispatch::run_logged_check(
+                &cadence_hooks_session::start::Start,
+                session,
+                canonical_hook,
+            ),
             SessionCommands::Heartbeat => run_logger_from_stdin(
                 &cadence_hooks_session::heartbeat::Heartbeat,
                 registry::sample_for("session", "heartbeat"),
             ),
-            SessionCommands::Guard => {
-                run_check_from_stdin(&cadence_hooks_session::guard::Guard, pre)
-            }
-            SessionCommands::WarnBranchDrift => {
-                run_check_from_stdin(&cadence_hooks_session::branch_drift::WarnBranchDrift, pre)
-            }
+            SessionCommands::Guard => dispatch::run_logged_check(
+                &cadence_hooks_session::guard::Guard,
+                pre,
+                canonical_hook,
+            ),
+            SessionCommands::WarnBranchDrift => dispatch::run_logged_check(
+                &cadence_hooks_session::branch_drift::WarnBranchDrift,
+                pre,
+                canonical_hook,
+            ),
             SessionCommands::End => run_logger_from_stdin(
                 &cadence_hooks_session::end::End,
                 registry::sample_for("session", "end"),
@@ -871,9 +941,11 @@ fn main() {
                 &cadence_hooks_session::backstop::BackstopRecord,
                 registry::sample_for("session", "backstop-record"),
             ),
-            SessionCommands::BackstopWarn => {
-                run_check_from_stdin(&cadence_hooks_session::backstop::BackstopWarn, session)
-            }
+            SessionCommands::BackstopWarn => dispatch::run_logged_check(
+                &cadence_hooks_session::backstop::BackstopWarn,
+                session,
+                canonical_hook,
+            ),
             SessionCommands::Declare {
                 intent,
                 touching,

--- a/tests/denial_log.rs
+++ b/tests/denial_log.rs
@@ -1,0 +1,149 @@
+//! Integration tests for the `denials.jsonl` audit log written at the dispatch
+//! outcome→exit-code seam (O1).
+//!
+//! Drives the built binary end to end: a terminology-violating Edit piped to
+//! `cadence terminology` must (a) still block byte-identically, and (b) append
+//! exactly one privacy-safe deny row to `denials.jsonl`. A companion run against
+//! an unwritable metrics dir proves the write is fail-open and never perturbs
+//! the block (ADR-0001).
+
+use std::io::Write;
+use std::process::{Command, Output};
+
+fn cadence_hooks() -> Command {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_cadence-hooks"));
+    // Isolate from the test runner's session env so the block output and the
+    // logging decision are deterministic.
+    cmd.env_remove("CADENCE_BYPASS");
+    cmd.env_remove("CADENCE_DISABLE");
+    cmd.env_remove("CADENCE_LOG_NUDGES");
+    cmd.env_remove("CADENCE_NO_FEEDBACK_FOOTER");
+    cmd.env_remove("CLAUDECODE");
+    cmd.env_remove("CLAUDE_EFFORT");
+    cmd
+}
+
+/// A terminology-violating Edit against a non-excluded, non-git path. The
+/// `old_string` carries no violation, so the introduced `whitelist` fires a
+/// hard block (exit 2).
+const BLOCK_PAYLOAD: &str = r#"{"tool_name":"Edit","tool_input":{"file_path":"/tmp/o1-denial-it/notes.md","new_string":"we should whitelist this host","old_string":"we should permit this host"},"session_id":"itsess","cwd":"/tmp/o1-denial-it"}"#;
+
+fn run_terminology(metrics_dir: &std::path::Path) -> Output {
+    let mut cmd = cadence_hooks();
+    cmd.args(["cadence", "terminology"]);
+    cmd.env("CADENCE_METRICS_DIR", metrics_dir);
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn binary");
+    if let Some(ref mut stdin) = child.stdin {
+        match stdin.write_all(BLOCK_PAYLOAD.as_bytes()) {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(e) => panic!("failed to write child stdin: {e}"),
+        }
+    }
+    child.wait_with_output().expect("failed to wait on binary")
+}
+
+fn denial_rows(metrics_dir: &std::path::Path) -> Vec<serde_json::Value> {
+    let path = metrics_dir.join("denials.jsonl");
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => contents
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l).expect("each denials.jsonl line is valid JSON"))
+            .collect(),
+        Err(_) => vec![],
+    }
+}
+
+#[test]
+fn block_writes_one_privacy_safe_deny_row() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out = run_terminology(tmp.path());
+
+    // The block itself is unchanged: exit 2, block message + feedback footer.
+    assert_eq!(out.status.code(), Some(2), "terminology block must exit 2");
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("BLOCKED: Inclusive terminology"),
+        "block message present: {stderr}"
+    );
+    assert!(
+        stderr.contains("whitelist"),
+        "names the offending term: {stderr}"
+    );
+    assert!(
+        stderr.contains("/cadence:feedback"),
+        "feedback footer present: {stderr}"
+    );
+    assert!(out.stdout.is_empty(), "a block must emit no stdout");
+
+    // Exactly one deny row, with the canonical hook name and no sensitive keys.
+    let rows = denial_rows(tmp.path());
+    assert_eq!(rows.len(), 1, "exactly one denial row: {rows:?}");
+    let row = &rows[0];
+    assert_eq!(
+        row["hook"], "terminology",
+        "canonical registry name, not Check::name()"
+    );
+    assert_eq!(row["decision"], "deny");
+    assert_eq!(row["event"], "PreToolUse");
+    assert_eq!(row["tool"], "Edit");
+    assert_eq!(row["sessionId"], "itsess");
+    assert!(row["ts"].is_string());
+    assert!(row["repo"].is_string());
+
+    // Privacy by construction: no command, file path, or edited content anywhere.
+    let obj = row.as_object().expect("row is an object");
+    for forbidden in ["command", "file_path", "filePath", "content", "new_string"] {
+        assert!(
+            !obj.contains_key(forbidden),
+            "row must not carry '{forbidden}': {row}"
+        );
+    }
+    let serialized = row.to_string();
+    assert!(
+        !serialized.contains("/tmp/o1-denial-it"),
+        "leaked path: {serialized}"
+    );
+    assert!(
+        !serialized.contains("host"),
+        "leaked edited content: {serialized}"
+    );
+}
+
+#[test]
+fn logging_does_not_perturb_the_block_when_write_fails() {
+    // Byte-identity: the block's stderr and exit code must be the same whether
+    // the denial write succeeds (writable dir) or fail-opens (unwritable dir).
+    // This is the load-bearing "logger must not touch enforcement output" check.
+    let ok = tempfile::tempdir().unwrap();
+    let writable = run_terminology(ok.path());
+
+    // An unwritable metrics dir: a path whose parent is a regular file, so
+    // create_dir_all fails and the writer degrades to a no-op.
+    let blocker_dir = tempfile::tempdir().unwrap();
+    let blocker_file = blocker_dir.path().join("not-a-dir");
+    std::fs::write(&blocker_file, b"x").unwrap();
+    let unwritable_metrics = blocker_file.join("metrics");
+    let failopen = run_terminology(&unwritable_metrics);
+
+    assert_eq!(writable.status.code(), Some(2));
+    assert_eq!(
+        failopen.status.code(),
+        Some(2),
+        "fail-open write still exits 2"
+    );
+    assert_eq!(
+        writable.stderr, failopen.stderr,
+        "block stderr must be byte-identical regardless of write outcome"
+    );
+    assert_eq!(writable.stdout, failopen.stdout, "no stdout in either case");
+
+    // The fail-open run wrote nothing; the writable run wrote exactly one row.
+    assert!(!unwritable_metrics.join("denials.jsonl").exists());
+    assert_eq!(denial_rows(ok.path()).len(), 1);
+}

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -543,16 +543,19 @@ fn main_rs_event_types() -> BTreeMap<String, String> {
 
     let mut result = BTreeMap::new();
 
-    // Find `run_check_from_stdin(&module::Check, pre)` or `post)` patterns.
-    // The callsite format is: run_check_from_stdin(&..., pre) or run_check_from_stdin(&..., post)
-    // We need to correlate with the match arm above it to get the subcommand name.
+    // Find `dispatch::run_logged_check(&module::Check, pre, canonical_hook)` (the
+    // logged-dispatch wrapper that records denials) or the legacy
+    // `run_check_from_stdin(&..., pre)` form. The event variable (`pre`/`post`/
+    // `session`) sits in the same position in both — the trailing `canonical_hook`
+    // arg lands beyond the 3-line correlation window, so the event scan is
+    // unaffected. We correlate with the match arm above to get the subcommand.
     //
-    // Strategy: scan for lines containing `run_check_from_stdin` and extract the event
-    // variable (`pre` or `post`), then look backwards for the enum variant.
+    // Strategy: scan for lines containing the dispatch call, extract the event
+    // variable, then look backwards for the enum variant.
 
     let lines: Vec<&str> = content.lines().collect();
     for (i, line) in lines.iter().enumerate() {
-        if !line.contains("run_check_from_stdin") {
+        if !line.contains("run_logged_check") && !line.contains("run_check_from_stdin") {
             continue;
         }
 
@@ -579,37 +582,45 @@ fn main_rs_event_types() -> BTreeMap<String, String> {
         for j in (0..=i).rev() {
             let prev = lines[j];
             if prev.contains("Commands::") {
-                // Extract variant name, convert to kebab-case subcommand
-                if let Some(variant) = prev.split("::").last() {
-                    // Strip everything after => (handles both `Variant => {` and
-                    // `Variant => run_check_from_stdin(` formatting)
-                    let variant = variant.split("=>").next().unwrap_or("").trim();
-                    let subcmd = to_kebab_case(variant);
+                // Extract the variant name, convert to kebab-case subcommand.
+                //
+                // rustfmt collapses a single-expression arm onto one line
+                // (`CadenceCommands::Terminology => dispatch::run_logged_check(`),
+                // so the arm line also carries the `dispatch::run_logged_check`
+                // call — `split("::").last()` would grab the call token. Take the
+                // identifier immediately after the FIRST `Commands::` instead;
+                // this reads the variant cleanly from both the collapsed form and
+                // the older `Variant => {` block form.
+                let after = prev.split("Commands::").nth(1).unwrap_or("");
+                let variant: String = after
+                    .chars()
+                    .take_while(|c| c.is_alphanumeric() || *c == '_')
+                    .collect();
+                let subcmd = to_kebab_case(&variant);
 
-                    // Determine plugin group from the Commands enum.
-                    //
-                    // Logger-dispatched hooks (metrics, session heartbeat) use
-                    // run_logger_from_stdin and carry no HookEvent, so they
-                    // never reach this scan — only Check-dispatched hooks are
-                    // mapped here.
-                    let plugin = if prev.contains("CadenceCommands") {
-                        "cadence"
-                    } else if prev.contains("GuardrailsCommands") {
-                        "guardrails"
-                    } else if prev.contains("RulesCommands") {
-                        "rules"
-                    } else if prev.contains("ObsidianCommands") {
-                        "obsidian"
-                    } else if prev.contains("LabCommands") {
-                        "lab"
-                    } else if prev.contains("SessionCommands") {
-                        "session"
-                    } else {
-                        continue;
-                    };
+                // Determine plugin group from the Commands enum.
+                //
+                // Logger-dispatched hooks (metrics, session heartbeat) use
+                // run_logger_from_stdin and carry no HookEvent, so they
+                // never reach this scan — only Check-dispatched hooks are
+                // mapped here.
+                let plugin = if prev.contains("CadenceCommands") {
+                    "cadence"
+                } else if prev.contains("GuardrailsCommands") {
+                    "guardrails"
+                } else if prev.contains("RulesCommands") {
+                    "rules"
+                } else if prev.contains("ObsidianCommands") {
+                    "obsidian"
+                } else if prev.contains("LabCommands") {
+                    "lab"
+                } else if prev.contains("SessionCommands") {
+                    "session"
+                } else {
+                    continue;
+                };
 
-                    result.insert(format!("{plugin} {subcmd}"), event.to_string());
-                }
+                result.insert(format!("{plugin} {subcmd}"), event.to_string());
                 break;
             }
         }


### PR DESCRIPTION
No guard records anything when it fires or blocks — a deny lands as prose in the tool result, invisible to any tally, and a false-positive block leaves zero on-disk trace. The guards are the engine's most consequential runtime behavior and its least measured (2026-07-02 session-mining report, blind spot 1). This adds one append-only audit writer at the dispatch seam — not per-guard instrumentation.

## What

- `core::run_check` split into `decide_check` + `emit_and_exit` (behavior-identical decomposition; `run_check` remains as the composition — existing callers unchanged).
- New binary-level `dispatch::run_logged_check`: parse stdin once → decide → log the outcome → emit. All 48 block-capable check arms route through it; loggers are untouched (they never block). The canonical registry hook name is threaded from `main.rs::hook_name` — `check.name()` diverges from registry names for ~8 guards and would break cross-referencing.
- New `metrics::log_denial`: appends `{ts, hook, event, decision, tool, repo, sessionId, agentId}` to `<metrics_dir>/denials.jsonl` on every **deny**; nudges only under `CADENCE_LOG_NUDGES=1` (no hot-path I/O by default). Privacy by construction: the writer never receives command content, file paths, or the block message — the record says which guard fired on which tool in which repo, never what was blocked. Compact serde JSON, single `write_all` O_APPEND, every branch fail-open (ADR-0001).
- `HookInput` gains additive `agent_id` (also the standing prerequisite for subagent-scoped guard work).

## Evidence

- `cargo test` 153 passed / 0 failed; `cargo fmt --check` + `cargo clippy --all-targets -- -D warnings` clean — on the rebased tree over the record-polish and sessions.jsonl merges.
- **Byte-identity proof:** the same terminology-block payload produces exit 2 and byte-identical stderr before vs after (integration test diffs them), with exactly one denials row appearing after. Unwritable metrics dir → still exit 2, byte-identical stderr, no row (fail-open).
- Adversarial security review (independent): MERGE-SAFE-WITH-NITS — `log_denial` call graph verified panic-free (a panic pre-exit would have flipped a block to fail-open), single-stdin-parse parity with the old path, serde escaping kills JSONL forgery via crafted payload fields, no `deny_unknown_fields` regression. Sole nit: one `git rev-parse` subprocess on the deny path for repo basename — same pattern the existing loggers use.

Companion PRs: schema docs (cadence monorepo) and a profiler denies-by-hook table (meta-repo). Provenance: 2026-07-02 session-mining report, blind spot 1 — tracking issue deliberately skipped, ships same-day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
