### PR TITLE
docs(guardrails): reconcile guard-browser-device doc — prompts, not enforces (#134)

### DIFF
--- a/crates/guardrails/src/guard_browser_device.rs
+++ b/crates/guardrails/src/guard_browser_device.rs
@@ -10,9 +10,12 @@
 //! `select_browser`/`switch_browser` for exactly this, and
 //! `list_connected_browsers`'s description *mandates* an `AskUserQuestion`
 //! listing every browser — but that mandate is advisory; the model can skip
-//! it. This guard makes the handshake enforced: it blocks the **first**
-//! claude-in-chrome tool call of a session (exit 2, re-clarify message),
-//! writes a per-session marker, and allows every subsequent call.
+//! it. This guard surfaces the handshake with a one-time hard stop: it blocks
+//! the **first** claude-in-chrome tool call of a session (exit 2, re-clarify
+//! message), writes a per-session marker, and allows every subsequent call —
+//! including a blind retry of the same call. It *prompts* the selection; it
+//! does not *enforce* that a device was actually chosen (see the policy note
+//! below). By design a deliberate soft confirmation, not a hard gate.
 //!
 //! **Policy note (deliberate exception to `developing-guards`).** The
 //! block-vs-nudge heuristic would route "a single connected browser makes


### PR DESCRIPTION
Reconciles a self-contradictory doc-comment on `guard-browser-device`. Line 13 claimed the guard "makes the handshake **enforced**" while lines 24-26 admit it "does not verify a device was actually chosen." Both can't be true.

The guard is a **deliberate soft confirmation** (intentional and documented since #75): it blocks the first claude-in-chrome tool call once (exit 2), writes a per-session marker, and allows every subsequent call — including a blind retry. It *prompts* the device selection; it does not *enforce* it. This PR fixes only the doc-comment to describe that behavior honestly. No behavior change — closing as works-as-intended.

Closes #134
