### PR TITLE
feat(metrics): stamp session bounds (startTs/endTs/durationMs) + commits count on sessions.jsonl (cadence-hooks#182)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Fixed
 
 - **`dismiss-enforce-worktree` marker now resolves the git common dir, so snoozing works from a linked worktree (#179).** The marker was written under the passed directory's own `.git/cadence-hooks/`, which for a linked worktree is the per-worktree git dir — invisible to the primary checkout where the guard fires. Both the reader and the dismiss CLI now resolve the shared common dir via `git rev-parse --git-common-dir`, so a snooze recorded from any worktree is honoured at the primary. Fail-open on non-repos preserved (ADR-0001).
+### Added
+
+- session bounds (startTs/endTs/durationMs) and commits count on sessions.jsonl, plus a log-session-start hook to stamp SessionStart (#182)
 
 ## [0.45.0] - 2026-07-03
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -245,6 +245,7 @@ version = "0.45.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
+ "jiff",
  "regex",
  "serde",
  "serde_json",

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -11,6 +11,7 @@ cadence-hooks-rules.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 regex.workspace = true
+jiff.workspace = true
 
 [dev-dependencies]
 cadence-hooks-core = { workspace = true, features = ["test-builders"] }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -20,6 +20,8 @@ pub mod log_denial;
 pub mod log_polish_nudge;
 /// Append per-session cost records to `sessions.jsonl` at `SessionEnd`.
 pub mod log_session;
+/// Stamp this session's start timestamp at `SessionStart`.
+pub mod log_session_start;
 /// Append subagent lifecycle records to `subagents.jsonl`.
 pub mod log_subagent;
 /// Append threshold-gated hook self-timing records to `hooks.jsonl`.
@@ -40,6 +42,7 @@ pub use log_commit::LogCommit;
 pub use log_denial::log_denial;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_session::LogSession;
+pub use log_session_start::LogSessionStart;
 pub use log_subagent::LogSubagent;
 pub use log_timing::log_timing;
 pub use snapshot::Snapshot;

--- a/crates/metrics/src/log_session.rs
+++ b/crates/metrics/src/log_session.rs
@@ -50,6 +50,16 @@ impl Logger for LogSession {
             return;
         }
 
+        // The marker from the `log-session-start` SessionStart partner. Consume
+        // it (mirrors `log_commit`'s `.before` handling) so a later session
+        // can't reuse a stale timestamp.
+        let start_marker = common::state_dir().join(format!("{session_id}.start"));
+        let start_ts = std::fs::read_to_string(&start_marker)
+            .ok()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty());
+        let _ = std::fs::remove_file(&start_marker);
+
         let Ok(transcript) = std::fs::read_to_string(transcript_path) else {
             return;
         };
@@ -63,9 +73,20 @@ impl Logger for LogSession {
 
         let branch = common::branch(input.cwd.as_deref());
         let repo = common::repo_basename(input.cwd.as_deref());
+        let ts = common::utc_timestamp();
+
+        let dir = common::metrics_dir();
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+        let commits_path = dir.join("commits.jsonl");
+        let commits = std::fs::read_to_string(&commits_path)
+            .ok()
+            .map(|contents| count_commits(&contents, session_id))
+            .unwrap_or(0);
 
         let record = build_session_record(
-            &common::utc_timestamp(),
+            &ts,
             input,
             session_id,
             &branch,
@@ -73,12 +94,10 @@ impl Logger for LogSession {
             &scan,
             cost,
             &prices,
+            start_ts.as_deref(),
+            commits,
         );
 
-        let dir = common::metrics_dir();
-        if std::fs::create_dir_all(&dir).is_err() {
-            return;
-        }
         let sessions_path = dir.join("sessions.jsonl");
 
         if let Ok(mut file) = std::fs::OpenOptions::new()
@@ -97,6 +116,31 @@ impl Logger for LogSession {
     }
 }
 
+/// Count `commits.jsonl` rows belonging to `session_id`. Pure — operates on
+/// file contents, no I/O. Patterned on `log_commit::parse_last_message_id`.
+fn count_commits(commits_jsonl: &str, session_id: &str) -> u64 {
+    commits_jsonl
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|v| v.get("sessionId").and_then(Value::as_str) == Some(session_id))
+        .count() as u64
+}
+
+/// Session wall-clock duration in milliseconds, from the `log-session-start`
+/// marker (`start_ts`) to this record's own `ts`. Both are second-precision
+/// ISO 8601 timestamps from the same [`common::utc_timestamp`] source, so this
+/// is second-granular — a coarser fallback than `durationApproxMs` (which
+/// carries Claude Code's own millisecond-precision session timer, when the
+/// payload provides one). `None` when there's no start marker (e.g. a session
+/// that started before this feature shipped) or either timestamp fails to
+/// parse.
+fn session_duration_ms(start_ts: Option<&str>, ts: &str) -> Option<i64> {
+    let start: jiff::Timestamp = start_ts?.parse().ok()?;
+    let end: jiff::Timestamp = ts.parse().ok()?;
+    let diff = end.duration_since(start);
+    Some(diff.as_secs() * 1000 + i64::from(diff.subsec_millis()))
+}
+
 /// Build the `sessions.jsonl` record. Pure — no I/O. The `byModel`/`unpricedModels`
 /// shapes come from [`crate::model_breakdown`], shared verbatim with `log_commit`.
 #[allow(clippy::too_many_arguments)]
@@ -109,9 +153,12 @@ fn build_session_record(
     scan: &ScanResult,
     cost: f64,
     prices: &Prices,
+    start_ts: Option<&str>,
+    commits: u64,
 ) -> Value {
     let by_model = by_model_json(&scan.by_model, prices);
     let unpriced = unpriced_models(&scan.by_model, prices);
+    let duration_ms = session_duration_ms(start_ts, ts);
 
     json!({
         "ts": ts,
@@ -121,6 +168,10 @@ fn build_session_record(
         "branch": branch,
         "reason": input.reason,
         "durationApproxMs": input.duration_ms,
+        "startTs": start_ts,
+        "endTs": ts,
+        "durationMs": duration_ms,
+        "commits": commits,
         "model": scan.model,
         "tokens": {
             "input": scan.tokens.input,
@@ -196,6 +247,8 @@ mod tests {
             &sample_scan(),
             0.001234,
             &prices,
+            None,
+            2,
         );
         assert_eq!(record["sessionId"], "s1");
         assert_eq!(record["transcriptPath"], "/tmp/t.jsonl");
@@ -203,6 +256,7 @@ mod tests {
         assert_eq!(record["branch"], "feat/x");
         assert_eq!(record["reason"], "prompt_input_exit");
         assert_eq!(record["durationApproxMs"], 4567);
+        assert_eq!(record["commits"], 2);
         assert_eq!(record["model"], "claude-opus-4-7");
         assert_eq!(record["tokens"]["input"], 100);
         assert_eq!(record["tokens"]["cacheCreate"], 50);
@@ -239,6 +293,8 @@ mod tests {
             &sample_scan(),
             0.0,
             &prices,
+            None,
+            0,
         );
         // Absent → null, not omitted.
         assert!(record["reason"].is_null());
@@ -246,6 +302,11 @@ mod tests {
         assert!(record["agentId"].is_null());
         assert!(record["parentSessionId"].is_null());
         assert_eq!(record["branch"], "");
+        // No start marker → startTs/durationMs null, endTs still stamped, commits 0.
+        assert!(record["startTs"].is_null());
+        assert!(record["durationMs"].is_null());
+        assert_eq!(record["endTs"], "2026-07-02T00:00:00Z");
+        assert_eq!(record["commits"], 0);
     }
 
     #[test]
@@ -278,10 +339,57 @@ mod tests {
             &scan,
             0.0,
             &prices,
+            None,
+            0,
         );
         let unpriced = record["unpricedModels"].as_array().unwrap();
         assert_eq!(unpriced.len(), 1);
         assert_eq!(unpriced[0], "gpt-9");
+    }
+
+    #[test]
+    fn session_record_start_ts_present_computes_duration() {
+        let prices = Prices::embedded();
+        let record = build_session_record(
+            "2026-07-02T00:10:30Z",
+            &sample_input(),
+            "s1",
+            "main",
+            "r",
+            &sample_scan(),
+            0.0,
+            &prices,
+            Some("2026-07-02T00:10:00Z"),
+            5,
+        );
+        assert_eq!(record["startTs"], "2026-07-02T00:10:00Z");
+        assert_eq!(record["endTs"], "2026-07-02T00:10:30Z");
+        assert_eq!(record["durationMs"], 30_000);
+        assert_eq!(record["commits"], 5);
+    }
+
+    #[test]
+    fn session_duration_ms_unparseable_start_is_none() {
+        assert_eq!(
+            session_duration_ms(Some("not-a-timestamp"), "2026-07-02T00:00:00Z"),
+            None
+        );
+        assert_eq!(session_duration_ms(None, "2026-07-02T00:00:00Z"), None);
+    }
+
+    #[test]
+    fn count_commits_counts_matching_session_rows() {
+        let jsonl = [
+            r#"{"sessionId":"s1"}"#,
+            r#"{"sessionId":"s2"}"#,
+            r#"{"sessionId":"s1"}"#,
+            r#"{"sessionId":"s1"}"#,
+        ]
+        .join("\n");
+        assert_eq!(count_commits(&jsonl, "s1"), 3);
+        assert_eq!(count_commits(&jsonl, "s2"), 1);
+        assert_eq!(count_commits(&jsonl, "other"), 0);
+        assert_eq!(count_commits("", "s1"), 0);
     }
 
     /// Whole ≥ parts: a session scan of the full transcript costs at least as

--- a/crates/metrics/src/log_session_start.rs
+++ b/crates/metrics/src/log_session_start.rs
@@ -1,0 +1,105 @@
+//! `SessionStart` — stamp the current timestamp as this session's start marker
+//! at `<state_dir>/<session_id>.start`, so the paired `log-session` logger can
+//! compute a session's wall-clock duration at `SessionEnd`.
+//!
+//! Sibling of [`crate::snapshot`]: same before-marker shape, different pairing
+//! (`log-session` reads and consumes the marker instead of `log-commit`).
+//! Fire-and-forget: silent no-op on any failure, never blocks.
+
+use crate::common;
+use cadence_hooks_core::{Logger, MetricsInput};
+
+/// Stamps the session start timestamp at `SessionStart`.
+pub struct LogSessionStart;
+
+impl Logger for LogSessionStart {
+    fn name(&self) -> &str {
+        "log-session-start"
+    }
+
+    fn run(&self, input: &MetricsInput) {
+        if input.hook_event_name.as_deref() != Some("SessionStart") {
+            return;
+        }
+
+        let Some(session_id) = input
+            .session_id
+            .as_deref()
+            .filter(|s| common::is_safe_session_id(s))
+        else {
+            return;
+        };
+
+        let dir = common::state_dir();
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+
+        let _ = std::fs::write(
+            dir.join(format!("{session_id}.start")),
+            common::utc_timestamp(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn input_with(event: &str, session: Option<&str>) -> MetricsInput {
+        MetricsInput {
+            session_id: session.map(String::from),
+            hook_event_name: Some(event.to_string()),
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn name_is_log_session_start() {
+        assert_eq!(LogSessionStart.name(), "log-session-start");
+    }
+
+    #[test]
+    fn non_session_start_is_noop() {
+        LogSessionStart.run(&input_with("SessionEnd", Some("s1")));
+    }
+
+    #[test]
+    fn missing_session_is_noop() {
+        LogSessionStart.run(&input_with("SessionStart", None));
+        LogSessionStart.run(&input_with("SessionStart", Some("")));
+    }
+
+    #[test]
+    fn unsafe_session_id_is_noop() {
+        LogSessionStart.run(&input_with("SessionStart", Some("../../etc/passwd")));
+        LogSessionStart.run(&input_with("SessionStart", Some("a/b")));
+    }
+
+    #[test]
+    fn session_start_writes_marker() {
+        // `CADENCE_METRICS_DIR` is process-global — serialize against every
+        // other env-mutating test crate-wide (see `common::ENV_LOCK`).
+        let _guard = common::ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let tmp = tempfile::tempdir().unwrap();
+        // SAFETY: serialized against every other env-mutating test crate-wide via `common::ENV_LOCK`.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", tmp.path());
+        }
+
+        LogSessionStart.run(&input_with("SessionStart", Some("s1")));
+
+        let marker = tmp.path().join("state").join("s1.start");
+        assert!(marker.is_file(), "expected {marker:?} to exist");
+        let contents = std::fs::read_to_string(&marker).unwrap();
+        assert!(
+            contents.ends_with('Z'),
+            "expected an ISO timestamp: {contents}"
+        );
+
+        // SAFETY: serialized against every other env-mutating test crate-wide via `common::ENV_LOCK`.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+        }
+    }
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -96,6 +96,7 @@ exit 0. They never block a tool call (see
 | `log-commit` | PostToolUse (Bash, `git commit`) | Scan the transcript for tokens since the last commit, compute cost, append to `commits.jsonl` |
 | `log-subagent` | SubagentStart / SubagentStop | Append a subagent lifecycle record to `subagents.jsonl` |
 | `log-session` | SessionEnd | Scan the whole session log at session end, compute per-model cost, append to `sessions.jsonl` |
+| `log-session-start` | SessionStart | Stamp the session start timestamp, so `log-session` can compute `durationMs` at `SessionEnd` |
 | `log-polish-nudge` | PostToolUse (Bash, `gh pr create`) | Record every nudged PR and whether `/polish` ran earlier this session, append to `polish_nudges.jsonl` |
 | `log-ask-user-question` | PreToolUse (`AskUserQuestion`) | Record each call's stance (recommended / declared-no-rec / silent) and shape (multiSelect, question/option counts), append to `askuserquestion.jsonl` |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,6 +263,8 @@ enum MetricsCommands {
         #[arg(long, value_name = "PATH")]
         prices: Option<String>,
     },
+    /// Capture session start timestamp (SessionStart)
+    LogSessionStart,
     /// Log polish-nudge skips: `gh pr create` + whether /polish ran (PostToolUse)
     LogPolishNudge,
     /// Log AskUserQuestion stance + shape on every call (PreToolUse)
@@ -384,6 +386,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::LogCommit { .. } => "log-commit",
             MetricsCommands::LogSubagent => "log-subagent",
             MetricsCommands::LogSession { .. } => "log-session",
+            MetricsCommands::LogSessionStart => "log-session-start",
             MetricsCommands::LogPolishNudge => "log-polish-nudge",
             MetricsCommands::LogAskUserQuestion => "log-ask-user-question",
             MetricsCommands::WarnStale => "warn-stale",
@@ -915,6 +918,11 @@ fn main() {
                     prices_path: prices,
                 },
                 registry::sample_for("metrics", "log-session"),
+                canonical_hook,
+            ),
+            MetricsCommands::LogSessionStart => dispatch::run_logged_logger(
+                &cadence_hooks_metrics::LogSessionStart,
+                registry::sample_for("metrics", "log-session-start"),
                 canonical_hook,
             ),
             MetricsCommands::LogPolishNudge => dispatch::run_logged_logger(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -315,6 +315,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: None,
     },
     HookEntry {
+        name: "log-session-start",
+        description: "Capture session start timestamp (SessionStart)",
+        plugin: "metrics",
+        event: None,
+    },
+    HookEntry {
         name: "log-polish-nudge",
         description: "Log polish-nudge skips: gh pr create + whether /polish ran (PostToolUse)",
         plugin: "metrics",
@@ -440,6 +446,11 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         ("metrics", "log-session") => Some(
             r#"{"session_id":"test","hook_event_name":"SessionEnd","transcript_path":"/tmp/transcript.jsonl","cwd":"/tmp","reason":"prompt_input_exit"}"#,
         ),
+        // log-session-start gates on hook_event_name == "SessionStart"; the
+        // generic logger sample carries a different event and would no-op.
+        ("metrics", "log-session-start") => {
+            Some(r#"{"session_id":"test","hook_event_name":"SessionStart","cwd":"/tmp"}"#)
+        }
         // log-polish-nudge gates on a `gh pr create` command (the nudge denominator)
         ("metrics", "log-polish-nudge") => Some(
             r#"{"session_id":"test","hook_event_name":"PostToolUse","tool_input":{"command":"gh pr create --title test"},"transcript_path":"/tmp/transcript.jsonl"}"#,
@@ -614,6 +625,7 @@ mod tests {
             "log-commit",
             "log-subagent",
             "log-session",
+            "log-session-start",
             "log-polish-nudge",
             "log-ask-user-question",
             "heartbeat",

--- a/tests/session_log.rs
+++ b/tests/session_log.rs
@@ -163,6 +163,107 @@ fn unpriced_model_lands_in_unpriced_never_silently_zero() {
     assert!(row["reason"].is_null(), "absent reason → null");
 }
 
+// ── Session bounds: log-session-start / log-session round trip (#182) ────
+
+/// Build a SessionStart payload for `metrics log-session-start`.
+fn session_start_payload(session_id: &str) -> String {
+    serde_json::json!({
+        "session_id": session_id,
+        "hook_event_name": "SessionStart",
+        "cwd": "/tmp",
+    })
+    .to_string()
+}
+
+#[test]
+fn session_start_then_end_round_trip_computes_duration() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let transcript = dir.path().join("transcript.jsonl");
+    write_transcript(&transcript);
+
+    let mut start_cmd = cadence_hooks();
+    start_cmd.env("CADENCE_METRICS_DIR", dir.path());
+    start_cmd.args(["metrics", "log-session-start"]);
+    let start_output = run_with_stdin(start_cmd, &session_start_payload("sess-bounds"));
+    assert_eq!(start_output.status.code(), Some(0), "loggers always exit 0");
+
+    let mut end_cmd = cadence_hooks();
+    end_cmd.env("CADENCE_METRICS_DIR", dir.path());
+    end_cmd.args(["metrics", "log-session"]);
+    let payload = session_payload("sess-bounds", "SessionEnd", &transcript, None);
+    let end_output = run_with_stdin(end_cmd, &payload);
+    assert_eq!(end_output.status.code(), Some(0), "loggers always exit 0");
+
+    let contents = std::fs::read_to_string(dir.path().join("sessions.jsonl"))
+        .expect("sessions.jsonl must exist after SessionEnd");
+    let row: serde_json::Value =
+        serde_json::from_str(contents.lines().next().unwrap()).expect("row parses as JSON");
+    assert!(row["startTs"].is_string(), "startTs should be stamped");
+    assert!(row["endTs"].is_string(), "endTs should be stamped");
+    assert!(
+        row["durationMs"].as_i64().unwrap() >= 0,
+        "durationMs should be a non-negative number: {row}"
+    );
+
+    // The `.start` marker is consumed — a second SessionEnd for the same
+    // session must not see a stale duration.
+    assert!(
+        !dir.path().join("state").join("sess-bounds.start").exists(),
+        "start marker must be consumed"
+    );
+}
+
+#[test]
+fn session_end_without_start_marker_has_null_bounds() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let transcript = dir.path().join("transcript.jsonl");
+    write_transcript(&transcript);
+
+    // No log-session-start ran for this session — SessionEnd fires on its own.
+    let mut cmd = cadence_hooks();
+    cmd.env("CADENCE_METRICS_DIR", dir.path());
+    cmd.args(["metrics", "log-session"]);
+    let payload = session_payload("sess-no-start", "SessionEnd", &transcript, None);
+    let output = run_with_stdin(cmd, &payload);
+    assert_eq!(output.status.code(), Some(0));
+
+    let contents = std::fs::read_to_string(dir.path().join("sessions.jsonl")).expect("row written");
+    let row: serde_json::Value =
+        serde_json::from_str(contents.lines().next().unwrap()).expect("parse");
+    assert!(row["startTs"].is_null(), "no marker → startTs null");
+    assert!(row["durationMs"].is_null(), "no marker → durationMs null");
+    assert!(row["endTs"].is_string(), "endTs is always stamped");
+    assert_eq!(row["commits"], 0, "no commits.jsonl → commits 0");
+}
+
+#[test]
+fn session_end_counts_commits_for_this_session() {
+    let dir = tempfile::tempdir().expect("tempdir");
+    let transcript = dir.path().join("transcript.jsonl");
+    write_transcript(&transcript);
+
+    // Seed commits.jsonl with 2 rows for this session and 1 for another.
+    let commits_jsonl = [
+        r#"{"sessionId":"sess-commits"}"#,
+        r#"{"sessionId":"other-session"}"#,
+        r#"{"sessionId":"sess-commits"}"#,
+    ]
+    .join("\n");
+    std::fs::write(dir.path().join("commits.jsonl"), commits_jsonl).expect("seed commits.jsonl");
+
+    let mut cmd = cadence_hooks();
+    cmd.env("CADENCE_METRICS_DIR", dir.path());
+    cmd.args(["metrics", "log-session"]);
+    let payload = session_payload("sess-commits", "SessionEnd", &transcript, None);
+    let output = run_with_stdin(cmd, &payload);
+    assert_eq!(output.status.code(), Some(0));
+
+    let contents = std::fs::read_to_string(dir.path().join("sessions.jsonl")).expect("row written");
+    let row: serde_json::Value =
+        serde_json::from_str(contents.lines().next().unwrap()).expect("parse");
+    assert_eq!(row["commits"], 2, "only this session's commit rows count");
+}
+
 // ── Fail-open: an unwritable metrics dir never perturbs the exit code ─────
 
 #[test]


### PR DESCRIPTION
## What

Enriches the per-session record in `sessions.jsonl` with session bounds and a commit count: `startTs`, `endTs`, `durationMs`, and `commits`.

## Change

- New `log-session-start` hook (metrics) — a fire-and-forget logger that stamps the SessionStart timestamp to a per-session state marker (mirrors `snapshot`).
- `log-session` (SessionEnd) reads + consumes that marker as `startTs`, uses its own fire time as `endTs`, computes `durationMs` (jiff), and counts `commits` from `commits.jsonl` by `sessionId`.
- All fields additive on the `json!` Value (no strict downstream deserializer); `startTs`/`durationMs` are null when the start marker is absent, so old sessions and existing consumers are unaffected.

## Two-repo

The SessionStart wiring that invokes `metrics log-session-start` lands in a companion PR on `cameronsjo/cadence` (cadence-metrics hooks.json). Until the binary ships that subcommand, the wiring is a fail-open "unknown subcommand" no-op — matching the existing `log-session`/`warn-stale` transient pattern.

## Verification

- `cargo test --workspace` — metrics 101 pass (incl. new log-session-start + build_session_record tests), integration 7 pass (round-trip duration, null fallback, commits count)
- `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --check` — clean

## Note

Added `jiff` to the metrics crate (for Timestamp parse/diff) and consolidated a duplicated test `ENV_LOCK` into `common.rs` (shared across the crate so env-mutating unit tests stay non-flaky under parallel execution).

Closes cameronsjo/cadence-hooks#182
