### PR TITLE
docs(testing): isolate a block to the binary vs the run-cadence-hooks wrapper (#69)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   (#140). The changelog jumped `[0.31.0]` → `[0.29.0]`; the three fixes that
   shipped in v0.30.0 are now stamped into a versioned section.
 - docs(hooks): add missing metrics-logger rows (`log-session`, `log-polish-nudge`, `log-ask-user-question`) to the cadence-metrics table in `docs/hooks.md` (#178)
+- docs(testing): document isolating a block to the binary vs the run-cadence-hooks wrapper, and the wrapper's fail-open signal (#69)
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ cadence-hooks --help
 
 - [docs/hooks.md](docs/hooks.md) — full hook catalog (all 45 hooks + CLI actions)
 - [docs/configuration.md](docs/configuration.md) — `hooks.json` wiring, environment variables, the `doctor` audit, snoozing `warn-main-branch`
-- [docs/testing.md](docs/testing.md) — run any hook against a sample payload by hand
+- [docs/testing.md](docs/testing.md) — run any hook against a sample payload by hand, including how to tell a real binary block from a wrapper fail-open
 - [CONTRIBUTING.md](CONTRIBUTING.md) — adding a hook and the check-author debugging loop
 - [SECURITY.md](SECURITY.md) — release signing, SBOM, and verification
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -57,3 +57,27 @@ Writing or debugging a check? See
 [CONTRIBUTING.md → Reproducing a Check by Hand](../CONTRIBUTING.md#reproducing-a-check-by-hand)
 for the check-author's debugging loop and the per-tool payload shapes
 (Write/Edit/MultiEdit carry their content in different fields).
+
+## Is a block the binary or the wrapper?
+
+A guard firing is unambiguous — the `cadence-hooks` binary decided to block
+and the tool call exits **2**. A silent allow is not: it can mean the binary
+ran and chose to allow, or it can mean the `run-cadence-hooks.sh` wrapper
+**failed open** (the binary is missing from `PATH`, or is stale enough that
+the wrapper hands it a subcommand it no longer recognizes) and no guard ran
+at all.
+
+To tell them apart, isolate the binary from the wrapper — pipe the same
+payload (or use `try`, above) straight to the subcommand and read the exit
+code directly, bypassing `run-cadence-hooks.sh`:
+
+```bash
+echo '{"tool_name":"Bash","tool_input":{"command":"git push --force origin main"}}' \
+  | cadence-hooks guardrails guard-push-remote; echo "exit: $?"
+```
+
+A `2` there is a real block from the binary. If it's `0` with no output, the
+binary allowed it — but if guards feel inert across the board, the wrapper is
+the next suspect, not the binary. A failed-open wrapper now emits a once/day
+stderr notice (`cameronsjo/cadence#223`) — that notice, not a silent `exit 0`,
+is the signal that guards aren't running.


### PR DESCRIPTION
Documents how to tell whether a silent no-block is the binary allowing vs the `run-cadence-hooks.sh` wrapper failing open (binary missing/stale) — a short `docs/testing.md` section (a real block exits 2 from the binary; a silent exit 0 with no diagnostic points at the wrapper) plus a README pointer.

This is the cadence-hooks docs slice of #69. The wrapper stderr-notice itself — the meat of #69 — lives in the `cameronsjo/cadence` monorepo and is tracked as cameronsjo/cadence#223.

Refs #69
