### PR TITLE
fix: harden untrusted .claude/*.json config reads against special-file DoS (#157)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Security
+
+- **Harden untrusted `.claude/*.json` config reads against a local special-file DoS (#157).** The per-repo `terminology.json` and `redaction.json` readers used an unbounded `fs::read_to_string` with no file-type check, so a `.claude/*.json` that was a symlink to an endless special file (`/dev/zero`, a FIFO) or a multi-GB blob could hang or OOM the hook when it fired inside a cloned/shared repo. Both now route through a new `core::paths::read_untrusted_config`, which rejects anything that is not a regular file (on `stat`, before any blocking read) and caps the read at 1 MiB, failing open (ADR-0001) — a rejected config is treated as absent.
+
 ## [0.44.0] - 2026-07-02
 
 ### Added

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -314,7 +314,7 @@ fn load_redaction_config(base_dir: &str) -> RedactionConfig {
         return RedactionConfig::default();
     };
     let path = root.join(".claude/redaction.json");
-    let Ok(content) = std::fs::read_to_string(path) else {
+    let Some(content) = cadence_hooks_core::paths::read_untrusted_config(&path) else {
         return RedactionConfig::default();
     };
     serde_json::from_str(&content).unwrap_or_default()
@@ -724,6 +724,22 @@ mod tests {
         // Universal scan still works despite the broken config.
         let cmd = "gh pr create --body \"see cadence:attune\"";
         let input = make_bash_with_cwd(cmd, repo.path().to_str().unwrap());
+        assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Nudge);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn special_file_config_fails_open_and_does_not_hang() {
+        // #157: a `.claude/redaction.json` symlinked to an endless special file
+        // (`/dev/zero`) is rejected on stat — the loader falls open to the
+        // default config and the universal scan still nudges a skill id, without
+        // an unbounded read hanging the hook.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::os::unix::fs::symlink("/dev/zero", dir.path().join(".claude/redaction.json")).unwrap();
+        let cmd = "gh pr create --body \"see cadence:attune\"";
+        let input = make_bash_with_cwd(cmd, dir.path().to_str().unwrap());
         assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Nudge);
     }
 

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -264,7 +264,7 @@ fn glob_match(pattern: &str, rel_path: &str, basename: &str) -> bool {
 /// all yield the default (empty) config (fail-open, ADR-0001).
 fn load_terminology_config(root: &Path) -> TerminologyConfig {
     let path = root.join(".claude/terminology.json");
-    let Ok(content) = std::fs::read_to_string(path) else {
+    let Some(content) = cadence_hooks_core::paths::read_untrusted_config(&path) else {
         return TerminologyConfig::default();
     };
     serde_json::from_str(&content).unwrap_or_default()
@@ -1182,6 +1182,22 @@ mod tests {
     fn invalid_json_fails_open_and_still_blocks() {
         let repo = temp_repo("{not valid json");
         let input = write_at(repo.path(), "acl.yml", BLOCK_VIOLATIONS[0].0);
+        assert_eq!(outcome(&input), Outcome::Block);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn special_file_config_fails_open_and_does_not_hang() {
+        // #157: a `.claude/terminology.json` that is a symlink to an endless
+        // special file (`/dev/zero`) must be rejected on stat — the guard falls
+        // open to the default (empty) config and a flagged term still blocks,
+        // without an unbounded read hanging the hook.
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".git")).unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::os::unix::fs::symlink("/dev/zero", dir.path().join(".claude/terminology.json"))
+            .unwrap();
+        let input = write_at(dir.path(), "src/main.rs", BLOCK_VIOLATIONS[0].0);
         assert_eq!(outcome(&input), Outcome::Block);
     }
 

--- a/crates/core/src/paths.rs
+++ b/crates/core/src/paths.rs
@@ -12,6 +12,7 @@
 //! races parallel tests), mirroring the `expand_tilde`/`expand_tilde_with`
 //! split elsewhere in the workspace.
 
+use std::io::Read;
 use std::path::{Path, PathBuf};
 
 /// The current user's home directory, portably.
@@ -92,6 +93,34 @@ pub fn find_git_root(start: &str) -> Option<PathBuf> {
             return None;
         }
     }
+}
+
+/// Cap for an untrusted per-repo `.claude/*.json` read. These are tiny
+/// hand-authored exemption lists; 1 MiB is ~100–1000x any legitimate size and
+/// bounds a pathological/malicious multi-GB blob from OOM-ing the hook.
+const MAX_UNTRUSTED_CONFIG_BYTES: u64 = 1024 * 1024; // 1 MiB
+
+/// Read a per-repo, repo-controlled `.claude/*.json` config safely.
+///
+/// Rejects anything that is not a **regular file** (metadata() follows
+/// symlinks, so a link to /dev/zero or a FIFO resolves to a non-regular
+/// target and is rejected on `stat`, before any blocking read) and caps the
+/// read at [`MAX_UNTRUSTED_CONFIG_BYTES`]. Returns `None` on any rejection or
+/// IO error so callers fail open (ADR-0001): a rejected config == a missing one.
+pub fn read_untrusted_config(path: &Path) -> Option<String> {
+    let meta = std::fs::metadata(path).ok()?;
+    if !meta.is_file() {
+        return None; // FIFO / device / dir / broken symlink
+    }
+    if meta.len() > MAX_UNTRUSTED_CONFIG_BYTES {
+        return None; // oversized regular file
+    }
+    let file = std::fs::File::open(path).ok()?;
+    let mut buf = String::new();
+    file.take(MAX_UNTRUSTED_CONFIG_BYTES) // TOCTOU belt-and-suspenders
+        .read_to_string(&mut buf)
+        .ok()?; // non-UTF8 → None (same as read_to_string)
+    Some(buf)
 }
 
 /// Resolve a checkout's git **common directory** — the shared `.git` that holds
@@ -419,5 +448,77 @@ mod tests {
             expand_tilde_with("/abs/path", "/home/test"),
             PathBuf::from("/abs/path")
         );
+    }
+
+    // --- read_untrusted_config (#157 special-file DoS hardening) ---
+
+    #[test]
+    fn read_untrusted_config_reads_small_regular_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("config.json");
+        std::fs::write(&path, r#"{"ok":true}"#).unwrap();
+        assert_eq!(
+            read_untrusted_config(&path),
+            Some(r#"{"ok":true}"#.to_string())
+        );
+    }
+
+    #[test]
+    fn read_untrusted_config_missing_is_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_untrusted_config(&tmp.path().join("absent.json")), None);
+    }
+
+    #[test]
+    fn read_untrusted_config_rejects_directory() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(read_untrusted_config(tmp.path()), None);
+    }
+
+    #[test]
+    fn read_untrusted_config_rejects_oversized() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("big.json");
+        // One byte over the 1 MiB cap.
+        std::fs::write(&path, vec![b'x'; (1024 * 1024) + 1]).unwrap();
+        assert_eq!(read_untrusted_config(&path), None);
+    }
+
+    #[test]
+    fn read_untrusted_config_reads_at_or_below_cap() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("atcap.json");
+        // Just under the cap → accepted.
+        let body = vec![b'y'; (1024 * 1024) - 1];
+        std::fs::write(&path, &body).unwrap();
+        let read = read_untrusted_config(&path).expect("under-cap file reads");
+        assert_eq!(read.len(), body.len());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_untrusted_config_rejects_fifo() {
+        let tmp = tempfile::tempdir().unwrap();
+        let path = tmp.path().join("fifo.json");
+        // mkfifo via the system binary keeps the dev-deps unchanged.
+        let status = std::process::Command::new("mkfifo")
+            .arg(&path)
+            .status()
+            .expect("spawn mkfifo");
+        assert!(status.success(), "mkfifo failed");
+        // A FIFO is not a regular file → rejected on stat, no blocking read.
+        assert_eq!(read_untrusted_config(&path), None);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn read_untrusted_config_rejects_symlink_to_dev_zero() {
+        // The headline DoS: a symlink to an endless special file. metadata()
+        // follows the link to a non-regular target, so it is rejected on stat —
+        // this test must NOT hang.
+        let tmp = tempfile::tempdir().unwrap();
+        let link = tmp.path().join("evil.json");
+        std::os::unix::fs::symlink("/dev/zero", &link).unwrap();
+        assert_eq!(read_untrusted_config(&link), None);
     }
 }


### PR DESCRIPTION
Hardens the untrusted per-repo `.claude/*.json` config readers (`terminology.json`, `redaction.json`) against a local special-file DoS.

Both used an unbounded `fs::read_to_string` with no file-type check, so a `.claude/*.json` that was a symlink to an endless special file (`/dev/zero`, a FIFO) or a multi-GB blob could hang or OOM the hook when it fired inside a cloned/shared repo. A size cap alone doesn't close it — special files report `len()==0` — so the fix is a regular-file type check on `stat` (before any blocking read) plus a 1 MiB cap, in a new shared `core::paths::read_untrusted_config`. Fail-open (ADR-0001): a rejected config is treated as absent, so the guard proceeds rather than crashing.

Verified: 7 helper unit tests (incl. symlink→/dev/zero and FIFO rejection — neither hangs, since rejection is on `stat`) + 2 guard-level regressions proving both readers fail open on a hostile symlink. Independent security + code review: clean.

Closes #157
