### PR TITLE
fix(core,rules): effective_content literal path + security-pattern coverage (#129, #131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`effective_content()` reads the literal write target, not the normalized path (#129).** For Edit/MultiEdit the helper now simulates against the file actually being written — a trailing-space/backslash/null path variant no longer makes a guard validate a different (or missing) file. Fail-open on an unreadable/non-UTF-8 file is preserved (ADR-0001) and documented; a future *blocking* content-security guard must supply its own fail-closed default.
+
+### Security
+
+- **`check-security-patterns` scans the simulated post-edit document and gains RCE/XSS coverage (#131).** The guard now routes through `effective_content()` (correct line numbers; no more scanning an Edit fragment or a MultiEdit's stale pre-edit file), and flags Python `eval(`/`exec(`/`os.system(`/`pickle.load(` and JS `eval(`/`document.write(`/`dangerouslySetInnerHTML`. Advisory-only (never blocks).
+
 ## [0.44.0] - 2026-07-02
 
 ### Added

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -341,10 +341,18 @@ impl HookInput {
     /// The full document the tool call will produce.
     ///
     /// - Write (`content` present) → the content as-is.
-    /// - Edit (`old_string`/`new_string` present) → reads `file_path` from disk,
-    ///   applies the replacement (honoring `replace_all`), returns the result.
+    /// - Edit (`old_string`/`new_string` present) → reads the **literal**
+    ///   `file_path` (falling back to `path`) from disk — *not* the
+    ///   `normalize_path`-processed value — applies the replacement (honoring
+    ///   `replace_all`), returns the result. Simulating against the literal
+    ///   write target keeps a guard validating the same file Claude Code will
+    ///   actually write, even when the path carries a trailing space/backslash
+    ///   or null byte.
     /// - MultiEdit (`edits[]` present) → reads the file, applies each edit in order.
-    /// - File unreadable or missing for Edit/MultiEdit → `None` (fail open, ADR-0001).
+    /// - File unreadable, missing, or non-UTF-8 for Edit/MultiEdit → `None`
+    ///   (fail open, ADR-0001). A future *blocking* content-security guard that
+    ///   adopts this helper must supply its own fail-closed default rather than
+    ///   treating `None` as "allow".
     pub fn effective_content(&self) -> Option<String> {
         let ti = self.tool_input.as_ref()?;
 
@@ -353,9 +361,11 @@ impl HookInput {
             return Some(content.to_string());
         }
 
-        // Edit / MultiEdit: simulate the edit against the on-disk file.
-        let path = self.file_path()?;
-        let on_disk = std::fs::read_to_string(&path).ok()?;
+        // Edit / MultiEdit: simulate the edit against the on-disk file, reading
+        // the LITERAL write target (not the normalized path) so the simulation
+        // matches the exact file Claude Code will write.
+        let path = ti.file_path.as_deref().or(ti.path.as_deref())?;
+        let on_disk = std::fs::read_to_string(path).ok()?;
 
         if let (Some(old), Some(new)) = (ti.old_string.as_deref(), ti.new_string.as_deref()) {
             return Some(apply_edit(
@@ -1520,6 +1530,32 @@ mod tests {
     fn effective_content_edit_missing_file_is_none() {
         let input = make_disk_edit("/nonexistent/path/doc.md", "a", "b", None);
         assert_eq!(input.effective_content(), None);
+    }
+
+    #[test]
+    fn effective_content_edit_reads_literal_not_normalized_path() {
+        // A path with a trailing space: normalize_path() would trim it and read
+        // a *different* (nonexistent) file. effective_content() must read the
+        // LITERAL write target so a guard validates the same file Claude Code
+        // actually writes (#129).
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("doc.md ");
+        std::fs::write(&path, "line one\nline two\n").unwrap();
+
+        let literal = path.to_str().unwrap();
+        assert!(
+            literal.ends_with(' '),
+            "test path must retain its trailing space, got {literal:?}"
+        );
+        // The normalized form trims the space and points at a nonexistent file.
+        assert_ne!(normalize_path(literal), literal);
+
+        let input = make_disk_edit(literal, "line two", "line 2", None);
+        assert_eq!(
+            input.effective_content().as_deref(),
+            Some("line one\nline 2\n"),
+            "should simulate against the literal trailing-space path, not the trimmed one"
+        );
     }
 
     #[test]

--- a/crates/rules/src/check_security_patterns.rs
+++ b/crates/rules/src/check_security_patterns.rs
@@ -114,6 +114,43 @@ const PATTERNS: &[SecurityPattern] = &[
         pattern: r"UserDefaults.*(password|secret|token|apiKey)",
         message: "Store secrets in Keychain",
     },
+    // Python — RCE / command injection
+    SecurityPattern {
+        extensions: &["py"],
+        pattern: r"\beval\s*[(]",
+        message: "RCE risk: eval() executes arbitrary code",
+    },
+    SecurityPattern {
+        extensions: &["py"],
+        pattern: r"\bexec\s*[(]",
+        message: "RCE risk: exec() runs arbitrary code",
+    },
+    SecurityPattern {
+        extensions: &["py"],
+        pattern: r"\bos[.]system\s*[(]",
+        message: "Command injection risk: use subprocess with an arg list",
+    },
+    SecurityPattern {
+        extensions: &["py"],
+        pattern: r"pickle[.]load[(]",
+        message: "RCE risk: use json or msgpack instead of pickle",
+    },
+    // JS/JSX — RCE / XSS
+    SecurityPattern {
+        extensions: &["js", "jsx", "mjs", "cjs"],
+        pattern: r"\beval\s*[(]",
+        message: "RCE risk: eval() executes arbitrary code",
+    },
+    SecurityPattern {
+        extensions: &["js", "jsx", "mjs", "cjs"],
+        pattern: r"\bdocument[.]write\s*[(]",
+        message: "XSS risk: avoid document.write()",
+    },
+    SecurityPattern {
+        extensions: &["jsx", "tsx"],
+        pattern: r"dangerouslySetInnerHTML",
+        message: "XSS risk: sanitize before dangerouslySetInnerHTML",
+    },
 ];
 
 /// Scan content for security anti-patterns matching the given file extension.
@@ -165,9 +202,14 @@ impl Check for SecurityPatternScanner {
 
         let ext = path.rsplit('.').next().unwrap_or("");
 
-        // Prefer content from the tool input (Write/Edit); fall back to disk (Read/Grep)
-        let content = match input.content() {
-            Some(c) => c.to_string(),
+        // Scan the *resulting* document, not the raw edit fragment (#131).
+        // effective_content() simulates Edit/MultiEdit against the on-disk file
+        // (correct line numbers, no stale pre-edit content); for Write it's the
+        // content as-is. Fall back to the current on-disk file when the payload
+        // carries no editable text, and fail open (allow) when neither is
+        // available (ADR-0001) — this guard is advisory only.
+        let content = match input.effective_content() {
+            Some(c) => c,
             None => match std::fs::read_to_string(&path) {
                 Ok(c) => c,
                 Err(_) => return CheckResult::allow(),
@@ -570,5 +612,140 @@ mod tests {
         };
         let result = SecurityPatternScanner.run(&input);
         assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    // --- new RCE / XSS pattern coverage (#131) ---
+
+    #[test]
+    fn py_eval() {
+        let results = scan_content("result = eval(user_input)", "py");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("eval"));
+    }
+
+    #[test]
+    fn py_exec() {
+        let results = scan_content("exec(compiled)", "py");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("exec"));
+    }
+
+    #[test]
+    fn py_os_system() {
+        let results = scan_content("os.system(cmd)", "py");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("injection"));
+    }
+
+    #[test]
+    fn py_pickle_load() {
+        let results = scan_content("obj = pickle.load(f)", "py");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("pickle"));
+    }
+
+    #[test]
+    fn js_eval() {
+        let results = scan_content("eval(payload)", "js");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("eval"));
+    }
+
+    #[test]
+    fn js_document_write() {
+        let results = scan_content("document.write(html)", "js");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("XSS"));
+    }
+
+    #[test]
+    fn jsx_dangerously_set_inner_html() {
+        let results = scan_content("<div dangerouslySetInnerHTML={{ __html: raw }} />", "jsx");
+        assert_eq!(results.len(), 1);
+        assert!(results[0].1.contains("sanitize"));
+    }
+
+    // --- false-positive regressions for the new patterns ---
+
+    #[test]
+    fn py_retrieval_not_flagged() {
+        // `retrieval(` embeds "eval(" but the \b boundary before eval fails.
+        let results = scan_content("retrieval(query)", "py");
+        assert!(
+            results.is_empty(),
+            "retrieval() must not trip eval, got {results:?}"
+        );
+    }
+
+    #[test]
+    fn py_execute_not_flagged() {
+        // `execute(` embeds "exec" but the required `[(]` after exec is absent.
+        let results = scan_content("cursor.execute(sql)", "py");
+        assert!(
+            results.is_empty(),
+            "execute() must not trip exec, got {results:?}"
+        );
+    }
+
+    #[test]
+    fn py_pickle_loads_not_double_counted() {
+        // pickle.loads matches only the existing `pickle[.]loads` pattern; the
+        // new `pickle[.]load[(]` requires "load(" and must not also fire.
+        let results = scan_content("pickle.loads(blob)", "py");
+        assert_eq!(
+            results.len(),
+            1,
+            "pickle.loads must match exactly once, got {results:?}"
+        );
+    }
+
+    #[test]
+    fn js_medieval_not_flagged() {
+        let results = scan_content("medieval(theme)", "js");
+        assert!(
+            results.is_empty(),
+            "medieval() must not trip eval, got {results:?}"
+        );
+    }
+
+    // --- run() routing through effective_content (#129, #131) ---
+
+    use cadence_hooks_core::test_builders::{make_edit, make_multi_edit};
+
+    /// Write source into a temp file with the given extension; returns
+    /// (tempdir guard, absolute path).
+    fn on_disk_source(ext: &str, content: &str) -> (tempfile::TempDir, String) {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join(format!("code.{ext}"));
+        std::fs::write(&path, content).unwrap();
+        (dir, path.to_str().unwrap().to_string())
+    }
+
+    #[test]
+    fn run_edit_introducing_pattern_scans_effective_content() {
+        // An Edit whose new_string introduces os.system on line 2 must be
+        // flagged with the correct post-edit line number — proving the guard
+        // scans the simulated document, not the raw edit fragment.
+        let (_dir, path) = on_disk_source("py", "import os\nplaceholder()\n");
+        let input = make_edit(&path, "placeholder()", r#"os.system("rm -rf /")"#);
+        let result = SecurityPatternScanner.run(&input);
+        assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.unwrap();
+        assert!(msg.contains("L2"), "expected line 2, got: {msg}");
+        assert!(
+            msg.contains("injection"),
+            "expected injection hint, got: {msg}"
+        );
+    }
+
+    #[test]
+    fn run_multi_edit_scans_resulting_document_not_stale() {
+        // The on-disk file is clean; only the applied MultiEdit introduces the
+        // pattern. A stale pre-edit scan would miss it.
+        let (_dir, path) = on_disk_source("py", "import os\nprint('hi')\n");
+        let input = make_multi_edit(&path, &[("print('hi')", "os.system('x')")]);
+        let result = SecurityPatternScanner.run(&input);
+        assert_eq!(result.outcome, Outcome::Nudge);
+        assert!(result.message.unwrap().contains("injection"));
     }
 }


### PR DESCRIPTION
Fixes two coupled defects in the security-content path.

**#129 — `effective_content()` reads the literal write target, not the normalized path.** For Edit/MultiEdit the helper now simulates against the file actually being written; a trailing-space/backslash/null path variant no longer makes a guard validate a different (or missing) file. Fail-open on an unreadable/non-UTF-8 file is preserved (ADR-0001) and documented — a future *blocking* content-security guard must supply its own fail-closed default.

**#131 — `check-security-patterns` scans the simulated post-edit document and gains RCE/XSS coverage.** The guard now routes through `effective_content()` (correct line numbers; no more scanning an Edit fragment or a MultiEdit's stale pre-edit file), and flags Python `eval(`/`exec(`/`os.system(`/`pickle.load(` and JS `eval(`/`document.write(`/`dangerouslySetInnerHTML`. Advisory-only (never blocks).

Verified: 350 core + 118 rules tests pass (new pattern tests + FP regressions — `retrieval(`/`execute(`/`medieval(` not flagged, `pickle.load(` vs `pickle.loads(` disjoint). The `effective_content()` fail-open behavior is deliberately preserved — its two block-capable callers (`validate_skill_frontmatter`, `memory_guard`) would regress into blocking unreadable files if flipped.

Closes #129
Closes #131
