### PR TITLE
fix(metrics): reconcile log-polish-nudge with the marker-based gate (#177)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`log-polish-nudge` now records the branch-scoped marker signal the pre-PR
+  gate acts on, not just a session-log scan (#177).** A new
+  `polish_marker_present(command, cwd)` helper in core is the single source of
+  truth both the `nudge-polish-before-pr` gate and the metric call; the metric
+  emits `markerPresent` alongside `polished`, making the gate-truth denominator
+  queryable and the scan-vs-marker drift measurable. Fail-open throughout
+  (ADR-0001).
+
 ## [0.44.0] - 2026-07-02
 
 ### Added

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -27,8 +27,8 @@
 //! CP2 escalates the absent-marker nudge to a block once the skill's marker
 //! write has propagated.
 
-use cadence_hooks_core::markers::polish_marker;
-use cadence_hooks_core::shell::{git_command, is_gh_pr_create, parse_work_dir};
+use cadence_hooks_core::markers::polish_marker_present;
+use cadence_hooks_core::shell::is_gh_pr_create;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
 /// Gates `/polish` (cadence-forge:polish) before opening a PR — conditional on a
@@ -46,31 +46,10 @@ impl Check for NudgePolishBeforePr {
         };
         // Only a `gh pr create` pays the git-resolution cost; every other
         // command short-circuits to allow inside `decide`.
-        let marker_present = is_gh_pr_create(command) && marker_present_for(command, input);
+        let marker_present =
+            is_gh_pr_create(command) && polish_marker_present(command, input.cwd.as_deref());
         decide(command, marker_present)
     }
-}
-
-/// Resolve the PR's `(repo_root, branch)` and report whether a polish marker
-/// exists for it. Mirrors the record side's resolution (`parse_work_dir` for a
-/// `cd`-prefixed command, then `git rev-parse --show-toplevel` + `git branch
-/// --show-current`) so a subdir cwd normalizes to the same key on both sides.
-///
-/// Any missing piece — no cwd, not a repo, detached HEAD — yields `false`, and
-/// `decide` then fails open to a nudge (ADR-0001); we never block on our own
-/// missing data.
-fn marker_present_for(command: &str, input: &HookInput) -> bool {
-    let Some(cwd) = input.cwd.as_deref() else {
-        return false;
-    };
-    let dir = parse_work_dir(command, cwd);
-    let Some(repo_root) = git_command(&dir, &["rev-parse", "--show-toplevel"]) else {
-        return false;
-    };
-    let Some(branch) = git_command(&dir, &["branch", "--show-current"]) else {
-        return false;
-    };
-    polish_marker(&repo_root, &branch).is_file()
 }
 
 /// The pure 2-way conditional — no I/O, so the gate logic is unit-tested without

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -20,6 +20,7 @@
 
 use crate::HookInput;
 use crate::paths;
+use crate::shell::{git_command, parse_work_dir};
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io;
@@ -138,6 +139,27 @@ pub fn polish_marker(repo_root: &str, branch: &str) -> PathBuf {
         hash_of(repo_root),
         hash_of(branch)
     ))
+}
+
+/// True when a branch-scoped polish marker exists for the `(repo, branch)` a
+/// `gh pr create` command targets. Single source of truth for "did `/polish`
+/// record for this PR's branch" — the pre-PR gate acts on it and the
+/// polish-nudge metric records it, so the two cannot disagree (#177).
+///
+/// Resolves `repo_root` (`git rev-parse --show-toplevel`) and `branch`
+/// (`git branch --show-current`) from `cwd`, honoring a `cd`-prefixed command
+/// via [`parse_work_dir`] — mirrors the record side. Any missing piece (no cwd,
+/// not a repo, detached HEAD) yields `false` (fail-open, ADR-0001).
+pub fn polish_marker_present(command: &str, cwd: Option<&str>) -> bool {
+    let Some(cwd) = cwd else { return false };
+    let dir = parse_work_dir(command, cwd);
+    let Some(repo_root) = git_command(&dir, &["rev-parse", "--show-toplevel"]) else {
+        return false;
+    };
+    let Some(branch) = git_command(&dir, &["branch", "--show-current"]) else {
+        return false;
+    };
+    polish_marker(&repo_root, &branch).is_file()
 }
 
 /// Write `contents` to a marker path symlink-safely.
@@ -348,5 +370,68 @@ mod tests {
         write_marker(&target, "first").unwrap();
         write_marker(&target, "second").unwrap();
         assert_eq!(std::fs::read_to_string(&target).unwrap(), "second");
+    }
+
+    // --- polish_marker_present (shared gate/metric helper, #177) ---
+
+    /// Init a git repo in a fresh tempdir, checked out on `branch`, and return
+    /// the tempdir plus the git-resolved (canonicalized) repo root — mirrors the
+    /// gate's own `init_repo_on_branch` so both sides key markers identically.
+    fn init_repo_on_branch(branch: &str) -> (tempfile::TempDir, String) {
+        use std::process::Command;
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().to_str().unwrap().to_string();
+        let git = |args: &[&str]| {
+            let ok = Command::new("git")
+                .arg("-C")
+                .arg(&dir)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&["init", "-q"]);
+        git(&["checkout", "-q", "-b", branch]);
+        let root = crate::shell::git_command(&dir, &["rev-parse", "--show-toplevel"])
+            .expect("temp repo resolves a toplevel");
+        (tmp, root)
+    }
+
+    #[test]
+    fn polish_marker_present_true_for_current_branch_with_marker() {
+        let (tmp, root) = init_repo_on_branch("feat/thing");
+        write_marker(&polish_marker(&root, "feat/thing"), "{}").unwrap();
+        assert!(polish_marker_present(
+            "gh pr create --title x",
+            Some(tmp.path().to_str().unwrap())
+        ));
+    }
+
+    #[test]
+    fn polish_marker_present_false_for_different_branch_marker() {
+        // A marker for branch A must NOT satisfy a repo checked out on branch B.
+        let (tmp, root) = init_repo_on_branch("branch-b");
+        write_marker(&polish_marker(&root, "branch-a"), "{}").unwrap();
+        assert!(!polish_marker_present(
+            "gh pr create --title x",
+            Some(tmp.path().to_str().unwrap())
+        ));
+    }
+
+    #[test]
+    fn polish_marker_present_false_when_no_marker() {
+        let (tmp, _root) = init_repo_on_branch("feat/unmarked");
+        assert!(!polish_marker_present(
+            "gh pr create --title x",
+            Some(tmp.path().to_str().unwrap())
+        ));
+    }
+
+    #[test]
+    fn polish_marker_present_false_when_cwd_none() {
+        // No cwd → unresolved → false (fail-open, ADR-0001).
+        assert!(!polish_marker_present("gh pr create --title x", None));
     }
 }

--- a/crates/metrics/src/log_polish_nudge.rs
+++ b/crates/metrics/src/log_polish_nudge.rs
@@ -14,6 +14,7 @@
 //! Silent no-op on any failure — never blocks (it is a [`Logger`]).
 
 use crate::common;
+use cadence_hooks_core::markers::polish_marker_present;
 use cadence_hooks_core::shell::is_gh_pr_create;
 use cadence_hooks_core::transcript::{
     subagent_transcripts_have_polish_run, transcript_has_polish_run,
@@ -66,6 +67,12 @@ impl Logger for LogPolishNudge {
             })
             .unwrap_or(false);
 
+        // The branch-scoped marker signal the pre-PR gate actually acts on —
+        // the same [`polish_marker_present`] the gate calls, so the metric can
+        // never disagree with the gate (#177). Recorded alongside `polished`
+        // (the transcript scan) so scan-vs-marker drift is measurable.
+        let marker_present = polish_marker_present(command, input.cwd.as_deref());
+
         let dir = common::metrics_dir();
         if std::fs::create_dir_all(&dir).is_err() {
             return;
@@ -78,6 +85,7 @@ impl Logger for LogPolishNudge {
             &common::branch(input.cwd.as_deref()),
             &common::repo_basename(input.cwd.as_deref()),
             polished,
+            marker_present,
         );
 
         if let Ok(mut file) = std::fs::OpenOptions::new()
@@ -101,6 +109,7 @@ fn build_polish_nudge_record(
     branch: &str,
     repo: &str,
     polished: bool,
+    marker_present: bool,
 ) -> Value {
     json!({
         "ts": ts,
@@ -109,6 +118,7 @@ fn build_polish_nudge_record(
         "branch": branch,
         "repo": repo,
         "polished": polished,
+        "markerPresent": marker_present,
         "agentId": input.agent_id,
         "parentSessionId": input.parent_session_id,
     })
@@ -140,6 +150,7 @@ mod tests {
             "feat/x",
             "myrepo",
             false,
+            false,
         );
         assert_eq!(rec["ts"], "2026-06-21T00:00:00Z");
         assert_eq!(rec["sessionId"], "s1");
@@ -147,6 +158,8 @@ mod tests {
         assert_eq!(rec["branch"], "feat/x");
         assert_eq!(rec["repo"], "myrepo");
         assert_eq!(rec["polished"], false);
+        // The branch-scoped marker signal, recorded alongside `polished`.
+        assert_eq!(rec["markerPresent"], false);
         assert_eq!(rec["agentId"], "a1");
         // Main-thread field absent → null, not omitted.
         assert!(rec["parentSessionId"].is_null());
@@ -154,7 +167,16 @@ mod tests {
 
     #[test]
     fn record_marks_polished_true() {
-        let rec = build_polish_nudge_record("ts", &sample_input(), "feat/x", "myrepo", true);
+        let rec = build_polish_nudge_record("ts", &sample_input(), "feat/x", "myrepo", true, false);
         assert_eq!(rec["polished"], true);
+        assert_eq!(rec["markerPresent"], false);
+    }
+
+    #[test]
+    fn record_marks_marker_present_true() {
+        // `markerPresent` serializes both signals independently of `polished`.
+        let rec = build_polish_nudge_record("ts", &sample_input(), "feat/x", "myrepo", false, true);
+        assert_eq!(rec["markerPresent"], true);
+        assert_eq!(rec["polished"], false);
     }
 }


### PR DESCRIPTION
Reconciles the `log-polish-nudge` metric's polish detection with the marker-based `nudge-polish-before-pr` gate so the two can't disagree.

Post-#172 the gate reads a branch-scoped `(repo, branch)` polish marker, while the metric detected polish via a session-log scan — they diverged on a `/polish` slash-command (no Skill block → logged `polished:false` though the gate allowed), a cross-session polish, and a wrong-branch polish. A new `core::markers::polish_marker_present(command, cwd)` helper is the single source of truth both call; the metric now emits `markerPresent` alongside `polished`, making the gate-truth denominator queryable and the scan-vs-marker drift measurable. Fail-open throughout (ADR-0001).

Verified: `cargo test` green (5 new marker tests); the gate change is a net simplification (`marker_present_for` deleted, collapsed onto the shared helper); the new JSONL key is additive (no consumer reads the file). Independent security + code review: clean.

Closes #177
