### PR TITLE
chore(release): v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.44.0] - 2026-07-02
+
 ### Added
 
 - **`metrics warn-stale` — telemetry staleness alarm at SessionStart + a

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -178,7 +178,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -196,7 +196,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-core",
  "glob",
@@ -208,7 +208,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -220,7 +220,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -241,7 +241,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -253,7 +253,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -261,7 +261,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -271,7 +271,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.43.0"
+version = "0.44.0"
 dependencies = [
  "cadence-hooks-core",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.43.0"
+version = "0.44.0"
 edition = "2024"
 license = "BSL-1.1"
 authors = ["Cameron Sjo"]


### PR DESCRIPTION
Version bump 0.43.0 → 0.44.0 + CHANGELOG roll. Ships: CP0 session-marker primitives (#170), branch-scoped polish marker + record-polish (#172), warn-stale telemetry alarm (#171), sessions.jsonl per-session cost (#173), denials.jsonl guard-fire audit log (#174). Merging to main auto-tags v0.44.0 and builds the release; the cadence-metrics wiring PR (cadence#192) unblocks once the release exists (doctor skew gate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)