### PR TITLE
fix(guardrails): resolve git-common-dir for dismiss-enforce-worktree marker so it works in linked worktrees (cadence-hooks#179)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - audience-aware redaction — redact-external-content now gates each hit on destination-tier vs per-category ceiling (d>c), nudge-only (#159)
+### Fixed
+
+- **`dismiss-enforce-worktree` marker now resolves the git common dir, so snoozing works from a linked worktree (#179).** The marker was written under the passed directory's own `.git/cadence-hooks/`, which for a linked worktree is the per-worktree git dir — invisible to the primary checkout where the guard fires. Both the reader and the dismiss CLI now resolve the shared common dir via `git rev-parse --git-common-dir`, so a snooze recorded from any worktree is honoured at the primary. Fail-open on non-repos preserved (ADR-0001).
 
 ## [0.45.0] - 2026-07-03
 

--- a/crates/guardrails/src/dismiss_enforce_worktree.rs
+++ b/crates/guardrails/src/dismiss_enforce_worktree.rs
@@ -1,33 +1,60 @@
 //! Per-repo snooze for the `enforce-worktree` guard.
 //!
 //! Mirrors [`crate::dismiss_main_branch_warn`] — same marker format
-//! (epoch-seconds line under `.git/cadence-hooks/`), same 24h cap, same
-//! duration grammar — but with its own marker file so snoozing the hard block
-//! and snoozing the main-branch nudge stay independent decisions.
+//! (epoch-seconds line), same 24h cap, same duration grammar — but with its own
+//! marker file so snoozing the hard block and snoozing the main-branch nudge stay
+//! independent decisions.
 //!
 //! Exposes:
 //! - `is_snoozed_now(repo_root)` — used by `enforce-worktree` before blocking
 //! - `run_dismiss(duration_str)` — the `dismiss-enforce-worktree` subcommand
 //!
-//! The marker lives in the **primary checkout's** `.git/` directory — which is
-//! exactly where the guard fires, so `git rev-parse --show-toplevel` from the
-//! blocked directory resolves to the right root.
+//! The marker lives under the **git common dir**
+//! (`<primary>/.git/cadence-hooks/`), which every linked worktree shares — so a
+//! snooze recorded from inside a worktree is seen from the primary checkout,
+//! where the guard actually fires (#179). Both the reader and the dismiss CLI
+//! resolve the common dir via `git rev-parse --git-common-dir` rather than
+//! assuming the marker sits under the passed directory's own `.git`.
 
 use crate::dismiss_main_branch_warn::{is_snoozed_at, parse_duration};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{self, Command};
+use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
-const SNOOZE_DIR: &str = ".git/cadence-hooks";
+/// Subdirectory (relative to the git common dir) that holds the marker. The
+/// common dir already ends in `.git`, so this is `.git/cadence-hooks/` on disk.
+const SNOOZE_DIR: &str = "cadence-hooks";
 const SNOOZE_FILE: &str = "enforce-worktree-snoozed-until";
 /// Same cap as the main-branch snooze: a lingering marker would silently
 /// disable the block long after the one-off reason for it expired.
 const MAX_SNOOZE_SECONDS: u64 = 24 * 60 * 60;
 
-/// Marker file path for a given repo root.
-pub fn marker_path(repo_root: &Path) -> PathBuf {
-    repo_root.join(SNOOZE_DIR).join(SNOOZE_FILE)
+/// Marker file path within a git common dir.
+///
+/// `git_common_dir` is the primary checkout's `.git` directory — shared across
+/// all linked worktrees — so the marker resolves to
+/// `<primary>/.git/cadence-hooks/enforce-worktree-snoozed-until` no matter which
+/// worktree wrote it.
+pub fn marker_path(git_common_dir: &Path) -> PathBuf {
+    git_common_dir.join(SNOOZE_DIR).join(SNOOZE_FILE)
+}
+
+/// Resolve the absolute git common dir for `dir` via
+/// `git rev-parse --git-common-dir`. `None` when `dir` is not inside a git repo
+/// (or git is unavailable) — callers treat that as fail-open.
+fn git_common_dir(dir: &Path) -> Option<PathBuf> {
+    cadence_hooks_core::shell::git_command(
+        &dir.to_string_lossy(),
+        &["rev-parse", "--path-format=absolute", "--git-common-dir"],
+    )
+    .map(PathBuf::from)
+}
+
+/// The marker path for `dir`, resolving the shared common dir first. `None` when
+/// `dir` is not inside a git repo. Used by the reader and the tests.
+pub fn marker_path_for(dir: &Path) -> Option<PathBuf> {
+    git_common_dir(dir).map(|c| marker_path(&c))
 }
 
 fn now_epoch() -> u64 {
@@ -38,33 +65,26 @@ fn now_epoch() -> u64 {
 }
 
 /// Read the marker for the given repo and decide if the snooze is active.
+///
+/// Resolves the marker through the shared git common dir, so a snooze written
+/// from a linked worktree is honoured here at the primary checkout. A missing
+/// marker, or a `repo_root` that isn't inside a git repo, yields `false`
+/// (fail-open — ADR-0001).
 pub fn is_snoozed_now(repo_root: &Path) -> bool {
-    let Ok(contents) = fs::read_to_string(marker_path(repo_root)) else {
+    let Some(path) = marker_path_for(repo_root) else {
+        return false;
+    };
+    let Ok(contents) = fs::read_to_string(path) else {
         return false;
     };
     is_snoozed_at(&contents, now_epoch())
 }
 
-/// Locate the current repo root via `git rev-parse --show-toplevel`.
-fn repo_root() -> Option<PathBuf> {
-    let out = Command::new("git")
-        .args(["rev-parse", "--show-toplevel"])
-        .output()
-        .ok()
-        .filter(|o| o.status.success())?;
-    let path = String::from_utf8_lossy(&out.stdout).trim().to_string();
-    if path.is_empty() {
-        None
-    } else {
-        Some(PathBuf::from(path))
-    }
-}
-
 /// Entry point for the `dismiss-enforce-worktree` subcommand.
 ///
-/// Writes the epoch-seconds expiry marker and confirms. Exits 1 on failure
-/// (missing repo, invalid duration, write error); 0 on success — this is a
-/// user-facing CLI, not a hook.
+/// Writes the epoch-seconds expiry marker under the shared git common dir and
+/// confirms. Exits 1 on failure (missing repo, invalid duration, write error);
+/// 0 on success — this is a user-facing CLI, not a hook.
 pub fn run_dismiss(duration_str: &str) -> ! {
     let Some(duration) = parse_duration(duration_str) else {
         eprintln!(
@@ -83,7 +103,8 @@ pub fn run_dismiss(duration_str: &str) -> ! {
         process::exit(1);
     }
 
-    let Some(root) = repo_root() else {
+    let cwd = Path::new(".");
+    let Some(common) = git_common_dir(cwd) else {
         eprintln!(
             "cadence-hooks: not inside a git repository\n   \
              dismiss-enforce-worktree must be run from within the repo you want to unblock."
@@ -91,7 +112,7 @@ pub fn run_dismiss(duration_str: &str) -> ! {
         process::exit(1);
     };
 
-    let path = marker_path(&root);
+    let path = marker_path(&common);
     if let Some(parent) = path.parent()
         && let Err(e) = fs::create_dir_all(parent)
     {
@@ -105,9 +126,13 @@ pub fn run_dismiss(duration_str: &str) -> ! {
         process::exit(1);
     }
 
+    // Prefer the friendly repo toplevel for the confirmation; fall back to the
+    // common dir if `--show-toplevel` doesn't resolve (e.g. a bare repo).
+    let where_display =
+        cadence_hooks_core::shell::git_command(".", &["rev-parse", "--show-toplevel"])
+            .unwrap_or_else(|| common.display().to_string());
     println!(
-        "enforce-worktree unblocked for {duration_str} in {} (until epoch {until})",
-        root.display()
+        "enforce-worktree unblocked for {duration_str} in {where_display} (until epoch {until})"
     );
     process::exit(0);
 }
@@ -115,10 +140,27 @@ pub fn run_dismiss(duration_str: &str) -> ! {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::process::Command;
+
+    /// Init a bare-minimum git repo in a fresh tempdir. No commit — enough for
+    /// `--git-common-dir` to resolve. Returns the tempdir (kept alive by caller).
+    fn init_repo() -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let ok = Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["init", "-q"])
+            .output()
+            .unwrap()
+            .status
+            .success();
+        assert!(ok, "git init failed");
+        tmp
+    }
 
     #[test]
     fn marker_path_is_under_dot_git() {
-        let p = marker_path(Path::new("/tmp/repo"));
+        let p = marker_path(Path::new("/tmp/repo/.git"));
         assert_eq!(
             p,
             Path::new("/tmp/repo/.git/cadence-hooks/enforce-worktree-snoozed-until")
@@ -127,35 +169,104 @@ mod tests {
 
     #[test]
     fn marker_is_distinct_from_main_branch_snooze() {
-        // Snoozing the hard block and snoozing the nudge are independent.
+        // Snoozing the hard block and snoozing the nudge are independent. The
+        // enforce marker keys off the common dir (`.git`); the main-branch legacy
+        // reference keys off the repo root — distinctness holds either way.
         let root = Path::new("/tmp/repo");
         assert_ne!(
-            marker_path(root),
+            marker_path(&root.join(".git")),
             crate::dismiss_main_branch_warn::marker_path(root)
         );
     }
 
     #[test]
     fn unreadable_marker_is_not_snoozed() {
-        let tmp = tempfile::TempDir::new().unwrap();
+        // Real repo, no marker written → read fails → not snoozed.
+        let tmp = init_repo();
+        assert!(!is_snoozed_now(tmp.path()));
+    }
+
+    #[test]
+    fn non_repo_dir_is_not_snoozed() {
+        // A directory outside any git repo → common dir unresolved → fail-open.
+        let tmp = tempfile::tempdir().unwrap();
         assert!(!is_snoozed_now(tmp.path()));
     }
 
     #[test]
     fn future_marker_is_snoozed() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let path = marker_path(tmp.path());
+        let tmp = init_repo();
+        let repo = tmp.path();
+        let path = marker_path_for(repo).unwrap();
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, format!("{}\n", now_epoch() + 3600)).unwrap();
-        assert!(is_snoozed_now(tmp.path()));
+        assert!(is_snoozed_now(repo));
     }
 
     #[test]
     fn expired_marker_is_not_snoozed() {
-        let tmp = tempfile::TempDir::new().unwrap();
-        let path = marker_path(tmp.path());
+        let tmp = init_repo();
+        let repo = tmp.path();
+        let path = marker_path_for(repo).unwrap();
         fs::create_dir_all(path.parent().unwrap()).unwrap();
         fs::write(&path, "100\n").unwrap();
-        assert!(!is_snoozed_now(tmp.path()));
+        assert!(!is_snoozed_now(repo));
+    }
+
+    #[test]
+    fn dismiss_writes_marker_readable_across_linked_worktree() {
+        // A snooze recorded from inside a linked worktree must be seen from the
+        // primary checkout, since they share one git common dir (#179).
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("repo");
+        fs::create_dir(&primary).unwrap();
+        let git = |dir: &Path, args: &[&str]| {
+            let ok = Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&primary, &["init", "-q"]);
+        // `git worktree add -b` bases the new branch on HEAD, so a commit must
+        // exist first.
+        git(
+            &primary,
+            &[
+                "-c",
+                "user.email=t@t",
+                "-c",
+                "user.name=t",
+                "commit",
+                "-q",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        );
+        let worktree = tmp.path().join("wt");
+        git(
+            &primary,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                &worktree.to_string_lossy(),
+                "-b",
+                "feat/x",
+            ],
+        );
+
+        // Write the snooze via the worktree's resolved marker path...
+        let path = marker_path_for(&worktree).unwrap();
+        fs::create_dir_all(path.parent().unwrap()).unwrap();
+        fs::write(&path, format!("{}\n", now_epoch() + 3600)).unwrap();
+
+        // ...and read it back from the primary checkout.
+        assert!(is_snoozed_now(&primary));
     }
 }

--- a/crates/guardrails/src/enforce_worktree.rs
+++ b/crates/guardrails/src/enforce_worktree.rs
@@ -582,7 +582,7 @@ mod tests {
         let scratch = Scratch::new("snooze");
         let (primary, _wt) = primary_and_worktree(&scratch);
 
-        let marker = dismiss_enforce_worktree::marker_path(&primary);
+        let marker = dismiss_enforce_worktree::marker_path_for(&primary).unwrap();
         std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
         let until = std::time::SystemTime::now()
             .duration_since(std::time::UNIX_EPOCH)


### PR DESCRIPTION
## What

The `dismiss-enforce-worktree` snooze marker was written to `<repo-root>/.git/cadence-hooks/...`. In a linked worktree, `<root>/.git` is a file (a gitdir pointer), not a directory, so `create_dir_all` failed with `Not a directory (os error 20)` — dismissing the enforce-worktree block was impossible from a linked worktree.

## Fix

Resolve the git *common* dir via `git rev-parse --path-format=absolute --git-common-dir` and anchor the marker there (`<common>/cadence-hooks/...`). Writer and reader resolve identically, so a snooze recorded from a linked worktree is seen from the primary checkout. `--path-format=absolute` is load-bearing — bare `--git-common-dir` returns a relative `.git` from the primary, which would diverge the two sides.

Backward compatible: for a primary checkout the common dir is `<root>/.git`, so the marker path is byte-identical to before. No migration. Fail-open behavior (ADR-0001) preserved on every git-resolution miss.

## Change

- `crates/guardrails/src/dismiss_enforce_worktree.rs`: `SNOOZE_DIR` → `cadence-hooks`; `marker_path(git_common_dir)`; new `git_common_dir()` + `marker_path_for()`; `is_snoozed_now`/`run_dismiss` resolve the common dir; module doc rewritten; test module rewritten to build real git repos.
- New regression test `dismiss_writes_marker_readable_across_linked_worktree` (snooze from a linked worktree, read from primary).
- `enforce_worktree.rs`: one test updated to `marker_path_for`; runtime caller unchanged.

## Verification

- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p cadence-hooks-guardrails` — 670 passed. The 2 `enforce_worktree` failures are pre-existing and environmental: `is_temp_root` exempts repos under `/tmp`, and these tests build scratch repos under a `/tmp` worktree — they fail identically on pristine `origin/main` and pass in CI (which runs outside `/tmp`).

Closes cameronsjo/cadence-hooks#179
