### PR TITLE
feat(guardrails): per-model Read/Grep guard — deny reads by resolved session model (cadence-hooks#144)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 - threshold-gated hook self-timing — hooks slower than CADENCE_HOOK_TIMING_THRESHOLD_MS (default 1000) are logged to hooks.jsonl (#143)
 - warn-subagent-concurrency — nudges when live subagents reach CADENCE_MAX_CONCURRENT_SUBAGENTS (default 5) (#145)
 - warn-branch-intent — nudges when new work starts on a stale, unrelated branch; once per session, opt out with CADENCE_ALLOW_BRANCH_INTENT (#155)
+- **guard-read-model — opt-in per-model Read/Grep guard (#144).** Resolves the current session model from the transcript tail (`core::transcript::last_assistant_model`, no metrics dep) and blocks Read/Grep per `CADENCE_READ_MODEL_GUARD_*` policy: `CADENCE_READ_MODEL_GUARD_MODELS` (space/comma list of family keywords or full ids; unset → disabled), `CADENCE_READ_MODEL_GUARD_MODE` (`deny`|`allow`, default `deny`), `CADENCE_READ_MODEL_GUARD_ON_UNKNOWN` (`block`|`allow`, default `allow`). Matching is case-insensitive substring (`opus` matches `claude-opus-4-8`). Blocks ONLY on a positively-identified denied model; fail-open on unknown — a missing/empty/unreadable transcript never bricks reads (ADR-0001).
 
 ### Fixed
 

--- a/crates/core/src/test_builders.rs
+++ b/crates/core/src/test_builders.rs
@@ -124,6 +124,39 @@ pub fn make_agent(subagent_type: Option<&str>, isolation: Option<&str>, cwd: &st
     }
 }
 
+/// Build a `HookInput` for a `Read` tool invocation, optionally carrying the
+/// session `transcript_path` the read-model guard resolves the model from.
+pub fn make_read(path: &str, transcript_path: Option<&str>) -> HookInput {
+    HookInput {
+        tool_name: Some("Read".into()),
+        tool_input: Some(ToolInput {
+            file_path: Some(path.into()),
+            ..Default::default()
+        }),
+        transcript_path: transcript_path.map(Into::into),
+        ..Default::default()
+    }
+}
+
+/// Build a `HookInput` for a `Grep` tool invocation, optionally carrying the
+/// session `transcript_path`.
+///
+/// Grep's `pattern` has no dedicated `ToolInput` field, and the read-model guard
+/// branches only on `tool_name` + `transcript_path` (never on tool-input
+/// content), so the pattern rides in `command` purely to preserve the caller's
+/// value.
+pub fn make_grep(pattern: &str, transcript_path: Option<&str>) -> HookInput {
+    HookInput {
+        tool_name: Some("Grep".into()),
+        tool_input: Some(ToolInput {
+            command: Some(pattern.into()),
+            ..Default::default()
+        }),
+        transcript_path: transcript_path.map(Into::into),
+        ..Default::default()
+    }
+}
+
 /// Build a `HookInput` for a `SessionStart` event with the given session id and
 /// source (`startup` | `resume` | `clear` | `compact`).
 pub fn make_session(session_id: &str, source: &str) -> HookInput {

--- a/crates/core/src/transcript.rs
+++ b/crates/core/src/transcript.rs
@@ -8,8 +8,50 @@
 //! gate that blocks an evidenced polish-skip share one implementation and one
 //! set of tests.
 
+use serde::Deserialize;
 use serde_json::Value;
 use std::path::{Path, PathBuf};
+
+/// Minimal transcript-line shape for model resolution. Only the fields
+/// [`last_assistant_model`] needs are deserialized; every other key is ignored.
+/// Deliberately local (not shared with `metrics::scan_tokens`) so the guardrails
+/// path carries no `metrics` dependency — see the reference implementation
+/// `metrics::scan_tokens::scan_tokens`, which resolves the same last-assistant
+/// model as a side effect of token accounting.
+#[derive(Deserialize)]
+struct ModelLine {
+    message: Option<ModelMessage>,
+}
+
+#[derive(Deserialize)]
+struct ModelMessage {
+    role: Option<String>,
+    model: Option<String>,
+}
+
+/// The model id of the *last* assistant message in a session transcript, or
+/// `None` when no assistant message carries a non-empty `model`.
+///
+/// Scans lines from the tail (`.lines().rev()`) and returns the first that
+/// parses as a message with `role == "assistant"` and a non-empty `model` —
+/// so the newest model wins and a short transcript with a late model is cheap.
+/// Corrupt lines, non-assistant messages, and assistant messages without a
+/// model are skipped, never fatal. Pure — operates on the transcript text, no
+/// I/O.
+///
+/// Reference implementation: `metrics::scan_tokens::scan_tokens` resolves the
+/// same last-assistant model while accounting tokens; this is the minimal,
+/// dependency-free variant the read-model guard needs.
+pub fn last_assistant_model(transcript: &str) -> Option<String> {
+    transcript.lines().rev().find_map(|line| {
+        let parsed = serde_json::from_str::<ModelLine>(line).ok()?;
+        let message = parsed.message?;
+        if message.role.as_deref() != Some("assistant") {
+            return None;
+        }
+        message.model.filter(|m| !m.is_empty())
+    })
+}
 
 /// True when the session transcript contains a `cadence-forge:polish` Skill
 /// invocation. Pure — operates on the transcript text, no I/O.
@@ -273,5 +315,72 @@ mod tests {
         )
         .unwrap();
         assert!(!subagent_transcripts_have_polish_run(&parent));
+    }
+
+    // --- last_assistant_model (#144) ---
+
+    fn model_line(role: &str, model: &str) -> String {
+        format!(r#"{{"message":{{"role":"{role}","model":"{model}"}}}}"#)
+    }
+
+    #[test]
+    fn last_assistant_model_returns_newest() {
+        // Two assistant models in order — the last (tail-most) wins.
+        let transcript = [
+            model_line("assistant", "claude-sonnet-4-5"),
+            model_line("assistant", "claude-opus-4-8"),
+        ]
+        .join("\n");
+        assert_eq!(
+            last_assistant_model(&transcript).as_deref(),
+            Some("claude-opus-4-8"),
+            "the last assistant model must win over earlier ones"
+        );
+    }
+
+    #[test]
+    fn last_assistant_model_skips_trailing_user_and_corrupt_lines() {
+        // A trailing user turn and a corrupt line after the assistant model must
+        // not shadow it — the scan skips non-assistant and unparseable lines.
+        let transcript = [
+            model_line("assistant", "claude-opus-4-8"),
+            r#"{"message":{"role":"user","content":"next"}}"#.to_string(),
+            "not json {{".to_string(),
+        ]
+        .join("\n");
+        assert_eq!(
+            last_assistant_model(&transcript).as_deref(),
+            Some("claude-opus-4-8")
+        );
+    }
+
+    #[test]
+    fn last_assistant_model_none_without_assistant() {
+        // Only user turns → no model to resolve.
+        let transcript = [
+            r#"{"message":{"role":"user","content":"hi"}}"#,
+            r#"{"message":{"role":"user","content":"still hi"}}"#,
+        ]
+        .join("\n");
+        assert_eq!(last_assistant_model(&transcript), None);
+    }
+
+    #[test]
+    fn last_assistant_model_none_when_assistant_has_no_model() {
+        // Assistant messages without a `model` field yield None, not a panic.
+        let transcript = r#"{"message":{"role":"assistant","content":"thinking"}}"#;
+        assert_eq!(last_assistant_model(transcript), None);
+    }
+
+    #[test]
+    fn last_assistant_model_ignores_empty_model_string() {
+        // A present-but-empty model is treated as absent.
+        let transcript = model_line("assistant", "");
+        assert_eq!(last_assistant_model(&transcript), None);
+    }
+
+    #[test]
+    fn last_assistant_model_empty_transcript_is_none() {
+        assert_eq!(last_assistant_model(""), None);
     }
 }

--- a/crates/guardrails/src/guard_read_model.rs
+++ b/crates/guardrails/src/guard_read_model.rs
@@ -1,0 +1,545 @@
+//! Opt-in per-model `Read`/`Grep` guard.
+//!
+//! Blocks a `Read`/`Grep` when the *current session model* — resolved from the
+//! transcript tail — is denied by an env-configured allow/deny policy. Its whole
+//! reason to exist is to let a session pin sensitive reads to a capable model
+//! (e.g. keep 🔒 security reads on the Opus family): configure the policy and a
+//! read attempted under the wrong model is blocked before it runs.
+//!
+//! **Fail-open by construction.** The guard blocks ONLY on a *positively
+//! identified* model that policy denies. Every "we don't know the model" path —
+//! guard disabled, no transcript path, an unreadable transcript, or a transcript
+//! with no assistant model — defaults to ALLOW, so a missing or empty transcript
+//! can never brick reads. `CADENCE_READ_MODEL_GUARD_ON_UNKNOWN=block` flips the
+//! unknown-model paths to BLOCK for callers who want strict fail-closed.
+//!
+//! **Opt-in:** disabled unless `CADENCE_READ_MODEL_GUARD_MODELS` is set.
+//!
+//! Config (env vars — the codebase has no config file):
+//! - `CADENCE_READ_MODEL_GUARD_MODELS` — space/comma list of model tokens
+//!   (family keywords like `opus`/`sonnet`/`haiku`, or full ids like
+//!   `claude-opus-4-8`). Unset/empty → guard disabled (no-op allow).
+//! - `CADENCE_READ_MODEL_GUARD_MODE` — `deny` | `allow` (default `deny`).
+//! - `CADENCE_READ_MODEL_GUARD_ON_UNKNOWN` — `block` | `allow` (default `allow`).
+//!
+//! Matching is a case-insensitive substring of each config token against the
+//! resolved model id: `opus` matches `claude-opus-4-8`; a full id matches only
+//! itself.
+
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+
+/// Env var: the model token list. Unset/empty disables the guard.
+const MODELS_VAR: &str = "CADENCE_READ_MODEL_GUARD_MODELS";
+/// Env var: policy direction (`deny` | `allow`), default `deny`.
+const MODE_VAR: &str = "CADENCE_READ_MODEL_GUARD_MODE";
+/// Env var: unknown-model disposition (`block` | `allow`), default `allow`.
+const ON_UNKNOWN_VAR: &str = "CADENCE_READ_MODEL_GUARD_ON_UNKNOWN";
+
+/// Policy direction for the configured model list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Mode {
+    /// Block when the resolved model matches the list (deny-list).
+    Deny,
+    /// Block when the resolved model does NOT match the list (allow-list).
+    Allow,
+}
+
+impl Mode {
+    /// Parse `CADENCE_READ_MODEL_GUARD_MODE`; anything but `allow` → `Deny`.
+    fn from_env_value(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("allow") {
+            Mode::Allow
+        } else {
+            Mode::Deny
+        }
+    }
+}
+
+/// What to do when no session model can be positively identified.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OnUnknown {
+    /// Allow the read (default) — a missing/empty transcript never bricks reads.
+    Allow,
+    /// Block the read — strict fail-closed for callers who opt in.
+    Block,
+}
+
+impl OnUnknown {
+    /// Parse `CADENCE_READ_MODEL_GUARD_ON_UNKNOWN`; anything but `block` → `Allow`.
+    fn from_env_value(value: &str) -> Self {
+        if value.eq_ignore_ascii_case("block") {
+            OnUnknown::Block
+        } else {
+            OnUnknown::Allow
+        }
+    }
+}
+
+/// True when any config token is a case-insensitive substring of the model id.
+/// `opus` matches `claude-opus-4-8`; the full id `claude-opus-4-8` matches only
+/// itself.
+fn model_matches(resolved: &str, models: &[String]) -> bool {
+    let lowered = resolved.to_lowercase();
+    models
+        .iter()
+        .any(|token| lowered.contains(&token.to_lowercase()))
+}
+
+/// Pure policy decision — no env reads, no I/O. `Some(block_message)` blocks;
+/// `None` allows. Implements the #144 fail-direction table exactly.
+///
+/// BLOCK happens ONLY on a positively-identified model that policy denies (a
+/// deny-list hit, or an allow-list miss). Every unknown-model path defers to
+/// `on_unknown`, which defaults to `Allow`. An empty `models` list is the
+/// disabled state — always allow.
+pub fn judge(
+    resolved_model: Option<&str>,
+    mode: Mode,
+    models: &[String],
+    on_unknown: OnUnknown,
+) -> Option<String> {
+    // Guard disabled — an empty model list is a no-op allow.
+    if models.is_empty() {
+        return None;
+    }
+
+    let Some(model) = resolved_model else {
+        // No positively-identified model → defer to on_unknown (default allow).
+        return match on_unknown {
+            OnUnknown::Block => Some(unknown_block_message()),
+            OnUnknown::Allow => None,
+        };
+    };
+
+    match (mode, model_matches(model, models)) {
+        // deny-list hit → block
+        (Mode::Deny, true) => Some(deny_hit_message(model)),
+        // deny-list miss → allow
+        (Mode::Deny, false) => None,
+        // allow-list hit → allow
+        (Mode::Allow, true) => None,
+        // allow-list miss → block
+        (Mode::Allow, false) => Some(allow_miss_message(model)),
+    }
+}
+
+/// Block message for a deny-list hit (mode=deny, model in list).
+fn deny_hit_message(model: &str) -> String {
+    format!(
+        "🔒 guard-read-model: Read/Grep blocked — session model {model:?} is on the deny-list (rule: deny-hit).\n   \
+         Adjust or disable via {MODELS_VAR} / {MODE_VAR}.",
+    )
+}
+
+/// Block message for an allow-list miss (mode=allow, model not in list).
+fn allow_miss_message(model: &str) -> String {
+    format!(
+        "🔒 guard-read-model: Read/Grep blocked — session model {model:?} is not on the allow-list (rule: allow-miss).\n   \
+         Adjust or disable via {MODELS_VAR} / {MODE_VAR}.",
+    )
+}
+
+/// Block message for the strict unknown-model path (on_unknown=block, no model).
+fn unknown_block_message() -> String {
+    format!(
+        "🔒 guard-read-model: Read/Grep blocked — session model could not be identified and {ON_UNKNOWN_VAR}=block (rule: unknown-block).\n   \
+         Disable via {MODELS_VAR}, or set {ON_UNKNOWN_VAR}=allow.",
+    )
+}
+
+/// Opt-in per-model Read/Grep guard (see the module docs for the policy table).
+pub struct GuardReadModel;
+
+impl Check for GuardReadModel {
+    fn name(&self) -> &str {
+        "guard-read-model"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        // Only Read/Grep are gated; every other tool passes through.
+        let tool = input.tool_name().unwrap_or("");
+        if tool != "Read" && tool != "Grep" {
+            return CheckResult::allow();
+        }
+
+        // Opt-in: an empty model list disables the guard entirely.
+        let models = cadence_hooks_core::config::env_list(MODELS_VAR);
+        if models.is_empty() {
+            return CheckResult::allow();
+        }
+
+        let mode = Mode::from_env_value(&std::env::var(MODE_VAR).unwrap_or_default());
+        let on_unknown =
+            OnUnknown::from_env_value(&std::env::var(ON_UNKNOWN_VAR).unwrap_or_default());
+
+        // Resolve the current model from the transcript tail. Every failure to
+        // read or parse is a fail-open path — routed through `judge(None, …)` →
+        // on_unknown (default allow) — so a missing transcript never bricks reads.
+        let resolved = input
+            .transcript_path()
+            .and_then(|path| std::fs::read_to_string(path).ok())
+            .and_then(|content| cadence_hooks_core::transcript::last_assistant_model(&content));
+
+        match judge(resolved.as_deref(), mode, &models, on_unknown) {
+            Some(msg) => CheckResult::block(msg),
+            None => CheckResult::allow(),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::Outcome;
+    use cadence_hooks_core::test_builders::{make_bash, make_grep, make_read};
+
+    fn models(list: &[&str]) -> Vec<String> {
+        list.iter().map(|s| s.to_string()).collect()
+    }
+
+    // --- judge: the fail-direction table, every row ---
+
+    #[test]
+    fn disabled_empty_models_allows() {
+        // Guard disabled (MODELS empty) → allow, regardless of model/mode.
+        assert_eq!(
+            judge(Some("claude-opus-4-8"), Mode::Deny, &[], OnUnknown::Block),
+            None
+        );
+    }
+
+    #[test]
+    fn deny_hit_blocks() {
+        // mode=deny, model IN deny-list → BLOCK, message names model + deny-hit.
+        let msg = judge(
+            Some("claude-opus-4-8"),
+            Mode::Deny,
+            &models(&["opus"]),
+            OnUnknown::Allow,
+        );
+        let msg = msg.expect("deny-list hit must block");
+        assert!(msg.contains("claude-opus-4-8"), "names the model: {msg}");
+        assert!(msg.contains("deny-hit"), "names the rule: {msg}");
+        assert!(
+            msg.contains("CADENCE_READ_MODEL_GUARD_MODELS"),
+            "names the disabling env var: {msg}"
+        );
+    }
+
+    #[test]
+    fn deny_miss_allows() {
+        // mode=deny, model NOT in deny-list → ALLOW.
+        assert_eq!(
+            judge(
+                Some("claude-sonnet-4-5"),
+                Mode::Deny,
+                &models(&["opus"]),
+                OnUnknown::Allow
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn allow_hit_allows() {
+        // mode=allow, model IN allow-list → ALLOW.
+        assert_eq!(
+            judge(
+                Some("claude-opus-4-8"),
+                Mode::Allow,
+                &models(&["opus"]),
+                OnUnknown::Allow
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn allow_miss_blocks() {
+        // mode=allow, model NOT in allow-list → BLOCK, message names allow-miss.
+        let msg = judge(
+            Some("claude-haiku-4-5"),
+            Mode::Allow,
+            &models(&["opus"]),
+            OnUnknown::Allow,
+        );
+        let msg = msg.expect("allow-list miss must block");
+        assert!(msg.contains("claude-haiku-4-5"), "names the model: {msg}");
+        assert!(msg.contains("allow-miss"), "names the rule: {msg}");
+        assert!(
+            msg.contains("CADENCE_READ_MODEL_GUARD_MODELS"),
+            "names the disabling env var: {msg}"
+        );
+    }
+
+    #[test]
+    fn unknown_model_defaults_allow() {
+        // resolved None, on_unknown=Allow (default) → ALLOW, both modes.
+        assert_eq!(
+            judge(None, Mode::Deny, &models(&["opus"]), OnUnknown::Allow),
+            None
+        );
+        assert_eq!(
+            judge(None, Mode::Allow, &models(&["opus"]), OnUnknown::Allow),
+            None
+        );
+    }
+
+    #[test]
+    fn unknown_model_block_flips_to_block() {
+        // resolved None, on_unknown=Block → BLOCK (unknown-block), never on a model.
+        let msg = judge(None, Mode::Deny, &models(&["opus"]), OnUnknown::Block);
+        let msg = msg.expect("on_unknown=block must block when no model is identified");
+        assert!(msg.contains("unknown-block"), "names the rule: {msg}");
+        assert!(
+            msg.contains("CADENCE_READ_MODEL_GUARD_ON_UNKNOWN"),
+            "names the on-unknown env var: {msg}"
+        );
+    }
+
+    #[test]
+    fn matching_is_case_insensitive() {
+        // Config token casing and model casing both fold.
+        assert!(
+            judge(
+                Some("CLAUDE-OPUS-4-8"),
+                Mode::Deny,
+                &models(&["OpUs"]),
+                OnUnknown::Allow
+            )
+            .is_some(),
+            "case-insensitive substring must hit"
+        );
+    }
+
+    #[test]
+    fn family_keyword_matches_full_id() {
+        // Family keyword `opus` matches the full id.
+        assert!(
+            judge(
+                Some("claude-opus-4-8"),
+                Mode::Deny,
+                &models(&["opus"]),
+                OnUnknown::Allow
+            )
+            .is_some()
+        );
+    }
+
+    #[test]
+    fn full_id_matches_only_itself() {
+        // A full-id token matches its own id but not a different one.
+        assert!(
+            judge(
+                Some("claude-opus-4-8"),
+                Mode::Deny,
+                &models(&["claude-opus-4-8"]),
+                OnUnknown::Allow
+            )
+            .is_some(),
+            "full id must match itself"
+        );
+        assert_eq!(
+            judge(
+                Some("claude-sonnet-4-5"),
+                Mode::Deny,
+                &models(&["claude-opus-4-8"]),
+                OnUnknown::Allow
+            ),
+            None,
+            "full id must not match a different model"
+        );
+    }
+
+    // --- Mode / OnUnknown parsing ---
+
+    #[test]
+    fn mode_parses_allow_else_deny() {
+        assert_eq!(Mode::from_env_value("allow"), Mode::Allow);
+        assert_eq!(Mode::from_env_value("ALLOW"), Mode::Allow);
+        assert_eq!(Mode::from_env_value("deny"), Mode::Deny);
+        assert_eq!(Mode::from_env_value(""), Mode::Deny);
+        assert_eq!(Mode::from_env_value("garbage"), Mode::Deny);
+    }
+
+    #[test]
+    fn on_unknown_parses_block_else_allow() {
+        assert_eq!(OnUnknown::from_env_value("block"), OnUnknown::Block);
+        assert_eq!(OnUnknown::from_env_value("BLOCK"), OnUnknown::Block);
+        assert_eq!(OnUnknown::from_env_value("allow"), OnUnknown::Allow);
+        assert_eq!(OnUnknown::from_env_value(""), OnUnknown::Allow);
+        assert_eq!(OnUnknown::from_env_value("garbage"), OnUnknown::Allow);
+    }
+
+    // --- Check::run glue ---
+    //
+    // run() reads the three CADENCE_READ_MODEL_GUARD_* vars from the
+    // process-global environment, so every run()-based test serializes via
+    // ENV_LOCK and explicitly pins all three (restoring prior values) — this
+    // keeps the disabled-guard assertions deterministic even if the ambient env
+    // has MODELS set, and free of races with parallel tests.
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let prior: Vec<(String, Option<String>)> = vars
+            .iter()
+            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
+            .collect();
+        for (k, v) in vars {
+            // SAFETY: serialized via ENV_LOCK; restored below.
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(k, val),
+                    None => std::env::remove_var(k),
+                }
+            }
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        for (k, v) in prior {
+            // SAFETY: same lock still held; restoring prior state.
+            unsafe {
+                match v {
+                    Some(val) => std::env::set_var(&k, val),
+                    None => std::env::remove_var(&k),
+                }
+            }
+        }
+        if let Err(payload) = result {
+            std::panic::resume_unwind(payload);
+        }
+    }
+
+    /// Pin all three guard vars — a common base the per-test overrides adjust.
+    fn guard_env(
+        models: Option<&'static str>,
+        mode: Option<&'static str>,
+        on_unknown: Option<&'static str>,
+    ) -> Vec<(&'static str, Option<&'static str>)> {
+        vec![
+            (MODELS_VAR, models),
+            (MODE_VAR, mode),
+            (ON_UNKNOWN_VAR, on_unknown),
+        ]
+    }
+
+    /// Write a one-line transcript naming `model` and return its temp file.
+    fn transcript_with_model(model: &str) -> tempfile::NamedTempFile {
+        let tmp = tempfile::NamedTempFile::new().unwrap();
+        std::fs::write(
+            tmp.path(),
+            format!(r#"{{"message":{{"role":"assistant","model":"{model}"}}}}"#),
+        )
+        .unwrap();
+        tmp
+    }
+
+    #[test]
+    fn non_read_grep_tool_allows() {
+        // A denying policy is set, but Bash is not gated → allow before any env read.
+        with_env(&guard_env(Some("opus"), Some("deny"), None), || {
+            let input = make_bash("echo hi");
+            assert_eq!(GuardReadModel.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn read_with_guard_disabled_allows() {
+        // A temp transcript names opus, but MODELS is unset → guard disabled → allow.
+        with_env(&guard_env(None, None, None), || {
+            let tmp = transcript_with_model("claude-opus-4-8");
+            let input = make_read("/tmp/secret", tmp.path().to_str());
+            assert_eq!(GuardReadModel.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn read_deny_hit_blocks_end_to_end() {
+        // deny opus + a transcript resolving to opus → BLOCK through run().
+        with_env(&guard_env(Some("opus"), Some("deny"), None), || {
+            let tmp = transcript_with_model("claude-opus-4-8");
+            let input = make_read("/tmp/secret", tmp.path().to_str());
+            let result = GuardReadModel.run(&input);
+            assert_eq!(result.outcome, Outcome::Block, "opus read must be blocked");
+            assert!(
+                result
+                    .message
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("claude-opus-4-8")
+            );
+        });
+    }
+
+    #[test]
+    fn read_deny_miss_allows_end_to_end() {
+        // deny opus + a transcript resolving to sonnet → ALLOW through run().
+        with_env(&guard_env(Some("opus"), Some("deny"), None), || {
+            let tmp = transcript_with_model("claude-sonnet-4-5");
+            let input = make_read("/tmp/ok", tmp.path().to_str());
+            assert_eq!(GuardReadModel.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn grep_allow_miss_blocks_end_to_end() {
+        // allow-list = opus + a Grep under haiku → BLOCK through run().
+        with_env(&guard_env(Some("opus"), Some("allow"), None), || {
+            let tmp = transcript_with_model("claude-haiku-4-5");
+            let input = make_grep("pattern", tmp.path().to_str());
+            let result = GuardReadModel.run(&input);
+            assert_eq!(result.outcome, Outcome::Block, "non-allowed grep blocks");
+            assert!(
+                result
+                    .message
+                    .as_deref()
+                    .unwrap_or_default()
+                    .contains("claude-haiku-4-5")
+            );
+        });
+    }
+
+    #[test]
+    fn missing_transcript_path_allows_default() {
+        // Policy set, but no transcript_path → resolved None → on_unknown default
+        // allow: a missing transcript must never brick reads.
+        with_env(&guard_env(Some("opus"), Some("deny"), None), || {
+            let input = make_read("/tmp/secret", None);
+            assert_eq!(GuardReadModel.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn unreadable_transcript_allows_default() {
+        // transcript_path points at a nonexistent file → read fails → resolved
+        // None → on_unknown default allow (fail-open).
+        with_env(&guard_env(Some("opus"), Some("deny"), None), || {
+            let input = make_read("/tmp/secret", Some("/no/such/transcript.jsonl"));
+            assert_eq!(GuardReadModel.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn unknown_model_on_unknown_block_blocks_end_to_end() {
+        // No assistant model in the transcript + on_unknown=block → BLOCK.
+        with_env(
+            &guard_env(Some("opus"), Some("deny"), Some("block")),
+            || {
+                let tmp = tempfile::NamedTempFile::new().unwrap();
+                std::fs::write(tmp.path(), r#"{"message":{"role":"user","content":"hi"}}"#)
+                    .unwrap();
+                let input = make_read("/tmp/secret", tmp.path().to_str());
+                let result = GuardReadModel.run(&input);
+                assert_eq!(result.outcome, Outcome::Block);
+                assert!(
+                    result
+                        .message
+                        .as_deref()
+                        .unwrap_or_default()
+                        .contains("unknown-block")
+                );
+            },
+        );
+    }
+}

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -25,6 +25,8 @@ pub mod guard_git_init;
 pub mod guard_op_vault_scan;
 /// Block `git push` to remotes owned by others.
 pub mod guard_push_remote;
+/// Opt-in per-model Read/Grep guard; block reads by the resolved session model.
+pub mod guard_read_model;
 /// Inject the gh-write allowlist + `-R` rule on SessionStart.
 pub mod inject_gh_context;
 /// Shared closing-keyword detection for GitHub issue references.

--- a/src/main.rs
+++ b/src/main.rs
@@ -38,6 +38,7 @@ const PROTECTED_GUARDS: &[&str] = &[
     "guard-op-vault-scan",
     "guard-browser-device",
     "guard-dotfiles",
+    "guard-read-model",
     "trash-guard",
 ];
 
@@ -184,6 +185,8 @@ enum GuardrailsCommands {
     WarnUntracked,
     /// Block direct edits to production dotfiles (opt-in via CADENCE_GUARD_DOTFILES=1)
     GuardDotfiles,
+    /// Block Read/Grep by resolved session model (opt-in via CADENCE_READ_MODEL_GUARD_MODELS)
+    GuardReadModel,
     /// Nudge when `gh pr create` has no closing issue keyword in the body
     WarnPrIssueLink,
     /// Nudge when `gh issue create` targets a repo other than the canonical issue tracker
@@ -347,6 +350,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::NudgeUpgradeAfterPush => "nudge-upgrade-after-push",
             GuardrailsCommands::WarnUntracked => "warn-untracked",
             GuardrailsCommands::GuardDotfiles => "guard-dotfiles",
+            GuardrailsCommands::GuardReadModel => "guard-read-model",
             GuardrailsCommands::WarnPrIssueLink => "warn-pr-issue-link",
             GuardrailsCommands::WarnIssueTracker => "warn-issue-tracker",
             GuardrailsCommands::WarnGoingPublic => "warn-going-public",
@@ -784,6 +788,11 @@ fn main() {
             ),
             GuardrailsCommands::GuardDotfiles => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_dotfiles::GuardDotfiles,
+                pre,
+                canonical_hook,
+            ),
+            GuardrailsCommands::GuardReadModel => dispatch::run_logged_check(
+                &cadence_hooks_guardrails::guard_read_model::GuardReadModel,
                 pre,
                 canonical_hook,
             ),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -186,6 +186,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::PreToolUse),
     },
     HookEntry {
+        name: "guard-read-model",
+        description: "Block Read/Grep by resolved session model (opt-in)",
+        plugin: "guardrails",
+        event: Some(HookEvent::PreToolUse),
+    },
+    HookEntry {
         name: "warn-pr-issue-link",
         description: "Nudge when gh pr create has no closing issue keyword",
         plugin: "guardrails",
@@ -496,6 +502,12 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         ("guardrails", "enforce-worktree") => Some(
             r#"{"tool_name":"Edit","tool_input":{"file_path":"/tmp/sample/file.txt"},"cwd":"/tmp"}"#,
         ),
+        // guard-read-model only gates Read/Grep; the generic Bash PreToolUse
+        // sample would no-op. Carry a Read payload so `try`/list fail-open cleanly
+        // (no MODELS env in a smoke run → disabled → allow).
+        ("guardrails", "guard-read-model") => {
+            Some(r#"{"tool_name":"Read","tool_input":{"file_path":"/tmp/x"},"cwd":"/tmp"}"#)
+        }
         _ => None,
     }
 }


### PR DESCRIPTION
## What

`guard-read-model` — an opt-in, fail-closed PreToolUse guard on Read/Grep that resolves the current session model and blocks the read/grep per an env-configured allow/deny policy.

## Why transcript-resolved

The `model` field is `None` in a PreToolUse payload (it is SessionStart-only). So the guard resolves the model from the session transcript tail — a new `core::transcript::last_assistant_model` reverse-scan (the requesting assistant message sits at the tail). No `metrics` dependency: a lean local primitive with a doc cross-reference to `scan_tokens`.

## Policy (env vars, opt-in)

- `CADENCE_READ_MODEL_GUARD_MODELS` — space/comma model tokens (family keyword `opus`, or full id `claude-opus-4-8`). Unset → **guard disabled (no-op)**.
- `CADENCE_READ_MODEL_GUARD_MODE` — `deny` | `allow` (default `deny`).
- `CADENCE_READ_MODEL_GUARD_ON_UNKNOWN` — `block` | `allow` (default **`allow`**).

Matching is case-insensitive substring per token.

## Fail-direction

BLOCK happens **only** when the model is positively identified AND policy denies it (deny-list hit, or allow-list miss). Every path where the model can't be positively identified (no `transcript_path`, unreadable file, no assistant message yet) falls to `onUnknown`, which **defaults to ALLOW** — a missing/empty transcript can never brick reads. `onUnknown=block` is an explicit opt-in for hardened deployments. Zero blast radius until `MODELS` is set.

## Scope (what it is, and isn't)

A dedicated security review confirmed the fail-direction integrity and ruled out transcript-content spoofing (the scan reads only top-level `role`/`model`, so untrusted content a Read ingests can't forge an assistant line), substring evasion, and PROTECTED_GUARDS forcing-on (unconfigured is a provable no-op). This is a **self-imposed guardrail (advisory), not adversarial enforcement** — its inherent limits: it is Read/Grep-scoped (Bash `cat`/`head` reads are un-gated), the transcript is self-writable (an agent could append a forged model line), and tail-resolution can lag a mid-session `/model` switch. Appropriate for "don't let the wrong model read X" hygiene; not a defense against a hostile agent.

## Note

Added to `PROTECTED_GUARDS` (mirrors `guard-dotfiles`, the sibling opt-in security guard) so a silent `CADENCE_DISABLE` can't bypass it; `CADENCE_BYPASS` remains the maintenance escape. This does not force the guard on when unconfigured.

## Two-repo

The PreToolUse Read|Grep matcher wiring lands in a companion PR on `cameronsjo/cadence` (cadence-guardrails hooks.json, PR #234). That companion is release-gated (the doctor check requires the released binary to carry this subcommand), so it merges after the next cadence-hooks release.

## Verification

- `cargo test --workspace` — 20 new `guard_read_model` tests (full fail-direction table + Mode/OnUnknown parsing + end-to-end glue) + 6 `last_assistant_model` tests
- `cargo clippy --all-targets -- -D warnings` — clean

Closes cameronsjo/cadence-hooks#144
