### PR TITLE
feat(metrics): threshold-gated hook self-timing to hooks.jsonl (cadence-hooks#143)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- threshold-gated hook self-timing — hooks slower than CADENCE_HOOK_TIMING_THRESHOLD_MS (default 1000) are logged to hooks.jsonl (#143)
+
 ### Fixed
 
 - warn-recommended-option now allows a declared "no clear recommendation" stance (fires only on true silence) (#148)

--- a/crates/metrics/src/common.rs
+++ b/crates/metrics/src/common.rs
@@ -124,6 +124,15 @@ pub fn utc_timestamp() -> String {
     cadence_hooks_core::time::utc_timestamp()
 }
 
+/// Crate-wide serialization lock for env-mutating tests.
+///
+/// `CADENCE_METRICS_DIR` and its siblings are process-global, so every test that
+/// `set_var`/`remove_var`s one must hold *this one* lock — a per-module lock only
+/// serializes within its own module and lets tests in different modules
+/// (`log_denial`, `log_timing`, …) race on the same global.
+#[cfg(test)]
+pub(crate) static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -22,6 +22,8 @@ pub mod log_polish_nudge;
 pub mod log_session;
 /// Append subagent lifecycle records to `subagents.jsonl`.
 pub mod log_subagent;
+/// Append threshold-gated hook self-timing records to `hooks.jsonl`.
+pub mod log_timing;
 /// Shared per-model breakdown builders for `byModel[]` / `unpricedModels[]`.
 pub mod model_breakdown;
 /// Embedded + overridable model price table.
@@ -39,5 +41,6 @@ pub use log_denial::log_denial;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_session::LogSession;
 pub use log_subagent::LogSubagent;
+pub use log_timing::log_timing;
 pub use snapshot::Snapshot;
 pub use warn_stale::WarnStale;

--- a/crates/metrics/src/log_denial.rs
+++ b/crates/metrics/src/log_denial.rs
@@ -194,9 +194,10 @@ mod tests {
 
     // --- log_denial end-to-end (tempdir) ---
 
-    /// Serialize the env-mutating tests: `CADENCE_METRICS_DIR` and
-    /// `CADENCE_LOG_NUDGES` are process-global.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    /// Serialize the env-mutating tests against every other module's: the
+    /// process-global `CADENCE_METRICS_DIR` / `CADENCE_LOG_NUDGES` are shared with
+    /// sibling loggers' tests (`log_timing`), so all hold the one crate-wide lock.
+    use crate::common::ENV_LOCK;
 
     fn with_metrics_dir<F: FnOnce()>(dir: &std::path::Path, nudges: Option<&str>, f: F) {
         let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());

--- a/crates/metrics/src/log_timing.rs
+++ b/crates/metrics/src/log_timing.rs
@@ -1,0 +1,245 @@
+//! Threshold-gated self-timing for the hook dispatch hot path: one line per
+//! *slow* hook to `<metrics_dir>/hooks.jsonl`, so a guard or logger that starts
+//! costing real wall-clock time surfaces in telemetry instead of hiding.
+//!
+//! Called from the **binary** (`src/dispatch.rs`), which is the only layer that
+//! wraps a hook's full run and knows the canonical registry name. The timing
+//! write is the last side effect before exit: it runs *after* the guard's
+//! decision has been logged and *before* the process emits and exits, so it can
+//! never perturb the block message, the exit code, or the logger's output.
+//!
+//! **Gated by construction:** the common case is a *fast* hook, and a fast hook
+//! writes nothing — `over_threshold` filters below `CADENCE_HOOK_TIMING_THRESHOLD_MS`
+//! (default 1000ms) so the hot path adds zero I/O until a hook is genuinely slow.
+//! Every step is fail-open per ADR-0001 — a full disk or a read-only metrics dir
+//! degrades to a no-op and the hook's own behavior is unchanged.
+
+use crate::common;
+use serde_json::{Value, json};
+use std::io::Write;
+
+/// Default slow-hook threshold in milliseconds when
+/// `CADENCE_HOOK_TIMING_THRESHOLD_MS` is unset or unparseable.
+const DEFAULT_THRESHOLD_MS: u128 = 1000;
+
+/// Record a hook's wall-clock time at the dispatch seam — but only when it
+/// exceeds the threshold.
+///
+/// `hook` is the canonical registry name threaded from the binary, `plugin` its
+/// namespace, `event` the rendered event string (e.g. `PreToolUse`, `logger`),
+/// and `elapsed_ms` the measured duration. `session_id` is recorded when present
+/// and null otherwise. Fully fail-open: any error along the way is a no-op.
+pub fn log_timing(
+    hook: &str,
+    plugin: &str,
+    event: &str,
+    elapsed_ms: u128,
+    session_id: Option<&str>,
+) {
+    if !over_threshold(elapsed_ms, threshold_ms()) {
+        return;
+    }
+
+    let record = build_timing_record(hook, plugin, event, elapsed_ms, session_id);
+
+    let dir = common::metrics_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join("hooks.jsonl");
+
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        // One `write_all` of the record + newline, so a concurrent append from
+        // another session can't interleave a record with its trailing newline.
+        // `record` is compact JSON — one line, no embedded newlines.
+        let mut line = record.to_string();
+        line.push('\n');
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+/// The slow-hook threshold in milliseconds. Reads
+/// `CADENCE_HOOK_TIMING_THRESHOLD_MS`; a missing or unparseable value falls back
+/// to [`DEFAULT_THRESHOLD_MS`].
+fn threshold_ms() -> u128 {
+    std::env::var("CADENCE_HOOK_TIMING_THRESHOLD_MS")
+        .ok()
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(DEFAULT_THRESHOLD_MS)
+}
+
+/// True when `elapsed_ms` strictly exceeds `threshold`. Pure — the elapsed value
+/// is passed in so the gate is unit-testable without sleeping. Strict `>` so a
+/// hook landing exactly on the threshold is *not* logged.
+fn over_threshold(elapsed_ms: u128, threshold: u128) -> bool {
+    elapsed_ms > threshold
+}
+
+/// Build the `hooks.jsonl` record. Pure — no I/O beyond [`common::utc_timestamp`].
+/// camelCase keys: `ts`, `hook`, `plugin`, `event`, `elapsedMs` (numeric),
+/// `sessionId` (null when `None`).
+fn build_timing_record(
+    hook: &str,
+    plugin: &str,
+    event: &str,
+    elapsed_ms: u128,
+    session_id: Option<&str>,
+) -> Value {
+    json!({
+        "ts": common::utc_timestamp(),
+        "hook": hook,
+        "plugin": plugin,
+        "event": event,
+        "elapsedMs": elapsed_ms,
+        "sessionId": session_id,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // --- over_threshold ---
+
+    #[test]
+    fn over_threshold_true_above() {
+        assert!(over_threshold(1500, 1000));
+    }
+
+    #[test]
+    fn over_threshold_false_at_boundary() {
+        // Strict `>` — a hook exactly at the threshold is not slow.
+        assert!(!over_threshold(1000, 1000));
+    }
+
+    #[test]
+    fn over_threshold_false_below() {
+        assert!(!over_threshold(500, 1000));
+    }
+
+    // --- threshold_ms (env-mutating; serialized) ---
+
+    /// Serialize the env-mutating tests against every other module's: the
+    /// process-global `CADENCE_HOOK_TIMING_THRESHOLD_MS` / `CADENCE_METRICS_DIR`
+    /// are shared with sibling loggers' tests (`log_denial`), so all hold the one
+    /// crate-wide lock.
+    use crate::common::ENV_LOCK;
+
+    fn with_threshold_env<F: FnOnce()>(value: Option<&str>, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test in this module.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var("CADENCE_HOOK_TIMING_THRESHOLD_MS", v),
+                None => std::env::remove_var("CADENCE_HOOK_TIMING_THRESHOLD_MS"),
+            }
+        }
+        f();
+        // SAFETY: serialized against every other env-mutating test in this module.
+        unsafe {
+            std::env::remove_var("CADENCE_HOOK_TIMING_THRESHOLD_MS");
+        }
+    }
+
+    #[test]
+    fn threshold_ms_reads_env() {
+        with_threshold_env(Some("250"), || {
+            assert_eq!(threshold_ms(), 250);
+        });
+    }
+
+    #[test]
+    fn threshold_ms_defaults_when_unset() {
+        with_threshold_env(None, || {
+            assert_eq!(threshold_ms(), DEFAULT_THRESHOLD_MS);
+        });
+    }
+
+    #[test]
+    fn threshold_ms_defaults_on_garbage() {
+        with_threshold_env(Some("abc"), || {
+            assert_eq!(threshold_ms(), DEFAULT_THRESHOLD_MS);
+        });
+    }
+
+    // --- build_timing_record ---
+
+    #[test]
+    fn record_has_expected_camelcase_fields() {
+        let rec = build_timing_record("terminology", "cadence", "PreToolUse", 1500, Some("sess-1"));
+        assert_eq!(rec["hook"], "terminology");
+        assert_eq!(rec["plugin"], "cadence");
+        assert_eq!(rec["event"], "PreToolUse");
+        // Numeric, not a string.
+        assert_eq!(rec["elapsedMs"], 1500);
+        assert!(rec["elapsedMs"].is_number());
+        assert_eq!(rec["sessionId"], "sess-1");
+        assert!(rec["ts"].is_string());
+    }
+
+    #[test]
+    fn record_session_id_null_when_none() {
+        let rec = build_timing_record("git-safety", "cadence", "PreToolUse", 2000, None);
+        assert!(rec["sessionId"].is_null());
+    }
+
+    // --- log_timing end-to-end (tempdir, default threshold) ---
+
+    fn with_metrics_dir<F: FnOnce()>(dir: &std::path::Path, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test in this module.
+        // Clear the threshold so the default (1000ms) applies.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", dir);
+            std::env::remove_var("CADENCE_HOOK_TIMING_THRESHOLD_MS");
+        }
+        f();
+        // SAFETY: serialized against every other env-mutating test in this module.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+        }
+    }
+
+    fn read_lines(dir: &std::path::Path) -> Vec<Value> {
+        let path = dir.join("hooks.jsonl");
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str(l).expect("each line is valid JSON"))
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    #[test]
+    fn slow_hook_writes_one_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            // Elapsed injected as a u128 — no Instant, no sleep.
+            log_timing("terminology", "cadence", "PreToolUse", 1500, Some("sess-1"));
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["elapsedMs"], 1500);
+        assert_eq!(rows[0]["hook"], "terminology");
+        assert_eq!(rows[0]["plugin"], "cadence");
+    }
+
+    #[test]
+    fn fast_hook_writes_nothing() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_timing("terminology", "cadence", "PreToolUse", 500, Some("sess-1"));
+        });
+        assert!(
+            read_lines(tmp.path()).is_empty(),
+            "a fast hook must not write a row"
+        );
+        assert!(!tmp.path().join("hooks.jsonl").exists());
+    }
+}

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -1,30 +1,39 @@
-//! Logged check dispatch: the binary-level bridge that records a guard's
-//! decision to `denials.jsonl` between deciding and exiting.
+//! Logged dispatch: the binary-level bridge that records a hook's decision
+//! (`denials.jsonl`) and wall-clock time (`hooks.jsonl`) between running and
+//! exiting.
 //!
 //! `core` decides (it holds the [`Check`] trait) but cannot reach the metrics
 //! crate's writer (metrics depends on core, not the reverse); the binary depends
 //! on both **and** is the only layer that knows the canonical registry hook name
 //! (`Check::name()` diverges from it — e.g. `terminology-guard` vs the registry
-//! `terminology`). So the denial write lives here, calling
-//! [`cadence_hooks_metrics::log_denial`] with the name threaded from
-//! `main::hook_name`.
+//! `terminology`). So the denial and timing writes live here, calling
+//! [`cadence_hooks_metrics::log_denial`] / [`cadence_hooks_metrics::log_timing`]
+//! with the name threaded from `main::hook_name`.
 //!
-//! This mirrors [`cadence_hooks_core::run_check_from_stdin`] step for step — the
-//! interactive-terminal guard, fail-open stdin parse, effort-skip — and adds
-//! exactly one call (the denial write) on the decided-outcome path, so the block
-//! the guard emits and its exit code are byte-for-byte unchanged.
+//! These wrappers mirror [`cadence_hooks_core::run_check_from_stdin`] /
+//! [`cadence_hooks_core::run_logger_from_stdin`] step for step — the
+//! interactive-terminal guard, fail-open stdin parse, effort-skip / panic-catch —
+//! and add exactly two fail-open side effects (the denial write, then the timing
+//! write) sequenced *after* the decision is recorded and *before* the process
+//! emits and exits, so the block a guard emits, its exit code, and a logger's
+//! output are all byte-for-byte unchanged.
 
 use cadence_hooks_core::{
-    Check, HookEvent, HookInput, Outcome, decide_check, emit_and_exit, guard_interactive_terminal,
+    Check, HookEvent, HookInput, Logger, MetricsInput, Outcome, decide_check, emit_and_exit,
+    guard_interactive_terminal,
 };
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::process;
+use std::time::Instant;
 
-/// Run a single check from stdin, record its decision to `denials.jsonl`, then
-/// emit and exit exactly as [`cadence_hooks_core::run_check_from_stdin`] would.
+/// Run a single check from stdin, record its decision to `denials.jsonl` and its
+/// wall-clock time to `hooks.jsonl`, then emit and exit exactly as
+/// [`cadence_hooks_core::run_check_from_stdin`] would.
 ///
 /// `hook` is the canonical registry name from `main::hook_name`; when `None`
 /// (e.g. a subcommand with no registry mapping) it falls back to `check.name()`.
 pub fn run_logged_check(check: &dyn Check, event: HookEvent, hook: Option<&str>) -> ! {
+    let started = Instant::now();
     guard_interactive_terminal(check.name(), Some(event), None);
     let input = match HookInput::from_stdin() {
         Ok(input) => input,
@@ -37,15 +46,60 @@ pub fn run_logged_check(check: &dyn Check, event: HookEvent, hook: Option<&str>)
         // Effort-skipped → silent Allow, nothing to record.
         None => process::exit(Outcome::Allow.code()),
         Some(result) => {
-            // Record before emitting. The write is fully fail-open, so it cannot
-            // perturb the block message or the exit code that follows.
-            cadence_hooks_metrics::log_denial(
-                hook.unwrap_or_else(|| check.name()),
-                event,
-                &input,
-                result.outcome,
+            // Record before emitting. Both writes are fully fail-open, so neither
+            // can perturb the block message or the exit code that follows.
+            let hook_name = hook.unwrap_or_else(|| check.name());
+            cadence_hooks_metrics::log_denial(hook_name, event, &input, result.outcome);
+            cadence_hooks_metrics::log_timing(
+                hook_name,
+                crate::registry::plugin_for(hook_name).unwrap_or("unknown"),
+                event.name(),
+                started.elapsed().as_millis(),
+                input.session_id(),
             );
             emit_and_exit(&result, event);
         }
     }
+}
+
+/// Run a fire-and-forget logger from stdin, record its wall-clock time to
+/// `hooks.jsonl`, then **always exit 0** — exactly as
+/// [`cadence_hooks_core::run_logger_from_stdin`] would.
+///
+/// Replicates the core wrapper faithfully (interactive-terminal guard →
+/// `MetricsInput::from_stdin` → panic-caught `logger.run`) and adds exactly one
+/// fail-open side effect (the timing write) before `process::exit(0)`. Logger
+/// semantics are unchanged: a parse error, a missing field, or a panicking
+/// implementation still degrades to a no-op exit 0.
+///
+/// `hook` is the canonical registry name from `main::hook_name`; `event` is
+/// recorded as the constant `"logger"` since loggers react to `hook_event_name`
+/// in the payload rather than a fixed [`HookEvent`].
+pub fn run_logged_logger(
+    logger: &dyn Logger,
+    sample_override: Option<&str>,
+    hook: Option<&str>,
+) -> ! {
+    let started = Instant::now();
+    guard_interactive_terminal(logger.name(), None, sample_override);
+    // Capture the session id (when the payload carries one) for the timing row;
+    // a parse failure leaves it `None`, matching core's fail-open-to-exit-0 path.
+    let mut session_id: Option<String> = None;
+    if let Ok(input) = MetricsInput::from_stdin() {
+        session_id = input.session_id.clone();
+        // A panicking logger must not skip the timing write or the exit-0 below.
+        // Catch the unwind so the contract holds even on a buggy implementation.
+        // `AssertUnwindSafe` is required because `&dyn Logger` is not
+        // `UnwindSafe`; we exit immediately afterward, so there is no post-panic
+        // state to corrupt.
+        let _ = catch_unwind(AssertUnwindSafe(|| logger.run(&input)));
+    }
+    cadence_hooks_metrics::log_timing(
+        hook.unwrap_or("unknown"),
+        crate::registry::plugin_for(hook.unwrap_or("")).unwrap_or("metrics"),
+        "logger",
+        started.elapsed().as_millis(),
+        session_id.as_deref(),
+    );
+    process::exit(0);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -865,33 +865,39 @@ fn main() {
             ),
         },
         Commands::Metrics(cmd) => match cmd {
-            MetricsCommands::Snapshot => run_logger_from_stdin(
+            MetricsCommands::Snapshot => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::Snapshot,
                 registry::sample_for("metrics", "snapshot"),
+                canonical_hook,
             ),
-            MetricsCommands::LogCommit { prices } => run_logger_from_stdin(
+            MetricsCommands::LogCommit { prices } => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::LogCommit {
                     prices_path: prices,
                 },
                 registry::sample_for("metrics", "log-commit"),
+                canonical_hook,
             ),
-            MetricsCommands::LogSubagent => run_logger_from_stdin(
+            MetricsCommands::LogSubagent => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::LogSubagent,
                 registry::sample_for("metrics", "log-subagent"),
+                canonical_hook,
             ),
-            MetricsCommands::LogSession { prices } => run_logger_from_stdin(
+            MetricsCommands::LogSession { prices } => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::LogSession {
                     prices_path: prices,
                 },
                 registry::sample_for("metrics", "log-session"),
+                canonical_hook,
             ),
-            MetricsCommands::LogPolishNudge => run_logger_from_stdin(
+            MetricsCommands::LogPolishNudge => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::LogPolishNudge,
                 registry::sample_for("metrics", "log-polish-nudge"),
+                canonical_hook,
             ),
-            MetricsCommands::LogAskUserQuestion => run_logger_from_stdin(
+            MetricsCommands::LogAskUserQuestion => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::LogAskUserQuestion,
                 registry::sample_for("metrics", "log-ask-user-question"),
+                canonical_hook,
             ),
             // warn-stale is a SessionStart *check*, not a logger — it reads the
             // metrics dir's mtimes rather than reacting to a tool event.

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -379,6 +379,12 @@ pub fn entry(namespace: &str, subcommand: &str) -> Option<&'static HookEntry> {
         .find(|h| h.plugin == namespace && h.name == subcommand)
 }
 
+/// The plugin namespace for a canonical hook `name`, if it is registered.
+/// Used by the dispatch self-timing write to tag which plugin owns a slow hook.
+pub fn plugin_for(name: &str) -> Option<&'static str> {
+    HOOKS.iter().find(|h| h.name == name).map(|h| h.plugin)
+}
+
 /// Per-hook sample payload overrides for `try` and the interactive-terminal
 /// guidance.
 ///


### PR DESCRIPTION
## What

Threshold-gated hook self-timing: any hook whose execution exceeds `CADENCE_HOOK_TIMING_THRESHOLD_MS` (default 1000) is logged to `<metrics_dir>/hooks.jsonl`, to surface slow-hook outliers for later review — without meaningfully touching the fast path.

## Change

- New `log_timing` writer (metrics) — pure threshold gate + fail-open jsonl append; record `{ts, hook, plugin, event, elapsedMs, sessionId}`.
- Timing is captured at the two dispatch wrappers' entry (`run_logged_check` + a new `run_logged_logger`) and logged **after** `log_denial` and **before** `emit_and_exit`/`process::exit`, so it can never perturb a guard's stdout, exit code, or a logger's output. Only the executed-check arm times (effort-skip / parse-error arms exit untimed, as before).
- `run_logged_logger` replicates `run_logger_from_stdin` byte-for-byte (interactive guard → from_stdin → catch_unwind(run) → exit 0), adding only the `Instant` + timing call.
- `registry::plugin_for` resolves the plugin by hook name.

## Cost

Fast path adds one env read + one integer compare (threshold checked before building the record/timestamp). Fully fail-open: any write error is a silent no-op.

## Verification

- `cargo test --workspace` — green incl. 10 new `log_timing` tests
- `cargo clippy --all-targets -- -D warnings` — clean; `cargo fmt --check` — clean

## Note

Promoted a shared `#[cfg(test)] ENV_LOCK` into `common.rs` (both `log_denial` and `log_timing` mutate `CADENCE_METRICS_DIR` in tests; a shared lock prevents a cross-module env race under parallel execution).

Closes cameronsjo/cadence-hooks#143
