### PR TITLE
feat(metrics): add log-plan-phase — plan-phases.jsonl lifecycle logger

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- log-plan-phase — appends EnterPlanMode/ExitPlanMode lifecycle records (with a whole-transcript token/cost scan) to `plan-phases.jsonl`; pilots the `schemaVersion` convention (#218)
+
 ## [0.46.0] - 2026-07-03
 
 ### Added

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -467,6 +467,11 @@ pub struct MetricsInput {
     /// carries it (SessionStart and some Pre/PostToolUse payloads). Mirrors
     /// [`HookInput::model`]; deserializes to `None` when absent.
     pub model: Option<String>,
+    /// The tool that fired this event (e.g. `EnterPlanMode`, `ExitPlanMode`,
+    /// `Bash`). Mirrors [`HookInput::tool_name`]; deserializes to `None` when
+    /// absent. Powers event-derivation loggers like `log-plan-phase` that key
+    /// off which tool ran rather than a fixed `hook_event_name`.
+    pub tool_name: Option<String>,
     /// Top-level keys present in the raw payload. Populated by [`Self::from_json`],
     /// not deserialized — powers the `CADENCE_METRICS_DEBUG` `_keys` field that
     /// surfaces schema additions across Claude Code releases.
@@ -1874,6 +1879,15 @@ mod tests {
     #[test]
     fn metrics_input_rejects_malformed_json() {
         assert!(MetricsInput::from_json("not json").is_err());
+    }
+
+    #[test]
+    fn metrics_input_parses_tool_name_from_post_tool_use() {
+        // log-plan-phase keys its event derivation off this field.
+        let json =
+            r#"{"session_id":"s1","hook_event_name":"PostToolUse","tool_name":"ExitPlanMode"}"#;
+        let input = MetricsInput::from_json(json).unwrap();
+        assert_eq!(input.tool_name.as_deref(), Some("ExitPlanMode"));
     }
 
     // --- Interactive terminal guidance ---

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -16,6 +16,8 @@ pub mod log_askuserquestion;
 pub mod log_commit;
 /// Append guard-denial audit records to `denials.jsonl`.
 pub mod log_denial;
+/// Append plan-lifecycle records (EnterPlanMode/ExitPlanMode) to `plan-phases.jsonl`.
+pub mod log_plan_phase;
 /// Append polish-nudge (`gh pr create`) records to `polish_nudges.jsonl`.
 pub mod log_polish_nudge;
 /// Append per-session cost records to `sessions.jsonl` at `SessionEnd`.
@@ -40,6 +42,7 @@ pub mod warn_stale;
 pub use log_askuserquestion::LogAskUserQuestion;
 pub use log_commit::LogCommit;
 pub use log_denial::log_denial;
+pub use log_plan_phase::LogPlanPhase;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_session::LogSession;
 pub use log_session_start::LogSessionStart;

--- a/crates/metrics/src/log_plan_phase.rs
+++ b/crates/metrics/src/log_plan_phase.rs
@@ -1,0 +1,353 @@
+//! `EnterPlanMode` / `ExitPlanMode` — append one line per event to
+//! `<metrics_dir>/plan-phases.jsonl`.
+//!
+//! Reacts to `PostToolUse` and derives its event from `tool_name` rather than
+//! a fixed `hook_event_name` gate (sibling of [`crate::log_subagent`]'s
+//! two-event shape). Carries the same whole-transcript token/cost scan as
+//! [`crate::log_session`] (`scan_tokens` + `Prices::load`), but never gates
+//! the row on it — a stale or missing transcript degrades `tokensSinceStart`
+//! / `costUsd` / `model` to `null` rather than skipping the write, so a
+//! plan-phase transition is never silently dropped for lack of pricing data.
+//!
+//! Pilots the `schemaVersion` convention (stamped `1` on every row) — not yet
+//! adopted by the other metrics streams.
+
+use crate::common;
+use crate::compute_cost::compute_cost_by_model;
+use crate::prices::Prices;
+use crate::scan_tokens::{ScanResult, scan_tokens};
+use cadence_hooks_core::{Logger, MetricsInput};
+use serde_json::{Value, json};
+use std::io::Write;
+
+/// Schema version stamped on every `plan-phases.jsonl` row.
+const SCHEMA_VERSION: u32 = 1;
+
+/// Appends a line to `plan-phases.jsonl` for each plan lifecycle event. Holds
+/// the optional price table override path supplied via `--prices`, mirroring
+/// [`crate::log_session::LogSession`].
+pub struct LogPlanPhase {
+    pub prices_path: Option<String>,
+}
+
+impl Logger for LogPlanPhase {
+    fn name(&self) -> &str {
+        "log-plan-phase"
+    }
+
+    fn run(&self, input: &MetricsInput) {
+        if input.hook_event_name.as_deref() != Some("PostToolUse") {
+            return;
+        }
+        let Some(event) = plan_event(input.tool_name.as_deref()) else {
+            return;
+        };
+
+        let dir = common::metrics_dir();
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+
+        let summary = token_summary(input, self.prices_path.as_deref());
+        let branch = common::branch(input.cwd.as_deref());
+        let repo = common::repo_basename(input.cwd.as_deref());
+        let ts = common::utc_timestamp();
+        let debug = std::env::var("CADENCE_METRICS_DEBUG").as_deref() == Ok("1");
+
+        let record = build_plan_phase_record(
+            input,
+            event,
+            &ts,
+            &repo,
+            &branch,
+            summary.as_ref().map(|(scan, _)| scan),
+            summary.as_ref().map(|(_, cost)| *cost),
+            debug,
+        );
+
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join("plan-phases.jsonl"))
+        {
+            // Single write_all of record + newline, matching log_subagent.rs —
+            // atomic per-record so concurrent appends can't interleave.
+            let mut line = record.to_string();
+            line.push('\n');
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+/// Map a hook's `tool_name` to a plan-lifecycle event name. `None` for any
+/// tool other than `EnterPlanMode`/`ExitPlanMode` (or a missing `tool_name`) —
+/// the caller no-ops rather than logging every tool call.
+fn plan_event(tool_name: Option<&str>) -> Option<&'static str> {
+    match tool_name {
+        Some("EnterPlanMode") => Some("plan_enter"),
+        Some("ExitPlanMode") => Some("plan_exit"),
+        _ => None,
+    }
+}
+
+/// Whole-transcript token scan + cost, verbatim the same approach as
+/// [`crate::log_session::LogSession::run`]: `scan_tokens(&transcript, None)`,
+/// `Prices::load` from the `--prices` path, and an `is_safe_session_id` guard
+/// on the session id before touching the transcript path. Returns `None` on
+/// any failure (unsafe/missing session id, missing/unreadable transcript, or
+/// nothing to scan) — the caller treats that as "no pricing data", not an
+/// error.
+fn token_summary(input: &MetricsInput, prices_path: Option<&str>) -> Option<(ScanResult, f64)> {
+    input
+        .session_id
+        .as_deref()
+        .filter(|s| common::is_safe_session_id(s))?;
+    let transcript_path = input.transcript_path.as_deref()?;
+    if !std::path::Path::new(transcript_path).is_file() {
+        return None;
+    }
+    let transcript = std::fs::read_to_string(transcript_path).ok()?;
+    let scan = scan_tokens(&transcript, None)?;
+    let prices = Prices::load(prices_path);
+    let cost = compute_cost_by_model(&scan.by_model, &prices);
+    Some((scan, cost))
+}
+
+/// Build the JSONL record for a plan-phase event. Pure — no I/O. `scan`/`cost`
+/// are `None` when [`token_summary`] couldn't price the transcript; the
+/// resulting `model` / `tokensSinceStart` / `costUsd` fields serialize as
+/// explicit `null`, per crate convention.
+#[allow(clippy::too_many_arguments)]
+fn build_plan_phase_record(
+    input: &MetricsInput,
+    event: &str,
+    ts: &str,
+    repo: &str,
+    branch: &str,
+    scan: Option<&ScanResult>,
+    cost: Option<f64>,
+    include_keys: bool,
+) -> Value {
+    let model = scan.map(|s| s.model.clone());
+    let tokens_since_start = scan.map(|s| {
+        json!({
+            "input": s.tokens.input,
+            "cacheCreate": s.tokens.cache_create,
+            "cacheRead": s.tokens.cache_read,
+            "output": s.tokens.output,
+        })
+    });
+
+    let mut record = json!({
+        "schemaVersion": SCHEMA_VERSION,
+        "ts": ts,
+        "event": event,
+        "sessionId": input.session_id,
+        "transcriptPath": input.transcript_path,
+        "repo": repo,
+        "branch": branch,
+        "model": model,
+        "tokensSinceStart": tokens_since_start,
+        "costUsd": cost,
+        "agentId": input.agent_id,
+        "agentType": input.agent_type,
+        "parentSessionId": input.parent_session_id,
+    });
+
+    if include_keys && let Some(obj) = record.as_object_mut() {
+        obj.insert("_keys".to_string(), json!(input.raw_keys));
+    }
+
+    record
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn exit_plan_input() -> MetricsInput {
+        MetricsInput {
+            hook_event_name: Some("PostToolUse".into()),
+            tool_name: Some("ExitPlanMode".into()),
+            session_id: Some("s1".into()),
+            raw_keys: vec!["hook_event_name".into(), "tool_name".into()],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn name_is_log_plan_phase() {
+        assert_eq!(LogPlanPhase { prices_path: None }.name(), "log-plan-phase");
+    }
+
+    // --- event derivation ---
+
+    #[test]
+    fn enter_plan_mode_derives_plan_enter() {
+        assert_eq!(plan_event(Some("EnterPlanMode")), Some("plan_enter"));
+    }
+
+    #[test]
+    fn exit_plan_mode_derives_plan_exit() {
+        assert_eq!(plan_event(Some("ExitPlanMode")), Some("plan_exit"));
+    }
+
+    #[test]
+    fn other_tool_derives_none() {
+        assert_eq!(plan_event(Some("Bash")), None);
+    }
+
+    #[test]
+    fn missing_tool_name_derives_none() {
+        assert_eq!(plan_event(None), None);
+    }
+
+    #[test]
+    fn wrong_hook_event_is_noop() {
+        // PreToolUse (or any non-PostToolUse event) must not log, even with a
+        // recognized tool_name.
+        let input = MetricsInput {
+            hook_event_name: Some("PreToolUse".into()),
+            tool_name: Some("ExitPlanMode".into()),
+            ..Default::default()
+        };
+        LogPlanPhase { prices_path: None }.run(&input);
+    }
+
+    #[test]
+    fn other_tool_on_post_tool_use_is_noop() {
+        let input = MetricsInput {
+            hook_event_name: Some("PostToolUse".into()),
+            tool_name: Some("Bash".into()),
+            ..Default::default()
+        };
+        LogPlanPhase { prices_path: None }.run(&input);
+    }
+
+    // --- record shape ---
+
+    #[test]
+    fn record_carries_event_and_context_fields() {
+        let record = build_plan_phase_record(
+            &exit_plan_input(),
+            "plan_exit",
+            "2026-07-05T00:00:00Z",
+            "myrepo",
+            "feat/x",
+            None,
+            None,
+            false,
+        );
+        assert_eq!(record["schemaVersion"], 1);
+        assert_eq!(record["ts"], "2026-07-05T00:00:00Z");
+        assert_eq!(record["event"], "plan_exit");
+        assert_eq!(record["sessionId"], "s1");
+        assert_eq!(record["repo"], "myrepo");
+        assert_eq!(record["branch"], "feat/x");
+    }
+
+    #[test]
+    fn absent_optional_fields_are_null() {
+        let record = build_plan_phase_record(
+            &exit_plan_input(),
+            "plan_exit",
+            "2026-07-05T00:00:00Z",
+            "myrepo",
+            "feat/x",
+            None,
+            None,
+            false,
+        );
+        assert!(record["transcriptPath"].is_null());
+        assert!(record["model"].is_null());
+        assert!(record["tokensSinceStart"].is_null());
+        assert!(record["costUsd"].is_null());
+        assert!(record["agentId"].is_null());
+        assert!(record["agentType"].is_null());
+        assert!(record["parentSessionId"].is_null());
+        assert!(record.get("_keys").is_none());
+    }
+
+    #[test]
+    fn present_scan_populates_model_and_tokens() {
+        let scan = ScanResult {
+            tokens: crate::scan_tokens::Tokens {
+                input: 100,
+                cache_create: 50,
+                cache_read: 200,
+                output: 30,
+            },
+            last_message_id: "m9".into(),
+            messages_scanned: 3,
+            model: "claude-opus-4-8".into(),
+            by_model: vec![],
+        };
+        let record = build_plan_phase_record(
+            &exit_plan_input(),
+            "plan_exit",
+            "2026-07-05T00:00:00Z",
+            "myrepo",
+            "feat/x",
+            Some(&scan),
+            Some(0.001234),
+            false,
+        );
+        assert_eq!(record["model"], "claude-opus-4-8");
+        assert_eq!(record["tokensSinceStart"]["input"], 100);
+        assert_eq!(record["tokensSinceStart"]["cacheCreate"], 50);
+        assert_eq!(record["tokensSinceStart"]["cacheRead"], 200);
+        assert_eq!(record["tokensSinceStart"]["output"], 30);
+        assert_eq!(record["costUsd"], 0.001234);
+    }
+
+    #[test]
+    fn debug_adds_keys() {
+        let record = build_plan_phase_record(
+            &exit_plan_input(),
+            "plan_exit",
+            "2026-07-05T00:00:00Z",
+            "myrepo",
+            "feat/x",
+            None,
+            None,
+            true,
+        );
+        let keys = record["_keys"].as_array().unwrap();
+        assert!(keys.contains(&json!("tool_name")));
+    }
+
+    #[test]
+    fn record_serializes_to_single_line() {
+        let line = build_plan_phase_record(
+            &exit_plan_input(),
+            "plan_exit",
+            "2026-07-05T00:00:00Z",
+            "myrepo",
+            "feat/x",
+            None,
+            None,
+            true,
+        )
+        .to_string();
+        assert!(!line.contains('\n'), "record must be one line: {line}");
+    }
+
+    #[test]
+    fn token_summary_none_without_session_id() {
+        let input = MetricsInput {
+            transcript_path: Some("/nonexistent/path.jsonl".into()),
+            ..Default::default()
+        };
+        assert!(token_summary(&input, None).is_none());
+    }
+
+    #[test]
+    fn token_summary_none_for_unreadable_transcript() {
+        let input = MetricsInput {
+            session_id: Some("s1".into()),
+            transcript_path: Some("/nonexistent/path.jsonl".into()),
+            ..Default::default()
+        };
+        assert!(token_summary(&input, None).is_none());
+    }
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -96,6 +96,7 @@ exit 0. They never block a tool call (see
 | `log-subagent` | SubagentStart / SubagentStop | Append a subagent lifecycle record to `subagents.jsonl` |
 | `log-session` | SessionEnd | Scan the whole session log at session end, compute per-model cost, append to `sessions.jsonl` |
 | `log-session-start` | SessionStart | Stamp the session start timestamp, so `log-session` can compute `durationMs` at `SessionEnd` |
+| `log-plan-phase` | PostToolUse (`EnterPlanMode` / `ExitPlanMode`) | Append a plan-lifecycle record (with a whole-transcript token/cost scan) to `plan-phases.jsonl` |
 | `log-polish-nudge` | PostToolUse (Bash, `gh pr create`) | Record every nudged PR and whether `/polish` ran earlier this session, append to `polish_nudges.jsonl` |
 | `log-ask-user-question` | PreToolUse (`AskUserQuestion`) | Record each call's stance (recommended / declared-no-rec / silent) and shape (multiSelect, question/option counts), append to `askuserquestion.jsonl` |
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -263,6 +263,13 @@ enum MetricsCommands {
     },
     /// Capture session start timestamp (SessionStart)
     LogSessionStart,
+    /// Log plan-lifecycle events: EnterPlanMode / ExitPlanMode (PostToolUse)
+    LogPlanPhase {
+        /// Override path to the model price table (JSON). Falls back to the
+        /// embedded default; `CADENCE_METRICS_PRICES` env takes precedence.
+        #[arg(long, value_name = "PATH")]
+        prices: Option<String>,
+    },
     /// Log polish-nudge skips: `gh pr create` + whether /polish ran (PostToolUse)
     LogPolishNudge,
     /// Log AskUserQuestion stance + shape on every call (PreToolUse)
@@ -384,6 +391,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::LogSubagent => "log-subagent",
             MetricsCommands::LogSession { .. } => "log-session",
             MetricsCommands::LogSessionStart => "log-session-start",
+            MetricsCommands::LogPlanPhase { .. } => "log-plan-phase",
             MetricsCommands::LogPolishNudge => "log-polish-nudge",
             MetricsCommands::LogAskUserQuestion => "log-ask-user-question",
             MetricsCommands::WarnStale => "warn-stale",
@@ -915,6 +923,13 @@ fn main() {
             MetricsCommands::LogSessionStart => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::LogSessionStart,
                 registry::sample_for("metrics", "log-session-start"),
+                canonical_hook,
+            ),
+            MetricsCommands::LogPlanPhase { prices } => dispatch::run_logged_logger(
+                &cadence_hooks_metrics::LogPlanPhase {
+                    prices_path: prices,
+                },
+                registry::sample_for("metrics", "log-plan-phase"),
                 canonical_hook,
             ),
             MetricsCommands::LogPolishNudge => dispatch::run_logged_logger(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -315,6 +315,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: None,
     },
     HookEntry {
+        name: "log-plan-phase",
+        description: "Log plan-lifecycle events: EnterPlanMode / ExitPlanMode (PostToolUse)",
+        plugin: "metrics",
+        event: None,
+    },
+    HookEntry {
         name: "log-polish-nudge",
         description: "Log polish-nudge skips: gh pr create + whether /polish ran (PostToolUse)",
         plugin: "metrics",
@@ -445,6 +451,12 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         ("metrics", "log-session-start") => {
             Some(r#"{"session_id":"test","hook_event_name":"SessionStart","cwd":"/tmp"}"#)
         }
+        // log-plan-phase gates on hook_event_name == "PostToolUse" plus a
+        // tool_name of EnterPlanMode/ExitPlanMode; the generic logger sample
+        // carries neither and would no-op.
+        ("metrics", "log-plan-phase") => Some(
+            r#"{"session_id":"test","hook_event_name":"PostToolUse","tool_name":"ExitPlanMode","transcript_path":"/tmp/transcript.jsonl","cwd":"/tmp"}"#,
+        ),
         // log-polish-nudge gates on a `gh pr create` command (the nudge denominator)
         ("metrics", "log-polish-nudge") => Some(
             r#"{"session_id":"test","hook_event_name":"PostToolUse","tool_input":{"command":"gh pr create --title test"},"transcript_path":"/tmp/transcript.jsonl"}"#,
@@ -576,7 +588,13 @@ mod tests {
     fn sample_overrides_exist_for_event_gated_loggers() {
         // These loggers gate on specific hook_event_name values or command
         // shapes — the generic fallback would no-op them.
-        for name in ["snapshot", "log-commit", "log-subagent", "log-session"] {
+        for name in [
+            "snapshot",
+            "log-commit",
+            "log-subagent",
+            "log-session",
+            "log-plan-phase",
+        ] {
             assert!(
                 sample_for("metrics", name).is_some(),
                 "{name} needs a sample override"
@@ -620,6 +638,7 @@ mod tests {
             "log-subagent",
             "log-session",
             "log-session-start",
+            "log-plan-phase",
             "log-polish-nudge",
             "log-ask-user-question",
             "heartbeat",


### PR DESCRIPTION
## Summary

Adds a `metrics log-plan-phase` logger that appends plan-lifecycle rows to `plan-phases.jsonl` in the metrics dir. This is the instrumentation half of the plan-cohesion metrics slice (cameronsjo/cadence#243) — the deferred plan-phases stream from the O3 session-cost spec, now unblocked (nothing else wires `ExitPlanMode`).

Closes #218.

## Behavior

- Gates on `PostToolUse` and derives the event from `tool_name`: `EnterPlanMode` → `plan_enter`, `ExitPlanMode` → `plan_exit`; any other tool or hook event → silent no-op. Deriving (not hardcoding one event per wiring) keeps a future rejected-plan wiring a pure hooks.json addition.
- `plan_exit` means an **approved** plan (PostToolUse fires only on tool success). `plan_enter` is a known lower-bound signal — it fires only on Claude-initiated plan entry; user mode toggles emit no tool event.
- Tokens/cost: whole-transcript scan + `--prices`, same approach as `log-session`. Deliberate divergence: a failed scan degrades `model`/`tokensSinceStart`/`costUsd` to `null` instead of skipping the row — a plan-phase transition is never silently dropped for lack of pricing data.
- Stamps `schemaVersion: 1` on every row — this new stream pilots the schema-version convention (cameronsjo/cadence#238) without touching existing streams.
- Fail-open throughout; `CADENCE_METRICS_DEBUG=1` appends `_keys`.

## Changes

- New `crates/metrics/src/log_plan_phase.rs` — two-event gate + pure record builder + single atomic append (log-subagent's shape, log-session's scan/prices half).
- `MetricsInput` gains additive `tool_name: Option<String>` (crates/core) — loggers previously couldn't see the tool name.
- Registry entry (`event: None`, loggers array) with a `sample_for` override (PostToolUse + `tool_name: "ExitPlanMode"`) so `try`/`doctor` exercise the gate; clap variant with `--prices` mirroring `log-session`; docs/hooks.md row; CHANGELOG entry.

## Tests

- 14 new tests in the logger (event derivation ×4, no-op gates, record shape, null-field presence, `schemaVersion` stamp, `_keys` debug, single-line serialization, token-summary guards) + a `MetricsInput` `tool_name` parse test in core.
- Registry gates green: `registry_matches_clap_dispatch`, `only_loggers_have_no_event`, `sample_overrides_parse_as_metrics_input`.
- `cargo test --workspace` green apart from two pre-existing `enforce_worktree` failures that reproduce identically on the unmodified 0.46.0 base (environment-dependent, untouched by this diff).

## Follow-up (separate PRs)

- `cadence-metrics` plugin wiring (PostToolUse matcher `EnterPlanMode|ExitPlanMode`) lands after this releases, per the two-repo companion gating.
- Rejected-plan visibility (`plan_exit_rejected` via a failure-event wiring) is a named follow-up, probed empirically first.

Part of cameronsjo/cadence#243.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new metrics hook to record plan mode entry/exit events and write them to a JSONL log.
  * Added a CLI command to run this logger, with an optional price-table path for cost calculations.
  * Plan-phase records now include standardized versioning and can capture transcript-based token and cost data when available.

* **Documentation**
  * Updated hook documentation and changelog to reflect the new plan-phase logging support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->