### PR TITLE
docs(hooks): add missing metrics loggers to hooks.md table (#178)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- docs(hooks): add missing metrics-logger rows (`log-session`, `log-polish-nudge`, `log-ask-user-question`) to the cadence-metrics table in `docs/hooks.md` (#178)
+
 ## [0.44.0] - 2026-07-02
 
 ### Added

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -95,6 +95,9 @@ exit 0. They never block a tool call (see
 | `snapshot` | PreToolUse (Bash, `git commit`) | Snapshot HEAD before a commit, so `log-commit` can tell whether it landed |
 | `log-commit` | PostToolUse (Bash, `git commit`) | Scan the transcript for tokens since the last commit, compute cost, append to `commits.jsonl` |
 | `log-subagent` | SubagentStart / SubagentStop | Append a subagent lifecycle record to `subagents.jsonl` |
+| `log-session` | SessionEnd | Scan the whole session log at session end, compute per-model cost, append to `sessions.jsonl` |
+| `log-polish-nudge` | PostToolUse (Bash, `gh pr create`) | Record every nudged PR and whether `/polish` ran earlier this session, append to `polish_nudges.jsonl` |
+| `log-ask-user-question` | PreToolUse (`AskUserQuestion`) | Record each call's stance (recommended / declared-no-rec / silent) and shape (multiSelect, question/option counts), append to `askuserquestion.jsonl` |
 
 `log-commit` reads its price table from the embedded default, overridable with
 `--prices <path>` (or `CADENCE_METRICS_PRICES`). Set `CADENCE_METRICS_DEBUG=1`


### PR DESCRIPTION
Adds the three missing metrics-logger rows to the cadence-metrics table in `docs/hooks.md`:

- `log-session` — SessionEnd; scans the whole session log, computes per-model cost, appends to `sessions.jsonl`
- `log-polish-nudge` — PostToolUse (Bash, `gh pr create`); records each nudged PR and whether `/polish` ran, appends to `polish_nudges.jsonl`
- `log-ask-user-question` — PreToolUse (`AskUserQuestion`); records the call's stance and shape, appends to `askuserquestion.jsonl`

Each row's Event and description are grounded in the emitter modules (`crates/metrics/src/log_session.rs`, `log_polish_nudge.rs`, `log_askuserquestion.rs`) and `src/registry.rs`, not guessed. Docs-only, additive.

Closes #178
