### PR TITLE
docs(changelog): backfill the missing [0.30.0] section (#140)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **docs(changelog): backfilled the missing `[0.30.0] - 2026-06-16` section**
+  (#140). The changelog jumped `[0.31.0]` → `[0.29.0]`; the three fixes that
+  shipped in v0.30.0 are now stamped into a versioned section.
+
 ## [0.44.0] - 2026-07-02
 
 ### Added
@@ -491,6 +497,44 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   field so an unknown model is loud rather than a silent zero. `scan-tokens`
   parsed the entire transcript on every commit; it now byte-scans past the
   marker and only JSON-parses the tail, bounding the per-commit hot-path cost.
+
+## [0.30.0] - 2026-06-16
+
+### Fixed
+
+- **cadence secret guards: block the `.env.<x>` family on Read/Grep/Write/Edit**
+  (#64 on claude-configurations). The `.env` family was classified two ways: the
+  Bash path used a component substring-minus-safe-suffix predicate over
+  `.env.<x>`, while the Read/Grep/Write/Edit tool path used exact membership
+  against `BLOCKED_FILENAMES` — which omitted `.env.prod`, `.env.dev`,
+  `.env.development.local`, `.env.docker`, and the rest. So `Read .env.prod` was
+  allowed while `cat .env.prod` was blocked — the most-used ingestion tools were
+  the weakest check. The family logic is now a single shared
+  `is_env_family_secret` helper called from both predicates, so the tool and
+  shell paths agree on one rule.
+- **guardrails: validate an explicit `git push <URL>` against ownership**
+  (#68 on claude-configurations). `extract_remote` rejected any non-remote token,
+  so an explicit push URL (HTTPS or SCP) was discarded and the guard resolved and
+  validated `origin` in its place — allowing an irrecoverable push to an
+  arbitrary unowned host whenever `origin` happened to be owned. The new
+  `extract_push_target` classifies the positional target as `Named`, `Url`, or
+  `None` (tracking fallback); a `Url` is validated directly via `check_owner`,
+  blocking unowned hosts and naming the actual URL in the block message, while
+  `Named`/`None` keep the existing resolve-through-git behavior. URL detection
+  reuses `host_and_repo_from_url` (the same parser `check_owner` uses) and covers
+  the user-less SCP form (`host:owner/repo.git`).
+- **session: the stale-sweep no longer prunes live peers, and drift baselines on
+  a declared branch** (#69, #70 on claude-configurations). `run_start` now
+  reads/builds/writes its own record (refreshing mtime) *before* calling
+  `sweep_stale`, eliminating the self-sweep-then-minimal-rebuild path that
+  stripped a quiet session's intent/touching on `/clear` or compaction;
+  `sweep_stale` also excludes the caller's own file, and the staleness threshold
+  rises 10 → 30 minutes so a long read/think phase stays out of reach. The
+  commit-time drift warning now baselines against a new `declared_branch` field
+  that moves only when *this* session runs its own checkout/switch (detected via
+  the heredoc-aware `is_branch_switch`), so a peer moving shared HEAD no longer
+  masks divergence. Old records parse with `declared_branch=None` via serde
+  defaults (fail-open) and self-heal on the next session start — no migration.
 
 ## [0.29.0] - 2026-06-10
 


### PR DESCRIPTION
Backfills the missing `[0.30.0] - 2026-06-16` section in `CHANGELOG.md`. The hand-maintained changelog jumped `[0.31.0]` straight to `[0.29.0]`; this stamps the three fixes that shipped in v0.30.0 into a versioned section:

- `.env.<x>` family coverage on Read/Grep/Write/Edit (parity with the Bash path)
- explicit `git push <URL>` ownership validation
- stale-sweep no longer prunes live peers; commit-time drift baselines on a declared branch

Verified: each fix is first-tagged at `v0.30.0` (not mis-merged into a later version), and bullet content is cross-checked against the commit bodies. Docs-only, additive.

Closes #140
