### PR TITLE
feat(cadence): audience-aware redaction Phase 2 — d>c gating in redact-external-content (cadence-hooks#159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 - warn-recommended-option now allows a declared "no clear recommendation" stance (fires only on true silence) (#148)
 - **terminology guard's `cadence-hooks` exemption is now scoped to the active checkout, closing a self-grantable bypass (#139).** The exemption fired on any path with a `cadence-hooks` component, so `mkdir /tmp/cadence-hooks` plus a doc carrying a blocked term self-granted the free pass. It now fires only when the edit targets a file inside the current checkout AND that checkout is genuinely the cadence-hooks repo (identified by its primary-checkout dir name via the git common dir), so linked worktrees stay exempt while unrelated repos merely nested under a `cadence-hooks`-named ancestor no longer do. The `is_within` containment primitive (which rejects `..` traversal) is promoted from `crates/lab` to `crates/core` as the single implementation. Fail-safe: every failure path falls through to a block.
+### Added
+
+- audience-aware redaction — redact-external-content now gates each hit on destination-tier vs per-category ceiling (d>c), nudge-only (#159)
 
 ## [0.45.0] - 2026-07-03
 

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -35,9 +35,66 @@ use cadence_hooks_core::shell::{strip_quotes, tokenize};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 use regex::Regex;
 use serde::Deserialize;
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 use std::path::Path;
 use std::sync::LazyLock;
+
+/// The three audience tiers, ordered narrow → wide: owned-internal(1) <
+/// private-external(2) < public(3). Deserialized where a config field is
+/// tier-typed; the ordinal mapping is the single source of truth reused by the
+/// two string-keyed ordinal fns below.
+///
+/// Redaction is `f(content, audience)`: a hit is retained (nudged) only when it
+/// crosses to a *wider* audience than the tier where it is native — redact iff
+/// destination-tier ordinal `d` > the hit's ceiling ordinal `c`.
+#[derive(Debug, Clone, Copy, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+enum AudienceTier {
+    OwnedInternal,
+    PrivateExternal,
+    Public,
+}
+
+impl AudienceTier {
+    /// Position in the narrow→wide order.
+    fn ordinal(self) -> u8 {
+        match self {
+            AudienceTier::OwnedInternal => 1,
+            AudienceTier::PrivateExternal => 2,
+            AudienceTier::Public => 3,
+        }
+    }
+}
+
+/// Destination-tier ordinal. String-keyed (not `AudienceTier`-typed) so an
+/// unknown/typo'd string hits the documented fail-safe instead of failing to
+/// deserialize. Unknown → 3 (widest/public) so an unrecognized destination
+/// redacts MORE, never less. `always` is a config-only CEILING sentinel, never a
+/// valid destination — a stray `originAudience: "always"` must resolve to
+/// public(3), never 0, or it would suppress every hit (the total-bypass trap).
+fn dest_tier_ord(s: &str) -> u8 {
+    match s {
+        "owned-internal" => AudienceTier::OwnedInternal.ordinal(),
+        "private-external" => AudienceTier::PrivateExternal.ordinal(),
+        "public" => AudienceTier::Public.ordinal(),
+        _ => 3,
+    }
+}
+
+/// Ceiling ordinal. Unknown → 1 (owned-internal, the documented default) so a
+/// typo'd ceiling (`"owned_internal"`) never widens to public and silently
+/// suppresses a hit. Fail-safe for a ceiling is the SMALLER ordinal (redact at
+/// more destinations) — the opposite direction from a destination. `always`(0)
+/// is a config-only sentinel meaning "redact at every tier".
+fn ceiling_ord(s: &str) -> u8 {
+    match s {
+        "always" => 0,
+        "owned-internal" => AudienceTier::OwnedInternal.ordinal(),
+        "private-external" => AudienceTier::PrivateExternal.ordinal(),
+        "public" => AudienceTier::Public.ordinal(),
+        _ => 1,
+    }
+}
 
 /// Plugin/skill namespaces whose `<ns>:<name>` IDs are harness-internal.
 ///
@@ -125,6 +182,17 @@ static HARNESS_NOUN: LazyLock<Regex> = LazyLock::new(|| {
 #[derive(Debug, Default, Deserialize)]
 #[serde(rename_all = "camelCase")]
 struct RedactionConfig {
+    /// Tier of THIS surface, used as the scan destination when `CADENCE_AUDIENCE`
+    /// is unset. `String` (not `AudienceTier`) so a stray/typo'd value resolves
+    /// via [`dest_tier_ord`]'s fail-safe rather than failing the whole config to
+    /// deserialize. Omitted → public (widest, safest).
+    #[serde(default)]
+    origin_audience: Option<String>,
+    /// Per-category ceiling overrides, keyed by the emitted category name
+    /// (`skill-id`, `local-path`, `marketplace`, `harness-noun`). A category
+    /// without an entry uses the default ceiling (`owned-internal`).
+    #[serde(default)]
+    categories: HashMap<String, CategoryOverride>,
     /// Extra literal/regex patterns to flag, each with the replacement to show.
     #[serde(default)]
     additional_patterns: Vec<AdditionalPattern>,
@@ -140,6 +208,20 @@ struct RedactionConfig {
     /// wholesale instead of enumerating every skill ID.
     #[serde(default)]
     allowlist: Vec<String>,
+    /// Deserialized but inert in Phase 2. Reserved for Phase-2b, when it will
+    /// gate the `--repo` owner-vs-origin visibility resolution.
+    #[serde(default)]
+    #[allow(dead_code)]
+    resolve_visibility: bool,
+}
+
+/// One `categories[<name>]` entry: a per-category ceiling override.
+#[derive(Debug, Deserialize)]
+struct CategoryOverride {
+    /// Ceiling tier for this category; absent resolves to `owned-internal` at
+    /// use via [`category_ceiling`].
+    #[serde(default)]
+    ceiling: Option<String>,
 }
 
 /// One `additionalPatterns[]` entry: a project-specific string to flag and the
@@ -149,6 +231,11 @@ struct AdditionalPattern {
     pattern: String,
     #[serde(default)]
     replacement: String,
+    /// Per-entry ceiling tier; absent resolves to `owned-internal` at use. Opt
+    /// into `always` for PII / secrets-adjacent patterns that must redact at
+    /// every destination.
+    #[serde(default)]
+    ceiling: Option<String>,
 }
 
 /// A single blocklist hit within one body. `offset` is the match start within
@@ -189,13 +276,18 @@ impl Check for RedactExternalContent {
             return CheckResult::allow();
         }
 
-        // Phase 3 — config (per-repo additional patterns + allowlist).
+        // Phase 3 — config (per-repo additional patterns + allowlist + tiers).
         let config = load_redaction_config(&base_dir);
 
-        // Phase 4 — scan each body, collect hits.
+        // Phase 3.5 — resolve the destination-tier ordinal once. `CADENCE_AUDIENCE`
+        // wins over the config's `originAudience`; both fall back to public.
+        let env_audience = std::env::var("CADENCE_AUDIENCE").ok();
+        let d = resolve_dest_tier(env_audience.as_deref(), &config);
+
+        // Phase 4 — scan each body, collect hits (gated on d > ceiling).
         let mut hits: Vec<Hit> = Vec::new();
         for body in &bodies {
-            hits.extend(scan_body(body, &config));
+            hits.extend(scan_body(body, &config, d));
         }
 
         if hits.is_empty() {
@@ -320,41 +412,89 @@ fn load_redaction_config(base_dir: &str) -> RedactionConfig {
     serde_json::from_str(&content).unwrap_or_default()
 }
 
+/// Resolve the destination-tier ordinal (PURE — env passed as an argument, never
+/// read from `std::env` here, so the audience seam is fixture-testable).
+/// Resolution order: `CADENCE_AUDIENCE` (via `env_audience`) → config
+/// `originAudience` → public(3, widest/safest). Awareness only relaxes on proof.
+fn resolve_dest_tier(env_audience: Option<&str>, config: &RedactionConfig) -> u8 {
+    // Phase-2b: derive tier from --repo owner vs origin remote owner (local
+    // .git/config, no network) as a lower-priority source below env/config.
+    if let Some(a) = env_audience {
+        dest_tier_ord(a)
+    } else if let Some(a) = config.origin_audience.as_deref() {
+        dest_tier_ord(a)
+    } else {
+        3
+    }
+}
+
+/// Ceiling string for a universal category: the config `.categories` override or
+/// the default `owned-internal`. Returned as `&str` for a direct
+/// [`ceiling_ord`] call.
+fn category_ceiling<'a>(config: &'a RedactionConfig, category: &str) -> &'a str {
+    config
+        .categories
+        .get(category)
+        .and_then(|c| c.ceiling.as_deref())
+        .unwrap_or("owned-internal")
+}
+
 /// Scan one body for blocklist hits, deduped by start offset across categories,
-/// then drop any hit whose exact snippet is allowlisted.
+/// gating each hit on the audience rule: retain iff `d > c` (destination tier
+/// wider than the hit's ceiling).
 ///
-/// Categories are scanned skill → marketplace → local-path → harness →
+/// Categories are scanned skill-id → marketplace → local-path → harness →
 /// additional; the first to claim a start offset reports it (so a single
-/// `~/.claude/plugins/…` offset is reported once, as `marketplace`).
-fn scan_body(body: &str, config: &RedactionConfig) -> Vec<Hit> {
+/// `~/.claude/plugins/…` offset is reported once, as `marketplace`). An
+/// allowlisted hit pins its ceiling to public (never redacted here).
+fn scan_body(body: &str, config: &RedactionConfig, d: u8) -> Vec<Hit> {
     let mut hits: Vec<Hit> = Vec::new();
     let mut claimed: HashSet<usize> = HashSet::new();
 
     let universal: [(&'static str, &Regex); 4] = [
-        ("skill/plugin", &SKILL_ID),
+        ("skill-id", &SKILL_ID),
         ("marketplace", &MARKETPLACE_PATH),
         ("local-path", &LOCAL_PATH),
         ("harness-noun", &HARNESS_NOUN),
     ];
     for (category, regex) in universal {
         for m in regex.find_iter(body) {
+            // Claim the offset when first seen (so a lower-priority category
+            // never re-reports it), then decide whether the audience gate keeps
+            // it.
             if claimed.insert(m.start()) {
-                hits.push(Hit {
+                let hit = Hit {
                     category,
                     snippet: m.as_str().to_string(),
                     offset: m.start(),
                     replacement: None,
-                });
+                };
+                // Allowlisted → ceiling public (never redacts); else the
+                // category's configured/default ceiling. Retain iff d > c.
+                let ceiling = if is_allowlisted(&hit, &config.allowlist) {
+                    "public"
+                } else {
+                    category_ceiling(config, category)
+                };
+                if d > ceiling_ord(ceiling) {
+                    hits.push(hit);
+                }
             }
         }
     }
 
     // Per-repo additional patterns — each `pattern` is treated as a regex; one
-    // that fails to compile is skipped (fail-open).
+    // that fails to compile is skipped (fail-open). The ceiling is computed once
+    // per entry (default owned-internal); a whole pattern is skipped when the
+    // gate closes (d <= c).
     for ap in &config.additional_patterns {
         let Ok(re) = Regex::new(&ap.pattern) else {
             continue;
         };
+        let c = ceiling_ord(ap.ceiling.as_deref().unwrap_or("owned-internal"));
+        if d <= c {
+            continue;
+        }
         for m in re.find_iter(body) {
             if claimed.insert(m.start()) {
                 hits.push(Hit {
@@ -366,9 +506,6 @@ fn scan_body(body: &str, config: &RedactionConfig) -> Vec<Hit> {
             }
         }
     }
-
-    // Allowlist suppression (two forms — see [`is_allowlisted`]).
-    hits.retain(|h| !is_allowlisted(h, &config.allowlist));
 
     hits.sort_by_key(|h| h.offset);
     hits
@@ -385,7 +522,7 @@ fn is_allowlisted(hit: &Hit, allowlist: &[String]) -> bool {
         if entry.contains(':') {
             entry == &hit.snippet
         } else {
-            hit.category == "skill/plugin" && hit.snippet.starts_with(&format!("{entry}:"))
+            hit.category == "skill-id" && hit.snippet.starts_with(&format!("{entry}:"))
         }
     })
 }
@@ -545,9 +682,13 @@ mod tests {
 
     #[test]
     fn category_skill_id() {
-        assert_eq!(
-            run("gh issue create --body \"calls cadence-forge:polish\"").outcome,
-            Outcome::Nudge
+        let result = run("gh issue create --body \"calls cadence-forge:polish\"");
+        assert_eq!(result.outcome, Outcome::Nudge);
+        // Category tag is `skill-id` (lockstep with redaction.schema.json).
+        assert!(
+            result.message.as_deref().unwrap().contains("[skill-id]"),
+            "expected the [skill-id] category tag in: {:?}",
+            result.message
         );
     }
 
@@ -580,13 +721,16 @@ mod tests {
         // `cadence-mcp:` must be caught as cadence-mcp, not bare cadence/mcp.
         let result = run("gh pr create --body \"see cadence-mcp:server\"");
         assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.as_deref().unwrap();
         assert!(
-            result
-                .message
-                .as_deref()
-                .unwrap()
-                .contains("cadence-mcp:server"),
+            msg.contains("cadence-mcp:server"),
             "expected the full cadence-mcp:server snippet in: {:?}",
+            result.message
+        );
+        // Emitted under the `skill-id` category (schema lockstep).
+        assert!(
+            msg.contains("[skill-id]"),
+            "expected the [skill-id] category tag in: {:?}",
             result.message
         );
     }
@@ -751,5 +895,216 @@ mod tests {
         let cmd = "gh pr create --body \"cadence:attune /Users/x ~/.claude/plugins/y transcript\"";
         assert_ne!(run(cmd).outcome, Outcome::Block);
         assert_eq!(run(cmd).outcome, Outcome::Nudge);
+    }
+
+    // --- Audience gate (#159): d > c, driven through the pure scan_body /
+    // resolve_dest_tier seam rather than process env, mirroring the reference
+    // script `redact-check.sh` cases a–i. Ordinals: owned-internal=1,
+    // private-external=2, public=3. Cases inlined as Rust tests (rather than a
+    // shared JSON/TSV fixture) — the fixture would add setup scope with no
+    // parity win here, since Rust and the bash port are separately validated. ---
+
+    /// Parse a `.claude/redaction.json` body into a [`RedactionConfig`].
+    fn cfg(json: &str) -> RedactionConfig {
+        serde_json::from_str(json).expect("test config should deserialize")
+    }
+
+    /// Categories emitted by a scan at destination ordinal `d`, offset-sorted.
+    fn cats(body: &str, config: &RedactionConfig, d: u8) -> Vec<&'static str> {
+        scan_body(body, config, d)
+            .into_iter()
+            .map(|h| h.category)
+            .collect()
+    }
+
+    // One line per universal category, each firing exactly once.
+    const BODY_ALL: &str = "Use cadence-forge:polish. File /Users/alice/x. \
+         Installed ~/.claude/plugins/cadence-forge/skill.json. The transcript records.";
+    const BODY_SKILL: &str = "Use cadence-forge:polish here.";
+    const BODY_SKILL_PATH: &str = "Run cadence-forge:polish on /Users/alice/secret.txt now.";
+    const BODY_ACME: &str = "Deploy for ACME-INC today.";
+    const BODY_WIDGET: &str = "Partner WIDGET-CO ships it.";
+
+    // --- The two fail-direction traps, asserted directly ---
+
+    #[test]
+    fn dest_tier_ord_fail_safe() {
+        assert_eq!(dest_tier_ord("owned-internal"), 1);
+        assert_eq!(dest_tier_ord("private-external"), 2);
+        assert_eq!(dest_tier_ord("public"), 3);
+        // `always` is config-only — never a destination — and any unknown string
+        // must resolve to public(3, over-redact), never 0.
+        assert_eq!(dest_tier_ord("always"), 3, "always must NOT be 0 as a dest");
+        assert_eq!(dest_tier_ord("owned_internal"), 3, "typo → public");
+        assert_eq!(dest_tier_ord("bogus"), 3);
+    }
+
+    #[test]
+    fn ceiling_ord_fail_safe() {
+        assert_eq!(ceiling_ord("always"), 0);
+        assert_eq!(ceiling_ord("owned-internal"), 1);
+        assert_eq!(ceiling_ord("private-external"), 2);
+        assert_eq!(ceiling_ord("public"), 3);
+        // Unknown/typo → owned-internal(1), NOT public — a bad ceiling must not
+        // silently widen and suppress a hit.
+        assert_eq!(ceiling_ord("owned_internal"), 1, "typo → owned-internal");
+        assert_eq!(ceiling_ord("bogus"), 1);
+    }
+
+    // === (a) no audience → public → every universal category fires ===========
+    #[test]
+    fn gate_a_public_flags_all() {
+        let config = RedactionConfig::default();
+        assert_eq!(
+            resolve_dest_tier(None, &config),
+            3,
+            "no env, no originAudience → public"
+        );
+        let got = cats(BODY_ALL, &config, 3);
+        assert_eq!(
+            got,
+            vec!["skill-id", "local-path", "marketplace", "harness-noun"]
+        );
+    }
+
+    // === (b) owned-internal → universal categories suppressed ================
+    #[test]
+    fn gate_b_owned_internal_suppresses_universal() {
+        let config = RedactionConfig::default();
+        assert!(
+            cats(BODY_ALL, &config, 1).is_empty(),
+            "default owned-internal ceiling suppresses every universal hit at d=1"
+        );
+    }
+
+    // === (c) allowlisted skill-id suppressed at every tier (ceiling public) ==
+    #[test]
+    fn gate_c_allowlist_suppresses_at_every_tier() {
+        let config = cfg(r#"{"allowlist":["cadence-forge"]}"#);
+        assert!(cats(BODY_SKILL, &config, 3).is_empty(), "public suppressed");
+        assert!(
+            cats(BODY_SKILL, &config, 1).is_empty(),
+            "owned-internal suppressed"
+        );
+        // Contrast: without the allowlist, the same skill-id fires at public.
+        let bare = RedactionConfig::default();
+        assert_eq!(cats(BODY_SKILL, &bare, 3), vec!["skill-id"]);
+    }
+
+    // === (d) per-category ceiling: local-path → always fires at owned-internal
+    #[test]
+    fn gate_d_per_category_ceiling_always() {
+        let config = cfg(r#"{"categories":{"local-path":{"ceiling":"always"}}}"#);
+        let got = cats(BODY_SKILL_PATH, &config, 1);
+        // local-path (ceiling always, 0) fires at d=1; skill-id (default
+        // owned-internal, 1) stays suppressed — the override is category-scoped.
+        assert_eq!(got, vec!["local-path"]);
+    }
+
+    // === (e) custom pattern ceiling ==========================================
+    #[test]
+    fn gate_e_custom_pattern_ceiling() {
+        let always = cfg(
+            r#"{"additionalPatterns":[{"pattern":"ACME-INC","replacement":"[x]","ceiling":"always"}]}"#,
+        );
+        assert_eq!(
+            cats(BODY_ACME, &always, 1),
+            vec!["custom"],
+            "always-ceiling custom fires at owned-internal"
+        );
+        let default_ceiling = cfg(r#"{"additionalPatterns":[{"pattern":"WIDGET-CO"}]}"#);
+        assert_eq!(
+            cats(BODY_WIDGET, &default_ceiling, 3),
+            vec!["custom"],
+            "default-ceiling custom fires at public"
+        );
+        assert!(
+            cats(BODY_WIDGET, &default_ceiling, 1).is_empty(),
+            "default-ceiling custom quiet at owned-internal"
+        );
+    }
+
+    // === (g) private-external (middle tier) ==================================
+    #[test]
+    fn gate_g_private_external_middle_tier() {
+        let bare = RedactionConfig::default();
+        assert_eq!(
+            cats(BODY_ALL, &bare, 2),
+            vec!["skill-id", "local-path", "marketplace", "harness-noun"],
+            "universal categories fire at private-external"
+        );
+        let custom = cfg(r#"{"additionalPatterns":[{"pattern":"WIDGET-CO"}]}"#);
+        assert_eq!(
+            cats(BODY_WIDGET, &custom, 2),
+            vec!["custom"],
+            "default-ceiling custom fires at private-external"
+        );
+        assert!(
+            cats(BODY_WIDGET, &custom, 1).is_empty(),
+            "same custom stays quiet at owned-internal"
+        );
+    }
+
+    // === (h) invalid ceiling → owned-internal (not public), both call sites ==
+    #[test]
+    fn gate_h_invalid_ceiling_falls_to_owned_internal() {
+        // Category call site: a typo'd ceiling must still flag at public.
+        let cat = cfg(r#"{"categories":{"local-path":{"ceiling":"owned_internal"}}}"#);
+        assert!(
+            cats(BODY_SKILL_PATH, &cat, 3).contains(&"local-path"),
+            "invalid category ceiling must not silently suppress at public"
+        );
+        // Custom call site: same fail-safe.
+        let custom =
+            cfg(r#"{"additionalPatterns":[{"pattern":"WIDGET-CO","ceiling":"nonsense"}]}"#);
+        assert_eq!(
+            cats(BODY_WIDGET, &custom, 3),
+            vec!["custom"],
+            "invalid custom ceiling must not silently suppress at public"
+        );
+    }
+
+    // === (i) destination from config originAudience; "always" → public =======
+    #[test]
+    fn gate_i_origin_audience_resolution() {
+        let internal = cfg(r#"{"originAudience":"owned-internal"}"#);
+        assert_eq!(resolve_dest_tier(None, &internal), 1);
+        assert!(
+            cats(BODY_ALL, &internal, resolve_dest_tier(None, &internal)).is_empty(),
+            "originAudience owned-internal suppresses the universal categories"
+        );
+        // The config-only `always` sentinel is NOT a destination — it must fall
+        // through to public(3), never suppress every hit (the total-bypass trap).
+        let always = cfg(r#"{"originAudience":"always"}"#);
+        assert_eq!(
+            resolve_dest_tier(None, &always),
+            3,
+            "originAudience=always resolves to public, not 0"
+        );
+        assert_eq!(
+            cats(BODY_SKILL, &always, resolve_dest_tier(None, &always)),
+            vec!["skill-id"]
+        );
+    }
+
+    // === CADENCE_AUDIENCE env path: gated through the pure helper with an
+    // explicit Some(...) arg — no std::env::set_var (process-global, flaky). ===
+    #[test]
+    fn gate_env_audience_wins_over_config() {
+        // env owned-internal overrides a config originAudience of public.
+        let config = cfg(r#"{"originAudience":"public"}"#);
+        assert_eq!(
+            resolve_dest_tier(Some("owned-internal"), &config),
+            1,
+            "CADENCE_AUDIENCE wins over config originAudience"
+        );
+        assert!(
+            cats(
+                BODY_ALL,
+                &config,
+                resolve_dest_tier(Some("owned-internal"), &config)
+            )
+            .is_empty()
+        );
     }
 }


### PR DESCRIPTION
## What

Audience-aware redaction (Phase 2) for `redact-external-content`: each redaction hit is now gated on the destination audience tier vs a per-category ceiling — `redact iff dest_ordinal > ceiling_ordinal`. Nudge-only; audience-awareness only *relaxes* nudges on proven-narrow destinations, never adds suppression.

## Model

- Tiers: `owned-internal`=1, `private-external`=2, `public`=3.
- Per-category `ceiling` (config) with sentinels `always`=0 / `public`=3 (allowlist == never redacts).
- Two fail-safe defaults, mirrored from the merged `redact-check` script and directly tested:
  - unknown/`always` **destination** → `3` (public, over-redact) — a stray `originAudience: "always"` cannot become 0 and suppress everything (test `gate_i`).
  - unknown **ceiling** → `1` (owned-internal) — a typo'd ceiling cannot silently suppress at every destination (test `gate_h`, both call sites).
- Destination derived from `CADENCE_AUDIENCE` → config `originAudience` → default `public`. The `--repo` owner-heuristic is deferred to Phase-2b (a `// Phase-2b` marker); `resolveVisibility` (network) stays inert until Phase 3. This slice satisfies every acceptance criterion and shared fixture.

## Also

Emitted category `skill/plugin` → `skill-id`, for lockstep with the shipped `redaction.schema.json` (which keys categories on `skill-id`).

## Verification

- `cargo test --workspace` — `redact_external_content` 43 pass incl. 10 new gate tests (ported script cases a–e/g/h/i + the CADENCE_AUDIENCE path via the pure seam, no `std::env` mutation)
- `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --check` — clean

Closes cameronsjo/cadence-hooks#159
