### PR TITLE
fix(rules): gate warn-recommended-option on stance==Silent (cadence-hooks#148)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- warn-recommended-option now allows a declared "no clear recommendation" stance (fires only on true silence) (#148)
+
 ## [0.45.0] - 2026-07-03
 
 ### Added

--- a/crates/rules/src/askuserquestion.rs
+++ b/crates/rules/src/askuserquestion.rs
@@ -113,18 +113,17 @@ impl Check for WarnRecommendedOption {
         if questions.is_empty() {
             return CheckResult::allow();
         }
-        // Stage 1 (diagnose): behavior unchanged — still nudge whenever no option
-        // is labeled "(Recommended)". Stage 2 will gate this on `stance(...) ==
-        // Silent` so a declared "no clear recommendation" stops tripping it.
-        if has_recommended(questions) {
-            CheckResult::allow()
-        } else {
+        // Stage 2: nudge only on true silence. A declared "no clear
+        // recommendation" (DeclaredNoRec) is a legible stance, so it no longer trips.
+        if stance(questions) == Stance::Silent {
             CheckResult::nudge(
                 "None of these AskUserQuestion options is labeled \"(Recommended)\". \
                  If one option is your clear recommendation, label it \"(Recommended)\" \
                  and list it first so the user can decide faster. If the options are \
                  genuinely equivalent, no change is needed.",
             )
+        } else {
+            CheckResult::allow()
         }
     }
 }
@@ -291,6 +290,27 @@ mod tests {
                         ..Default::default()
                     },
                 ]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        assert_eq!(
+            WarnRecommendedOption.run(&input).outcome,
+            cadence_hooks_core::Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn pre_declared_no_rec_allows() {
+        // A declared "no clear recommendation" is a legible stance (DeclaredNoRec),
+        // not silence — the nudge should not trip even with no labeled option.
+        let input = HookInput {
+            tool_name: Some("AskUserQuestion".into()),
+            tool_input: Some(ToolInput {
+                questions: Some(vec![q(
+                    "Which approach? — no clear recommendation",
+                    &["A", "B"],
+                )]),
                 ..Default::default()
             }),
             ..Default::default()


### PR DESCRIPTION
## What

The AskUserQuestion recommended-option nudge (`warn-recommended-option`) fired even when Claude explicitly declared "no clear recommendation." This gates it correctly: it now nudges only on true silence.

## Why it isn't a no-op

The gate keyed on `has_recommended` (two buckets), but the `stance()` classifier has three: `Recommended`, `DeclaredNoRec`, `Silent`. The `DeclaredNoRec` bucket — options unlabeled, but the question text declares no clear recommendation — was nudged despite being a legible stance. This flips only that bucket from nudge → allow. `Recommended` (allow) and `Silent` (nudge) are unchanged.

## Change

- `crates/rules/src/askuserquestion.rs`: `if stance(questions) == Stance::Silent { nudge } else { allow }` (was `has_recommended`). Nudge message text unchanged.
- New test `pre_declared_no_rec_allows`; existing recommended/silent tests unchanged.

## Verification

- `cargo test` — full workspace green (rules crate: 119 passed, incl. the new test)
- `cargo clippy --all-targets -- -D warnings` — clean

## Scope

Ships the hook-gating half of #148. The companion — documenting the "no clear recommendation" stance marker so authors know to declare it — is a prose change in the cadence repo and tracks separately, so this deliberately does not close the issue.

Part of cameronsjo/cadence-hooks#148


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved option-label guidance so it only appears when a question is truly silent.
  * Questions that explicitly say there is “no clear recommendation” are now accepted without extra prompting.
  * Added coverage to ensure this behavior stays consistent.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->