### PR TITLE
feat(secret-guards): extend Bash-path coverage to non-.env deny-set files (#138)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Bash-path coverage for non-`.env` deny-set secret files (#138).** The secret guards' Bash arms judged only the `.env` family, so `cat ~/.aws/credentials`, `cat ~/.ssh/id_rsa`, `cat ~/.git-credentials`, `cat ~/.pgpass`, `cat ~/.kube/config`, and `cat ~/.netrc` — all already blocked on the tool paths — read and wrote freely over Bash. A new `is_dangerous_secret_token` classifier consults the full `BLOCKED_FILENAMES` / `BLOCKED_PATH_FRAGMENTS` deny-sets, and a `command_may_reference_secret` pre-filter generalizes the old `.env`-only gate. Safe templates short-circuit so `id_rsa.pub` and `.aws/credentials.example` stay readable. `.envrc` keeps its Bash name-block (content carve-out stays tool-path-only, #149).
+
 ## [0.44.0] - 2026-07-02
 
 ### Added

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -7,7 +7,10 @@
 //! metadata-safe allowlist (#65, #66). Safe templates (.env.example,
 //! .env.test) are always allowed.
 
-use crate::secret_patterns::{is_ambiguous, is_blocked, is_dangerous_env_token, is_safe_template};
+use crate::secret_patterns::{
+    command_may_reference_secret, is_ambiguous, is_blocked, is_dangerous_secret_token,
+    is_safe_template,
+};
 use cadence_hooks_core::shell::{command_segments, split_segments, tokenize};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
@@ -52,7 +55,7 @@ fn segment_env_read(segment: &str) -> Option<(String, String)> {
     }
     tokens[1..]
         .iter()
-        .find(|t| !t.chars().any(char::is_whitespace) && is_dangerous_env_token(t))
+        .find(|t| !t.chars().any(char::is_whitespace) && is_dangerous_secret_token(t))
         .map(|t| (cmd_word.to_string(), t.clone()))
 }
 
@@ -74,7 +77,7 @@ fn find_exec_leak(tokens: &[String]) -> Option<(String, String)> {
     }
     tokens
         .iter()
-        .find(|t| !t.chars().any(char::is_whitespace) && is_dangerous_env_token(t))
+        .find(|t| !t.chars().any(char::is_whitespace) && is_dangerous_secret_token(t))
         .map(|t| (sub_word.to_string(), t.clone()))
 }
 
@@ -108,19 +111,20 @@ fn is_executed_command(lower: &str, cmd: &[&str]) -> bool {
 fn bash_leaks_secrets(command: &str) -> Option<CheckResult> {
     let lower = command.to_lowercase();
 
-    // Block: a dangerous .env-family operand handed to any command that is
-    // not metadata-safe (#65, #66). Judged per segment so a chained or
-    // `sh -c`-wrapped read is still seen.
-    if lower.contains(".env") {
+    // Block: a dangerous deny-set operand (the `.env` family plus the non-`.env`
+    // credential stores) handed to any command that is not metadata-safe
+    // (#65, #66, #138). Judged per segment so a chained or `sh -c`-wrapped read
+    // is still seen.
+    if command_may_reference_secret(&lower) {
         for segment in command_segments(&lower) {
             if let Some((cmd_word, token)) = segment_env_read(&segment) {
                 return Some(CheckResult::block(format!(
-                    "🚫 BLOCKED: prevent-secret-leaks: command would expose .env file contents\n\
+                    "🚫 BLOCKED: prevent-secret-leaks: command would expose secret file contents\n\
                      Found: `{token}` as an operand of `{cmd_word}`\n\
                      Fix: secrets are available to programs via direnv (`direnv allow`) — \
-                     run the program directly instead of reading its env file.\n\
+                     run the program directly instead of reading its secret file.\n\
                      Allowed: metadata-only commands (ls, stat, wc, rm, touch, …) and \
-                     safe templates (.env.example, .env.test, …)."
+                     safe templates (.env.example, id_rsa.pub, .aws/credentials.example, …)."
                 )));
             }
         }
@@ -1359,5 +1363,79 @@ mod tests {
     fn bash_echo_plain_text_allowed() {
         let result = SecretLeaksGuard.run(&make_bash_input("echo hello world"));
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // ---------------------------------------------------------------
+    // #138: Bash-path coverage for non-.env deny-set secret files
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn bash_cat_aws_credentials_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("cat ~/.aws/credentials"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_cat_id_rsa_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("cat ~/.ssh/id_rsa"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_grep_git_credentials_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("grep password ~/.git-credentials"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_cat_pgpass_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("cat ~/.pgpass"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_cat_kube_config_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("cat ~/.kube/config"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_cat_netrc_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("cat ~/.netrc"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_base64_id_rsa_blocked() {
+        let result = SecretLeaksGuard.run(&make_bash_input("base64 ~/.ssh/id_rsa"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn bash_cat_id_rsa_pub_allowed() {
+        // Safe template (.pub) short-circuits.
+        let result = SecretLeaksGuard.run(&make_bash_input("cat ~/.ssh/id_rsa.pub"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn bash_cat_config_toml_allowed() {
+        // No deny-set filename/fragment — gate rejects early.
+        let result = SecretLeaksGuard.run(&make_bash_input("cat config.toml"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn bash_ls_id_rsa_allowed() {
+        // Metadata-safe command never emits contents.
+        let result = SecretLeaksGuard.run(&make_bash_input("ls -la ~/.ssh/id_rsa"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn bash_cat_envrc_still_blocked_138() {
+        // #149 contract: `.envrc` keeps its Bash name-block.
+        let result = SecretLeaksGuard.run(&make_bash_input("cat .envrc"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 }

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -6,8 +6,8 @@
 //! Safe templates (.env.example, .env.test) are always allowed.
 
 use crate::secret_patterns::{
-    is_ambiguous, is_blocked, is_dangerous_env_token, is_safe_template, is_secret_scan_exempt,
-    scan_secret_values,
+    command_may_reference_secret, is_ambiguous, is_blocked, is_dangerous_secret_token,
+    is_safe_template, is_secret_scan_exempt, scan_secret_values,
 };
 use cadence_hooks_core::shell::{command_segments, tokenize};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
@@ -214,8 +214,10 @@ fn find_writes(args: &[String]) -> bool {
 
 /// Check if a bash command targets .env files destructively.
 fn bash_targets_env_file(command: &str) -> bool {
-    // Quick reject: nothing to guard if no `.env` token appears anywhere.
-    if !command.to_lowercase().contains(".env") {
+    // Quick reject: nothing to guard if no deny-set secret file is mentioned
+    // anywhere (the `.env` family plus the non-`.env` credential stores) (#138).
+    let lower = command.to_lowercase();
+    if !command_may_reference_secret(&lower) {
         return false;
     }
 
@@ -227,7 +229,7 @@ fn bash_targets_env_file(command: &str) -> bool {
         if redirect_targets(&segment)
             .iter()
             .chain(writer_targets(&segment).iter())
-            .any(|t| is_dangerous_env_token(t))
+            .any(|t| is_dangerous_secret_token(t))
         {
             return true;
         }
@@ -306,10 +308,10 @@ impl Check for SecretWritesGuard {
 
                 if bash_targets_env_file(command) {
                     return CheckResult::block(
-                        "🚫 BLOCKED: prevent-secret-writes: command would write or delete a .env file\n\
-                         Found: a redirect or writer verb (tee, cp/mv/install, dd, truncate, rm) targeting a .env-family file\n\
-                         Fix: modify .env files manually outside Claude Code.\n\
-                         Allowed: safe templates (.env.example, .env.test, …) and non-.env targets.",
+                        "🚫 BLOCKED: prevent-secret-writes: command would write or delete a secret file\n\
+                         Found: a redirect or writer verb (tee, cp/mv/install, dd, truncate, rm) targeting a deny-set secret file (.env family, id_rsa, .aws/credentials, .git-credentials, .pgpass, .kube/config, .netrc, …)\n\
+                         Fix: modify secret files manually outside Claude Code.\n\
+                         Allowed: safe templates (.env.example, id_rsa.pub, …) and non-secret targets.",
                     );
                 }
 
@@ -710,6 +712,56 @@ mod tests {
     #[test]
     fn bash_rm_rf_env_blocked() {
         assert!(bash_targets_env_file("rm -rf .env"));
+    }
+
+    // --- #138: Bash-path writes/deletes for non-.env deny-set files ---
+
+    #[test]
+    fn bash_rm_id_rsa_blocked() {
+        assert!(bash_targets_env_file("rm ~/.ssh/id_rsa"));
+    }
+
+    #[test]
+    fn bash_redirect_git_credentials_blocked() {
+        assert!(bash_targets_env_file("echo token > ~/.git-credentials"));
+    }
+
+    #[test]
+    fn bash_tee_pgpass_blocked() {
+        assert!(bash_targets_env_file("echo pw | tee ~/.pgpass"));
+    }
+
+    #[test]
+    fn bash_cp_aws_credentials_blocked() {
+        assert!(bash_targets_env_file("cp tmp ~/.aws/credentials"));
+    }
+
+    #[test]
+    fn bash_rm_kube_config_blocked() {
+        assert!(bash_targets_env_file("rm ~/.kube/config"));
+    }
+
+    #[test]
+    fn bash_rm_netrc_blocked() {
+        assert!(bash_targets_env_file("rm ~/.netrc"));
+    }
+
+    #[test]
+    fn bash_rm_id_rsa_pub_allowed() {
+        // Safe template (.pub) is not a secret write.
+        assert!(!bash_targets_env_file("rm ~/.ssh/id_rsa.pub"));
+    }
+
+    #[test]
+    fn bash_rm_config_toml_allowed() {
+        // No deny-set filename/fragment — gate rejects early.
+        assert!(!bash_targets_env_file("rm ./config.toml"));
+    }
+
+    #[test]
+    fn bash_cp_to_id_rsa_blocked_via_run() {
+        let result = SecretWritesGuard.run(&make_bash_input("cp key ~/.ssh/id_rsa"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
     }
 
     #[test]

--- a/crates/cadence/src/secret_patterns.rs
+++ b/crates/cadence/src/secret_patterns.rs
@@ -150,6 +150,40 @@ pub fn is_dangerous_env_token(token: &str) -> bool {
     is_env_family_secret(component)
 }
 
+/// True if a shell token resolves to ANY deny-set secret file — the whole
+/// `.env` family (via `is_env_family_secret`) plus the non-`.env` credential
+/// stores in `BLOCKED_FILENAMES` and dir-qualified `BLOCKED_PATH_FRAGMENTS`.
+/// Generalizes `is_dangerous_env_token` so the Bash arms judge the same
+/// deny-sets the tool paths already do via `is_blocked` (#138). Safe templates
+/// (`SAFE_SUFFIXES`) short-circuit FIRST so `id_rsa.pub` / `.aws/credentials.example`
+/// stay clean. Filenames match the final path component exactly; fragments
+/// match as a substring of the whole token.
+pub fn is_dangerous_secret_token(token: &str) -> bool {
+    let lower = token.to_lowercase();
+    let trimmed = lower.strip_prefix('@').unwrap_or(&lower);
+    let trimmed = trimmed.trim_end_matches(')');
+    let component = trimmed.rsplit('/').next().unwrap_or(trimmed);
+    if is_safe_template(component) {
+        return false;
+    }
+    is_env_family_secret(component)
+        || BLOCKED_FILENAMES.contains(&component)
+        || BLOCKED_PATH_FRAGMENTS
+            .iter()
+            .any(|frag| trimmed.contains(frag))
+}
+
+/// Cheap superset pre-filter for the Bash arms: might this lowercased command
+/// mention any deny-set secret file? A false positive only costs a tokenize.
+/// Generalizes the old `command.contains(".env")` gate (#138). Input must be
+/// already lowercased.
+pub fn command_may_reference_secret(lower_command: &str) -> bool {
+    BLOCKED_FILENAMES.iter().any(|&f| lower_command.contains(f))
+        || BLOCKED_PATH_FRAGMENTS
+            .iter()
+            .any(|frag| lower_command.contains(frag))
+}
+
 /// High-confidence secret-*value* patterns: `(human name, regex)`.
 ///
 /// Each is deliberately provider-prefixed and length-bounded so a match means
@@ -408,6 +442,57 @@ mod tests {
         assert!(!is_dangerous_env_token("env"));
         assert!(!is_dangerous_env_token("-env"));
         assert!(!is_dangerous_env_token("feat/allow-main-branch-env"));
+    }
+
+    #[test]
+    fn dangerous_secret_tokens_detected() {
+        // #138: the full deny-set, not just the .env family, on the Bash path.
+        assert!(is_dangerous_secret_token("id_rsa"));
+        assert!(is_dangerous_secret_token("/home/user/.ssh/id_rsa"));
+        assert!(is_dangerous_secret_token(".netrc"));
+        assert!(is_dangerous_secret_token(".git-credentials"));
+        assert!(is_dangerous_secret_token(".pgpass"));
+        assert!(is_dangerous_secret_token(".npmrc"));
+        assert!(is_dangerous_secret_token("credentials.json"));
+        // Dir-qualified fragments.
+        assert!(is_dangerous_secret_token("/home/user/.aws/credentials"));
+        assert!(is_dangerous_secret_token("/home/user/.kube/config"));
+        // The .env family still classifies.
+        assert!(is_dangerous_secret_token(".env"));
+        assert!(is_dangerous_secret_token(".env.prod"));
+        // Curl upload idiom and subshell-close trims still apply.
+        assert!(is_dangerous_secret_token("@.env"));
+        assert!(is_dangerous_secret_token("@id_rsa"));
+        assert!(is_dangerous_secret_token(".pgpass)"));
+    }
+
+    #[test]
+    fn clean_secret_lookalike_tokens_pass() {
+        // Safe template short-circuits first.
+        assert!(!is_dangerous_secret_token("id_rsa.pub"));
+        // Bare generic basenames are fragments, not filenames — not dangerous
+        // outside their credential dirs.
+        assert!(!is_dangerous_secret_token("config"));
+        assert!(!is_dangerous_secret_token("credentials"));
+        assert!(!is_dangerous_secret_token(
+            "/home/user/.aws/credentials.example"
+        ));
+        assert!(!is_dangerous_secret_token("main.rs"));
+        assert!(!is_dangerous_secret_token("config.toml"));
+    }
+
+    #[test]
+    fn command_may_reference_secret_gate() {
+        assert!(command_may_reference_secret("cat ~/.aws/credentials"));
+        assert!(command_may_reference_secret("cat ~/.ssh/id_rsa"));
+        assert!(command_may_reference_secret("grep pw ~/.git-credentials"));
+        assert!(command_may_reference_secret("cat ~/.pgpass"));
+        assert!(command_may_reference_secret("cat ~/.kube/config"));
+        assert!(command_may_reference_secret("cat ~/.netrc"));
+        // Negatives: no deny-set filename or fragment mentioned.
+        assert!(!command_may_reference_secret("cargo test"));
+        assert!(!command_may_reference_secret("cat config.toml"));
+        assert!(!command_may_reference_secret("git status"));
     }
 
     // --- #85: secret-value content scanner ---


### PR DESCRIPTION
Extends the secret guards' **Bash-path** coverage to the non-`.env` credential stores already blocked on the tool paths.

The Bash arms judged only the `.env` family, so `cat ~/.aws/credentials`, `cat ~/.ssh/id_rsa`, `cat ~/.git-credentials`, `cat ~/.pgpass`, `cat ~/.kube/config`, and `cat ~/.netrc` — all blocked on Read/Grep/Write/Edit — read and wrote freely over Bash. A new `is_dangerous_secret_token` classifier consults the full existing `BLOCKED_FILENAMES` / `BLOCKED_PATH_FRAGMENTS` deny-sets (no new entries — the files were already listed; the Bash arms just didn't consult them), and a `command_may_reference_secret` pre-filter generalizes the old `.env`-only gate.

Safe templates short-circuit, so `id_rsa.pub` and `.aws/credentials.example` stay readable. `.envrc` keeps its Bash name-block — the content carve-out stays tool-path-only (#149).

Verified: clippy `-D warnings` clean, 758 cadence tests pass (20 new — every target file blocked on cat/rm/redirect/tee/cp, `id_rsa.pub` allowed, `.envrc` still blocked).

Note: two trivial merge unions expected against #149 (a shared `use` block + CHANGELOG `[Unreleased]`); this PR is authored to land after #149.

Closes #138
