### PR TITLE
feat(guardrails): guard-bypass provenance with reasoned dismissals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **guard-bypass provenance — every guardrail bypass now leaves a durable, privacy-safe audit line.** A new `bypasses.jsonl` metrics stream records two events: `armed` (a `dismiss-*` snooze was set) and `used` (a write rode through an active dismissal or env switch, which the denial log can't see because a bypass is an allow). Each line carries the guard, mechanism, kind (`dismissal`/`env_switch`), session, repo **basename**, a user-authored reason, and the expiry — never a command, path, or edited content (privacy-by-construction, like `denials.jsonl`). Both `dismiss-enforce-worktree` and `dismiss-main-branch-warn` gain `--reason`, **required for a dismissal longer than 1h** and nudged at or under it; the reason/session/expiry also land in a provenance sidecar beside the snooze marker (the load-bearing `{epoch}` marker is unchanged). v1 wires the two highest-value guards (`enforce-worktree`, `warn-main-branch`); the remaining guards, the global gates, and read-side surfacing are a tracked follow-up. Fully fail-open (ADR-0001) — a failed audit write never turns an allow into a block.
+
 ## [0.47.0] - 2026-07-05
 
 ### Added

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -538,6 +538,56 @@ pub struct BlockMetadata {
     pub severity: &'static str,
 }
 
+/// Why a guard allowed an operation it would otherwise have acted on.
+///
+/// v1 distinguishes a time-bounded `dismiss-*` snooze from a per-guard
+/// environment switch. Future kinds (`GlobalBypass`/`GlobalDisable` for the
+/// `main.rs` gates, `Exemption`, `EffortSkip`) extend this as the remaining
+/// bypass surface opts in — see the deferred follow-up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BypassKind {
+    /// A `cadence-hooks guardrails dismiss-*` snooze marker was active.
+    Dismissal,
+    /// A per-guard environment switch (e.g. `CADENCE_ALLOW_MAIN`,
+    /// `CADENCE_NO_ENFORCE_WORKTREE`) suppressed the guard.
+    EnvSwitch,
+}
+
+impl BypassKind {
+    /// Stable snake_case wire token, so the metrics record shape doesn't couple
+    /// to the Rust variant spelling.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BypassKind::Dismissal => "dismissal",
+            BypassKind::EnvSwitch => "env_switch",
+        }
+    }
+}
+
+/// Attribution for a bypass-allow: *why* a guard let an operation through that
+/// its own invariant would otherwise have blocked or nudged. Rides on
+/// [`CheckResult::bypass`] so the dispatch seam can record the ride-through
+/// (in `src/dispatch.rs`) without a new [`Outcome`] variant.
+///
+/// **Privacy contract (inherited from the denial log):** carries only the
+/// mechanism, a user-authored `reason`, the arming session, and the expiry —
+/// never a command, path, or edited content.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BypassProvenance {
+    /// Dismissal vs env-switch.
+    pub kind: BypassKind,
+    /// The concrete mechanism, e.g. `dismiss-enforce-worktree` or
+    /// `CADENCE_ALLOW_MAIN`.
+    pub mechanism: String,
+    /// The user-authored `--reason` from a `dismiss-*` snooze, when present.
+    /// Always `None` for an env-switch (there is nowhere to author one).
+    pub reason: Option<String>,
+    /// Unix epoch seconds when the dismissal expires, when known.
+    pub expires_at: Option<i64>,
+    /// The session id that armed the dismissal, when the sidecar recorded it.
+    pub armed_by_session: Option<String>,
+}
+
 /// Result of running a single check.
 pub struct CheckResult {
     pub outcome: Outcome,
@@ -547,6 +597,11 @@ pub struct CheckResult {
     /// it). When `Some`, `run_check` emits a `permissionDecision: "deny"`
     /// JSON envelope alongside the legacy stderr message.
     pub block_metadata: Option<BlockMetadata>,
+    /// Attribution when the guard allowed *because a bypass was active* — a
+    /// snooze marker or an env switch — rather than because the operation was
+    /// fine on its own. `None` for a normal allow/nudge/block. When `Some`, the
+    /// dispatch seam records a `used` line in `bypasses.jsonl`.
+    pub bypass: Option<BypassProvenance>,
 }
 
 impl CheckResult {
@@ -555,6 +610,7 @@ impl CheckResult {
             outcome: Outcome::Allow,
             message: None,
             block_metadata: None,
+            bypass: None,
         }
     }
 
@@ -563,6 +619,7 @@ impl CheckResult {
             outcome: Outcome::Nudge,
             message: Some(message.into()),
             block_metadata: None,
+            bypass: None,
         }
     }
 
@@ -571,6 +628,7 @@ impl CheckResult {
             outcome: Outcome::Block,
             message: Some(message.into()),
             block_metadata: None,
+            bypass: None,
         }
     }
 
@@ -582,6 +640,7 @@ impl CheckResult {
             outcome: Outcome::Block,
             message: Some(message.into()),
             block_metadata: Some(meta),
+            bypass: None,
         }
     }
 
@@ -592,6 +651,20 @@ impl CheckResult {
             outcome: Outcome::LoopBlock,
             message: Some(message.into()),
             block_metadata: None,
+            bypass: None,
+        }
+    }
+
+    /// An [`Outcome::Allow`] that carries [`BypassProvenance`]: the guard let the
+    /// operation through *because a bypass was active*, not because the operation
+    /// was fine on its own. Exit code is still 0 — the provenance rides the result
+    /// so the dispatch seam records a `used` line in `bypasses.jsonl`.
+    pub fn allow_bypassed(bypass: BypassProvenance) -> Self {
+        Self {
+            outcome: Outcome::Allow,
+            message: None,
+            block_metadata: None,
+            bypass: Some(bypass),
         }
     }
 }
@@ -1659,6 +1732,39 @@ mod tests {
     fn check_result_accepts_string() {
         let r = CheckResult::nudge(String::from("owned"));
         assert_eq!(r.message.as_deref(), Some("owned"));
+    }
+
+    // --- bypass provenance ---
+
+    #[test]
+    fn plain_constructors_carry_no_bypass() {
+        // Only allow_bypassed sets provenance; every other constructor leaves it
+        // None so the dispatch seam records nothing for a normal allow/block.
+        assert!(CheckResult::allow().bypass.is_none());
+        assert!(CheckResult::nudge("x").bypass.is_none());
+        assert!(CheckResult::block("y").bypass.is_none());
+        assert!(CheckResult::loop_block("z").bypass.is_none());
+    }
+
+    #[test]
+    fn allow_bypassed_carries_provenance() {
+        let prov = BypassProvenance {
+            kind: BypassKind::Dismissal,
+            mechanism: "dismiss-enforce-worktree".to_string(),
+            reason: Some("dogfooding vault symlink".to_string()),
+            expires_at: Some(2_000_000_000),
+            armed_by_session: Some("sess-1".to_string()),
+        };
+        let r = CheckResult::allow_bypassed(prov.clone());
+        assert_eq!(r.outcome, Outcome::Allow, "bypass-allow still exits 0");
+        assert_eq!(r.bypass.as_ref(), Some(&prov));
+    }
+
+    #[test]
+    fn bypass_kind_wire_tokens_are_stable() {
+        // Metrics records key off these; a rename would silently break greps.
+        assert_eq!(BypassKind::Dismissal.as_str(), "dismissal");
+        assert_eq!(BypassKind::EnvSwitch.as_str(), "env_switch");
     }
 
     // --- JSON deserialization ---

--- a/crates/guardrails/src/dismiss_enforce_worktree.rs
+++ b/crates/guardrails/src/dismiss_enforce_worktree.rs
@@ -16,10 +16,10 @@
 //! resolve the common dir via `git rev-parse --git-common-dir` rather than
 //! assuming the marker sits under the passed directory's own `.git`.
 
-use crate::dismiss_main_branch_warn::{is_snoozed_at, parse_duration};
+use crate::dismiss_main_branch_warn::{is_snoozed_at, parse_duration, session_id_from_env};
+use crate::snooze_meta::{self, DismissArmed, SnoozeMeta};
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Subdirectory (relative to the git common dir) that holds the marker. The
@@ -57,6 +57,20 @@ pub fn marker_path_for(dir: &Path) -> Option<PathBuf> {
     git_common_dir(dir).map(|c| marker_path(&c))
 }
 
+/// The provenance sidecar beside the snooze marker for `dir` (resolved through
+/// the shared common dir). `None` when `dir` isn't inside a git repo.
+pub fn meta_path_for(dir: &Path) -> Option<PathBuf> {
+    marker_path_for(dir).map(|m| snooze_meta::sidecar_for(&m))
+}
+
+/// Read the provenance sidecar for `repo_root`'s active snooze — reason, arming
+/// session, expiry. `None` when the sidecar is missing/unreadable (an older
+/// marker armed before this feature, or a fail-open sidecar write): the guard
+/// then attributes the bypass with a `None` reason and still allows.
+pub fn read_meta(repo_root: &Path) -> Option<SnoozeMeta> {
+    SnoozeMeta::read(&meta_path_for(repo_root)?)
+}
+
 fn now_epoch() -> u64 {
     SystemTime::now()
         .duration_since(UNIX_EPOCH)
@@ -80,18 +94,32 @@ pub fn is_snoozed_now(repo_root: &Path) -> bool {
     is_snoozed_at(&contents, now_epoch())
 }
 
-/// Entry point for the `dismiss-enforce-worktree` subcommand.
+/// The dismiss mechanism name recorded in bypass provenance.
+const MECHANISM: &str = "dismiss-enforce-worktree";
+
+/// Perform the `dismiss-enforce-worktree` action: validate, gate on `--reason`,
+/// write the epoch marker **and** its provenance sidecar under the shared git
+/// common dir. Returns [`DismissArmed`] for the binary to log + confirm.
 ///
-/// Writes the epoch-seconds expiry marker under the shared git common dir and
-/// confirms. Exits 1 on failure (missing repo, invalid duration, write error);
-/// 0 on success — this is a user-facing CLI, not a hook.
-pub fn run_dismiss(duration_str: &str) -> ! {
+/// Prints every error to stderr and returns `Err(())` (the binary exits 1) —
+/// missing repo, invalid duration, over-cap, or a missing `--reason` for a
+/// snooze longer than 1h. On success prints nothing and returns `Ok`.
+///
+/// The load-bearing marker stays exactly `{until}\n` (the guard's first-line
+/// parse is untouched); provenance rides in the sibling sidecar. The sidecar
+/// write is best-effort — a failure warns but does not fail the dismissal, so a
+/// snooze never depends on the audit trail succeeding (ADR-0001).
+///
+/// The `Err` is unit on purpose: this function prints every error to stderr
+/// itself, so the caller only needs pass/fail to pick an exit code.
+#[allow(clippy::result_unit_err)]
+pub fn perform_dismiss(duration_str: &str, reason: Option<&str>) -> Result<DismissArmed, ()> {
     let Some(duration) = parse_duration(duration_str) else {
         eprintln!(
             "cadence-hooks: invalid duration '{duration_str}'\n   \
              Expected: <number><s|m|h|d>, e.g. `30m`, `2h`, `1d`"
         );
-        process::exit(1);
+        return Err(());
     };
 
     let secs = duration.as_secs();
@@ -100,8 +128,17 @@ pub fn run_dismiss(duration_str: &str) -> ! {
             "cadence-hooks: snooze duration capped at 24h (got {duration_str})\n   \
              Re-run with a smaller window, or run again later to renew."
         );
-        process::exit(1);
+        return Err(());
     }
+
+    // Reason gate: required over 1h, nudged at or under.
+    let nudge = match snooze_meta::reason_gate(secs, reason, MECHANISM, duration_str) {
+        Ok(n) => n,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return Err(());
+        }
+    };
 
     let cwd = Path::new(".");
     let Some(common) = git_common_dir(cwd) else {
@@ -109,7 +146,7 @@ pub fn run_dismiss(duration_str: &str) -> ! {
             "cadence-hooks: not inside a git repository\n   \
              dismiss-enforce-worktree must be run from within the repo you want to unblock."
         );
-        process::exit(1);
+        return Err(());
     };
 
     let path = marker_path(&common);
@@ -117,13 +154,31 @@ pub fn run_dismiss(duration_str: &str) -> ! {
         && let Err(e) = fs::create_dir_all(parent)
     {
         eprintln!("cadence-hooks: could not create {}: {e}", parent.display());
-        process::exit(1);
+        return Err(());
     }
 
-    let until = now_epoch().saturating_add(secs);
+    let armed_at = now_epoch();
+    let until = armed_at.saturating_add(secs);
     if let Err(e) = fs::write(&path, format!("{until}\n")) {
         eprintln!("cadence-hooks: could not write {}: {e}", path.display());
-        process::exit(1);
+        return Err(());
+    }
+
+    // Provenance sidecar — best-effort, must never fail the snooze.
+    let reason = snooze_meta::normalize_reason(reason);
+    let session_id = session_id_from_env();
+    let meta = SnoozeMeta {
+        reason: reason.clone(),
+        session_id: session_id.clone(),
+        armed_at: Some(armed_at as i64),
+        expires_at: Some(until as i64),
+    };
+    let sidecar = snooze_meta::sidecar_for(&path);
+    if let Err(e) = fs::write(&sidecar, meta.to_json()) {
+        eprintln!(
+            "cadence-hooks: note — snooze set, but provenance sidecar {} could not be written: {e}",
+            sidecar.display()
+        );
     }
 
     // Prefer the friendly repo toplevel for the confirmation; fall back to the
@@ -131,10 +186,24 @@ pub fn run_dismiss(duration_str: &str) -> ! {
     let where_display =
         cadence_hooks_core::shell::git_command(".", &["rev-parse", "--show-toplevel"])
             .unwrap_or_else(|| common.display().to_string());
-    println!(
+    let mut confirmation = format!(
         "enforce-worktree unblocked for {duration_str} in {where_display} (until epoch {until})"
     );
-    process::exit(0);
+    if let Some(n) = nudge {
+        confirmation.push_str("\n   ");
+        confirmation.push_str(&n);
+    }
+
+    Ok(DismissArmed {
+        guard_hook: "enforce-worktree",
+        mechanism: MECHANISM,
+        reason,
+        session_id,
+        repo_root: Some(where_display),
+        armed_at: armed_at as i64,
+        expires_at: until as i64,
+        confirmation,
+    })
 }
 
 #[cfg(test)]
@@ -268,5 +337,30 @@ mod tests {
 
         // ...and read it back from the primary checkout.
         assert!(is_snoozed_now(&primary));
+    }
+
+    // --- perform_dismiss validation (early-return paths only) ---
+    //
+    // Only the paths that reject BEFORE resolving the git common dir are safe to
+    // unit-test: the success path writes a marker into the process cwd's repo,
+    // which under `cargo test` is the real cadence-hooks checkout. The success
+    // wiring (marker + sidecar + DismissArmed + armed event) is covered
+    // end-to-end against a scratch repo instead.
+
+    #[test]
+    fn perform_dismiss_rejects_invalid_duration() {
+        assert!(perform_dismiss("bogus", None).is_err());
+    }
+
+    #[test]
+    fn perform_dismiss_rejects_over_cap() {
+        // 2d exceeds the 24h cap → Err before touching git.
+        assert!(perform_dismiss("2d", Some("why")).is_err());
+    }
+
+    #[test]
+    fn perform_dismiss_rejects_long_snooze_without_reason() {
+        // The reason gate rejects >1h without a reason, before touching git.
+        assert!(perform_dismiss("4h", None).is_err());
     }
 }

--- a/crates/guardrails/src/dismiss_main_branch_warn.rs
+++ b/crates/guardrails/src/dismiss_main_branch_warn.rs
@@ -18,10 +18,11 @@
 //! against (its marker must differ from this one). Stale legacy files are
 //! orphaned harmlessly.
 
+use crate::snooze_meta::{self, DismissArmed, SnoozeMeta};
 use cadence_hooks_core::HookInput;
 use std::fs;
 use std::path::{Path, PathBuf};
-use std::process::{self, Command};
+use std::process::Command;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 const SNOOZE_DIR: &str = ".git/cadence-hooks";
@@ -77,6 +78,16 @@ fn session_snooze_marker(input: &HookInput, repo_root: &Path) -> PathBuf {
     )
 }
 
+/// Read the provenance sidecar for this session's active snooze of `repo_root`.
+/// `None` when the sidecar is missing/unreadable (a snooze armed before this
+/// feature, or a fail-open sidecar write) — the guard then attributes the bypass
+/// with a `None` reason and still allows. Resolved through the same session
+/// marker as the read path, so the key always agrees.
+pub fn read_meta(input: &HookInput, repo_root: &Path) -> Option<SnoozeMeta> {
+    let sidecar = snooze_meta::sidecar_for(&session_snooze_marker(input, repo_root));
+    SnoozeMeta::read(&sidecar)
+}
+
 /// Pure: given the marker contents and current epoch, is the snooze active?
 /// Shared with `dismiss_enforce_worktree`, which uses the same marker format and
 /// stays repo-scoped by design (it exempts the shared primary checkout).
@@ -110,7 +121,10 @@ fn file_mtime_epoch(path: &Path) -> Option<u64> {
 
 /// The Claude Code session id for the dismiss CLI, from `CLAUDE_CODE_SESSION_ID`
 /// (exported into the Bash tool environment). Empty/unset → `None`.
-fn session_id_from_env() -> Option<String> {
+///
+/// `pub(crate)` so the sibling `dismiss-enforce-worktree` snooze records the same
+/// arming session in its provenance sidecar.
+pub(crate) fn session_id_from_env() -> Option<String> {
     std::env::var("CLAUDE_CODE_SESSION_ID")
         .ok()
         .filter(|s| !s.is_empty())
@@ -156,14 +170,26 @@ pub fn is_snoozed_now(input: &HookInput, repo_root: &Path) -> bool {
     is_snoozed_clamped(&contents, mtime, now_epoch())
 }
 
-/// Entry point for the `dismiss-main-branch-warn` subcommand.
+/// The dismiss mechanism name recorded in bypass provenance.
+const MECHANISM: &str = "dismiss-main-branch-warn";
+
+/// Perform the `dismiss-main-branch-warn` action: validate, gate on `--reason`,
+/// write the session-scoped snooze marker **and** its provenance sidecar (both
+/// in the private marker dir, symlink-safe). Returns [`DismissArmed`] for the
+/// binary to log + confirm.
 ///
-/// Writes the session-scoped snooze marker (private marker dir, keyed on the
-/// session id resolved from `CLAUDE_CODE_SESSION_ID`) with the epoch seconds when
-/// the snooze expires, then prints a confirmation. Exits 1 on failure (no session
-/// id, missing repo, invalid duration, write error). Stays at exit 0 on success —
-/// this is a user-facing CLI, not a hook.
-pub fn run_dismiss(duration_str: &str) -> ! {
+/// Prints every error to stderr and returns `Err(())` (the binary exits 1) — no
+/// session id, missing repo, invalid duration, over-cap, or a missing `--reason`
+/// for a snooze longer than 1h. On success prints nothing and returns `Ok`.
+///
+/// The load-bearing marker stays exactly `{until}\n`; provenance rides in the
+/// sibling sidecar. The sidecar write is best-effort — a failure warns but does
+/// not fail the snooze (ADR-0001).
+///
+/// The `Err` is unit on purpose: this function prints every error to stderr
+/// itself, so the caller only needs pass/fail to pick an exit code.
+#[allow(clippy::result_unit_err)]
+pub fn perform_dismiss(duration_str: &str, reason: Option<&str>) -> Result<DismissArmed, ()> {
     let duration = match parse_duration(duration_str) {
         Some(d) => d,
         None => {
@@ -171,7 +197,7 @@ pub fn run_dismiss(duration_str: &str) -> ! {
                 "cadence-hooks: invalid duration '{duration_str}'\n   \
                  Expected: <number><s|m|h|d>, e.g. `30m`, `2h`, `1d`"
             );
-            process::exit(1);
+            return Err(());
         }
     };
 
@@ -181,8 +207,17 @@ pub fn run_dismiss(duration_str: &str) -> ! {
             "cadence-hooks: snooze duration capped at 24h (got {duration_str})\n   \
              Re-run with a smaller window, or run again later to renew."
         );
-        process::exit(1);
+        return Err(());
     }
+
+    // Reason gate: required over 1h, nudged at or under.
+    let nudge = match snooze_meta::reason_gate(secs, reason, MECHANISM, duration_str) {
+        Ok(n) => n,
+        Err(msg) => {
+            eprintln!("{msg}");
+            return Err(());
+        }
+    };
 
     // The snooze is session-scoped, so it needs the session id at write time.
     let Some(session_id) = session_id_from_env() else {
@@ -191,7 +226,7 @@ pub fn run_dismiss(duration_str: &str) -> ! {
              Run dismiss-main-branch-warn inside a Claude Code session \
              (or export CLAUDE_CODE_SESSION_ID)."
         );
-        process::exit(1);
+        return Err(());
     };
 
     let Some(root) = repo_root() else {
@@ -199,26 +234,56 @@ pub fn run_dismiss(duration_str: &str) -> ! {
             "cadence-hooks: not inside a git repository\n   \
              dismiss-main-branch-warn must be run from within the repo you want to silence."
         );
-        process::exit(1);
+        return Err(());
     };
 
     let input = HookInput {
-        session_id: Some(session_id),
+        session_id: Some(session_id.clone()),
         ..Default::default()
     };
     let path = session_snooze_marker(&input, &root);
 
-    let until = now_epoch().saturating_add(secs);
+    let armed_at = now_epoch();
+    let until = armed_at.saturating_add(secs);
     if let Err(e) = cadence_hooks_core::markers::write_marker(&path, &format!("{until}\n")) {
         eprintln!("cadence-hooks: could not write {}: {e}", path.display());
-        process::exit(1);
+        return Err(());
     }
 
-    println!(
+    // Provenance sidecar — best-effort, symlink-safe like the marker.
+    let reason = snooze_meta::normalize_reason(reason);
+    let meta = SnoozeMeta {
+        reason: reason.clone(),
+        session_id: Some(session_id.clone()),
+        armed_at: Some(armed_at as i64),
+        expires_at: Some(until as i64),
+    };
+    let sidecar = snooze_meta::sidecar_for(&path);
+    if let Err(e) = cadence_hooks_core::markers::write_marker(&sidecar, &meta.to_json()) {
+        eprintln!(
+            "cadence-hooks: note — snooze set, but provenance sidecar could not be written: {e}"
+        );
+    }
+
+    let mut confirmation = format!(
         "warn-main-branch silenced for this session for {duration_str} in {} (until epoch {until})",
         root.display()
     );
-    process::exit(0);
+    if let Some(n) = nudge {
+        confirmation.push_str("\n   ");
+        confirmation.push_str(&n);
+    }
+
+    Ok(DismissArmed {
+        guard_hook: "warn-main-branch",
+        mechanism: MECHANISM,
+        reason,
+        session_id: Some(session_id),
+        repo_root: Some(root.to_string_lossy().into_owned()),
+        armed_at: armed_at as i64,
+        expires_at: until as i64,
+        confirmation,
+    })
 }
 
 #[cfg(test)]

--- a/crates/guardrails/src/enforce_worktree.rs
+++ b/crates/guardrails/src/enforce_worktree.rs
@@ -43,7 +43,7 @@ use crate::dismiss_enforce_worktree;
 use crate::warn_main_branch::{git_dir_for_input, is_claude_managed_dir, is_plan_doc_dir};
 use crate::warn_subagent_worktree::is_primary_checkout;
 use cadence_hooks_core::shell::split_segments;
-use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
+use cadence_hooks_core::{BypassKind, BypassProvenance, Check, CheckResult, HookInput, Outcome};
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -168,7 +168,8 @@ fn block_message(repo_root: &str) -> String {
          not the shared primary tree.\n\
          Create one: `git worktree add .claude/worktrees/<slug> -b feat/<slug>` \
          (or EnterWorktree / `/worktree create feat <slug>`), then work there.\n\
-         One-off exception: `cadence-hooks guardrails dismiss-enforce-worktree --for 30m`\n\
+         One-off exception: `cadence-hooks guardrails dismiss-enforce-worktree --for 30m` \
+         (add `--reason \"<why>\"` — required over 1h; it's recorded in the repo-visible bypass log)\n\
          Repo works on main by design (dotfiles, vaults)? Set CADENCE_ALLOW_MAIN=true in \
          .claude/settings.json's env block.\n\
          Disable everywhere: CADENCE_NO_ENFORCE_WORKTREE=1"
@@ -195,17 +196,65 @@ fn assess_dir(dir: &Path, cfg: &EnvConfig) -> CheckResult {
         // Not a git repo (or a bare container dir) — nothing to enforce.
         return CheckResult::allow();
     };
+    let is_primary = is_primary_checkout(&repo_root);
+    let temp_root = is_temp_root(Path::new(&repo_root), cfg.tmpdir.as_deref());
+    let snoozed = dismiss_enforce_worktree::is_snoozed_now(Path::new(&repo_root));
     let blocked = should_block(
-        is_primary_checkout(&repo_root),
+        is_primary,
         cfg.allow_main,
         cfg.kill_switch,
-        is_temp_root(Path::new(&repo_root), cfg.tmpdir.as_deref()),
-        dismiss_enforce_worktree::is_snoozed_now(Path::new(&repo_root)),
+        temp_root,
+        snoozed,
     );
     if blocked {
-        CheckResult::block(block_message(&repo_root))
-    } else {
-        CheckResult::allow()
+        return CheckResult::block(block_message(&repo_root));
+    }
+
+    // Allowed. Attribute *why* only when the guard WOULD have blocked absent a
+    // bypass — a primary checkout that isn't a temp root. A worktree, a temp
+    // repo, or a carve-out is a normal allow with no bypass. Priority: an active
+    // dismissal, then the env switches (snooze is the more deliberate act).
+    //
+    // This DELIBERATELY differs from `warn-main-branch`, which tags only the
+    // snooze and leaves `CADENCE_ALLOW_MAIN` a bare allow. The asymmetry is by
+    // guard *severity*: enforce is a hard **block** on a shared primary checkout,
+    // and the guard can't tell a by-design main-mode repo (dotfiles/vault) from
+    // a session that set `CADENCE_ALLOW_MAIN`/`CADENCE_NO_ENFORCE_WORKTREE`
+    // specifically to disable enforcement — the bypass log is exactly where you'd
+    // look to answer "who lowered the hard block here", so a standing env switch
+    // is worth a line even if repetitive. warn's nudge is advisory, so the same
+    // static config there is noise, not signal. The deferred read-side surfacing
+    // aggregates the repetition.
+    if is_primary && !temp_root {
+        if snoozed {
+            let meta = dismiss_enforce_worktree::read_meta(Path::new(&repo_root));
+            return CheckResult::allow_bypassed(BypassProvenance {
+                kind: BypassKind::Dismissal,
+                mechanism: "dismiss-enforce-worktree".to_string(),
+                reason: meta.as_ref().and_then(|m| m.reason.clone()),
+                expires_at: meta.as_ref().and_then(|m| m.expires_at),
+                armed_by_session: meta.and_then(|m| m.session_id),
+            });
+        }
+        if cfg.allow_main {
+            return CheckResult::allow_bypassed(env_switch("CADENCE_ALLOW_MAIN"));
+        }
+        if cfg.kill_switch {
+            return CheckResult::allow_bypassed(env_switch("CADENCE_NO_ENFORCE_WORKTREE"));
+        }
+    }
+    CheckResult::allow()
+}
+
+/// Build an env-switch bypass provenance (no reason/expiry/session — an env var
+/// carries none of those).
+fn env_switch(var: &str) -> BypassProvenance {
+    BypassProvenance {
+        kind: BypassKind::EnvSwitch,
+        mechanism: var.to_string(),
+        reason: None,
+        expires_at: None,
+        armed_by_session: None,
     }
 }
 
@@ -578,10 +627,49 @@ mod tests {
     }
 
     #[test]
-    fn snooze_marker_exempts_primary() {
+    fn snooze_marker_exempts_primary_and_attributes_dismissal() {
         let scratch = Scratch::new("snooze");
         let (primary, _wt) = primary_and_worktree(&scratch);
 
+        let marker = dismiss_enforce_worktree::marker_path_for(&primary).unwrap();
+        std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
+        let until = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        std::fs::write(&marker, format!("{until}\n")).unwrap();
+        // Provenance sidecar written by the dismiss command.
+        let sidecar = dismiss_enforce_worktree::meta_path_for(&primary).unwrap();
+        std::fs::write(
+            &sidecar,
+            crate::snooze_meta::SnoozeMeta {
+                reason: Some("dogfooding vault symlink".into()),
+                session_id: Some("sess-1".into()),
+                armed_at: Some(1),
+                expires_at: Some(until as i64),
+            }
+            .to_json(),
+        )
+        .unwrap();
+
+        let file = primary.join("src.rs");
+        let input = make_edit(&file.to_string_lossy(), "a", "b");
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow, "active snooze exempts");
+        let prov = r.bypass.expect("snooze allow carries provenance");
+        assert_eq!(prov.kind, BypassKind::Dismissal);
+        assert_eq!(prov.mechanism, "dismiss-enforce-worktree");
+        assert_eq!(prov.reason.as_deref(), Some("dogfooding vault symlink"));
+        assert_eq!(prov.armed_by_session.as_deref(), Some("sess-1"));
+    }
+
+    #[test]
+    fn snooze_without_sidecar_allows_with_none_reason() {
+        // An older marker armed before the sidecar existed: the guard still
+        // allows and attributes a Dismissal, just with no reason/session.
+        let scratch = Scratch::new("snooze-legacy");
+        let (primary, _wt) = primary_and_worktree(&scratch);
         let marker = dismiss_enforce_worktree::marker_path_for(&primary).unwrap();
         std::fs::create_dir_all(marker.parent().unwrap()).unwrap();
         let until = std::time::SystemTime::now()
@@ -594,7 +682,45 @@ mod tests {
         let file = primary.join("src.rs");
         let input = make_edit(&file.to_string_lossy(), "a", "b");
         let r = run_enforce(&input, &cfg(false, false));
-        assert_eq!(r.outcome, Outcome::Allow, "active snooze exempts");
+        assert_eq!(r.outcome, Outcome::Allow);
+        let prov = r.bypass.expect("snooze still attributes a dismissal");
+        assert_eq!(prov.kind, BypassKind::Dismissal);
+        assert_eq!(prov.reason, None, "missing sidecar → no reason");
+        assert_eq!(prov.armed_by_session, None);
+    }
+
+    #[test]
+    fn env_switch_allow_attributes_env_switch() {
+        // CADENCE_ALLOW_MAIN / CADENCE_NO_ENFORCE_WORKTREE suppress the block on a
+        // primary checkout — the allow must carry an EnvSwitch bypass naming which.
+        let scratch = Scratch::new("env-bypass");
+        let (primary, _wt) = primary_and_worktree(&scratch);
+        let file = primary.join("src.rs");
+        let input = make_edit(&file.to_string_lossy(), "a", "b");
+
+        let r = run_enforce(&input, &cfg(true, false));
+        let prov = r.bypass.expect("allow_main carries provenance");
+        assert_eq!(prov.kind, BypassKind::EnvSwitch);
+        assert_eq!(prov.mechanism, "CADENCE_ALLOW_MAIN");
+        assert_eq!(prov.reason, None);
+
+        let r = run_enforce(&input, &cfg(false, true));
+        let prov = r.bypass.expect("kill switch carries provenance");
+        assert_eq!(prov.kind, BypassKind::EnvSwitch);
+        assert_eq!(prov.mechanism, "CADENCE_NO_ENFORCE_WORKTREE");
+    }
+
+    #[test]
+    fn worktree_allow_carries_no_bypass() {
+        // A normal worktree edit is fine on its own — no guard was stepped
+        // outside of, so the allow stays bare (no bypasses.jsonl line).
+        let scratch = Scratch::new("wt-nobypass");
+        let (_primary, wt) = primary_and_worktree(&scratch);
+        let file = wt.join("src.rs");
+        let input = make_edit(&file.to_string_lossy(), "a", "b");
+        let r = run_enforce(&input, &cfg(false, false));
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(r.bypass.is_none(), "normal worktree allow is not a bypass");
     }
 
     #[test]

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -31,6 +31,8 @@ pub mod inject_gh_context;
 pub mod issue_refs;
 /// Nudge to schedule a brew upgrade after pushing cadence-hooks to main.
 pub mod nudge_upgrade_after_push;
+/// Shared provenance sidecar for the `dismiss-*` snooze markers.
+pub mod snooze_meta;
 /// Warn about broken issue refs on PR create; close straggler issues on PR merge.
 pub mod verify_pr_autoclose;
 /// Warn when piping aliased-tool output (ls/find/cat/du/df/top) into parsers.

--- a/crates/guardrails/src/snooze_meta.rs
+++ b/crates/guardrails/src/snooze_meta.rs
@@ -1,0 +1,275 @@
+//! Shared sidecar for the `dismiss-*` snooze markers: the *provenance* a bare
+//! epoch marker can't hold — who armed it, why, and when.
+//!
+//! The load-bearing marker files stay exactly `{epoch}\n` (so the guards'
+//! first-line parse is unchanged). Each dismiss command writes a **sibling**
+//! JSON file alongside its marker holding `{reason, session_id, armed_at,
+//! expires_at}`; the guard reads it back when a snooze is active to attribute
+//! *why* it allowed. A missing sidecar (an older marker, or a fail-open write)
+//! degrades to reason/session `None` — never an error, never a block (ADR-0001).
+//!
+//! Built on `serde_json::Value` rather than derived serde so the guardrails
+//! crate needs no `serde` derive dependency.
+
+use std::path::Path;
+
+/// A dismissal longer than this **requires** a `--reason`: a repo-wide (or
+/// long-lived) bypass that outlives an hour should say why it exists, so the
+/// provenance record isn't a bare "someone lowered the guard". Shorter snoozes
+/// only get a nudge.
+pub const REASON_REQUIRED_ABOVE_SECS: u64 = 3600;
+
+/// Normalize a `--reason`: trim, and treat empty as absent.
+pub fn normalize_reason(reason: Option<&str>) -> Option<String> {
+    reason
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(str::to_string)
+}
+
+/// The reason gate for a `dismiss-*` command, pure so it's unit-testable.
+///
+/// - Reason supplied → `Ok(None)` (proceed, nothing to add).
+/// - No reason, snooze **over** [`REASON_REQUIRED_ABOVE_SECS`] → `Err(msg)`: the
+///   caller prints `msg` to stderr and exits non-zero, teaching the `--reason` form.
+/// - No reason, snooze **at or under** the threshold → `Ok(Some(nudge))`: proceed,
+///   but the caller appends `nudge` so the habit is taught at the point of friction.
+pub fn reason_gate(
+    secs: u64,
+    reason: Option<&str>,
+    dismiss_cmd: &str,
+    duration_str: &str,
+) -> Result<Option<String>, String> {
+    if normalize_reason(reason).is_some() {
+        return Ok(None);
+    }
+    if secs > REASON_REQUIRED_ABOVE_SECS {
+        return Err(format!(
+            "cadence-hooks: --reason is required for a dismissal longer than 1h (got {duration_str})\n   \
+             A guard lowered for more than an hour should record why — it's repo-visible provenance.\n   \
+             Re-run with a reason, e.g.:\n   \
+             cadence-hooks guardrails {dismiss_cmd} --for {duration_str} --reason \"<why>\""
+        ));
+    }
+    Ok(Some(format!(
+        "note: no --reason recorded for this dismissal. Add one so the bypass is attributable:\n   \
+         cadence-hooks guardrails {dismiss_cmd} --for {duration_str} --reason \"<why>\""
+    )))
+}
+
+/// A successful `dismiss-*` outcome, handed back to the binary so it can record
+/// the `bypass_armed` event (the binary owns the metrics writer — the seam that
+/// keeps the guardrails crate metrics-free) and print the confirmation.
+///
+/// Plain data only — no metrics types — so it never couples guardrails to the
+/// metrics crate. The binary unpacks these fields into a `BypassEvent::armed`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DismissArmed {
+    /// Canonical guard name the dismissal applies to (`enforce-worktree`, …).
+    pub guard_hook: &'static str,
+    /// The dismiss mechanism (`dismiss-enforce-worktree`, …).
+    pub mechanism: &'static str,
+    /// User-authored `--reason`, when supplied.
+    pub reason: Option<String>,
+    /// Session that armed the dismissal, when known.
+    pub session_id: Option<String>,
+    /// Repo root the dismissal was written for (for the record's repo basename).
+    pub repo_root: Option<String>,
+    /// Unix epoch seconds the dismissal was armed.
+    pub armed_at: i64,
+    /// Unix epoch seconds the dismissal expires.
+    pub expires_at: i64,
+    /// The confirmation line for the binary to print to stdout.
+    pub confirmation: String,
+}
+
+/// The provenance recorded beside a snooze marker.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct SnoozeMeta {
+    /// User-authored `--reason`, when supplied.
+    pub reason: Option<String>,
+    /// Session that armed the snooze (`CLAUDE_CODE_SESSION_ID`), when known.
+    pub session_id: Option<String>,
+    /// Unix epoch seconds when the snooze was armed.
+    pub armed_at: Option<i64>,
+    /// Unix epoch seconds when the snooze expires.
+    pub expires_at: Option<i64>,
+}
+
+impl SnoozeMeta {
+    /// Serialize to the sidecar's JSON body. `null` for any absent field, so the
+    /// shape is stable whether or not a reason was authored.
+    pub fn to_json(&self) -> String {
+        serde_json::json!({
+            "reason": self.reason,
+            "session_id": self.session_id,
+            "armed_at": self.armed_at,
+            "expires_at": self.expires_at,
+        })
+        .to_string()
+    }
+
+    /// Parse a sidecar body. Tolerant: unknown/absent keys map to `None`; a
+    /// malformed body yields `None` (the caller treats a missing/garbage sidecar
+    /// as "no provenance" and still allows).
+    pub fn from_json(contents: &str) -> Option<Self> {
+        let v: serde_json::Value = serde_json::from_str(contents).ok()?;
+        Some(Self {
+            reason: v.get("reason").and_then(|x| x.as_str()).map(String::from),
+            session_id: v
+                .get("session_id")
+                .and_then(|x| x.as_str())
+                .map(String::from),
+            armed_at: v.get("armed_at").and_then(serde_json::Value::as_i64),
+            expires_at: v.get("expires_at").and_then(serde_json::Value::as_i64),
+        })
+    }
+
+    /// Read and parse the sidecar at `path`. `None` when the file is absent or
+    /// unreadable (older marker, or fail-open write) — never an error.
+    pub fn read(path: &Path) -> Option<Self> {
+        let contents = std::fs::read_to_string(path).ok()?;
+        Self::from_json(&contents)
+    }
+}
+
+/// The provenance sidecar path for a snooze marker: a same-directory sibling
+/// whose file name is the marker's plus a `.meta.json` suffix (e.g.
+/// `enforce-worktree-snoozed-until` → `enforce-worktree-snoozed-until.meta.json`).
+/// Appending — rather than rewriting the marker's suffix — keeps both files in
+/// the same directory (the git common dir or the private marker dir) and can
+/// never collide with the marker's own name.
+pub fn sidecar_for(marker: &Path) -> std::path::PathBuf {
+    let mut name = marker
+        .file_name()
+        .map(|n| n.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "marker".to_string());
+    name.push_str(".meta.json");
+    marker.with_file_name(name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trips_full_meta() {
+        let meta = SnoozeMeta {
+            reason: Some("dogfooding vault symlink".into()),
+            session_id: Some("sess-1".into()),
+            armed_at: Some(1_700_000_000),
+            expires_at: Some(1_700_003_600),
+        };
+        let parsed = SnoozeMeta::from_json(&meta.to_json()).expect("parses");
+        assert_eq!(parsed, meta);
+    }
+
+    #[test]
+    fn round_trips_reasonless_meta() {
+        // No reason (a short snooze): reason serializes to null and reads back None.
+        let meta = SnoozeMeta {
+            reason: None,
+            session_id: Some("sess-2".into()),
+            armed_at: Some(100),
+            expires_at: Some(200),
+        };
+        let json = meta.to_json();
+        assert!(
+            json.contains("\"reason\":null"),
+            "reason is explicit null: {json}"
+        );
+        assert_eq!(SnoozeMeta::from_json(&json), Some(meta));
+    }
+
+    #[test]
+    fn malformed_body_is_none() {
+        assert_eq!(SnoozeMeta::from_json("not json"), None);
+        assert_eq!(SnoozeMeta::from_json(""), None);
+    }
+
+    #[test]
+    fn missing_keys_map_to_none() {
+        // An empty object (or a partial one) is valid — absent fields are None.
+        let parsed = SnoozeMeta::from_json("{}").expect("empty object parses");
+        assert_eq!(parsed, SnoozeMeta::default());
+    }
+
+    #[test]
+    fn read_missing_file_is_none() {
+        assert_eq!(SnoozeMeta::read(Path::new("/nonexistent/meta.json")), None);
+    }
+
+    // --- reason gate ---
+
+    #[test]
+    fn reason_supplied_proceeds_without_nudge() {
+        // Any length + a reason → Ok(None): proceed, nothing to teach.
+        assert_eq!(
+            reason_gate(
+                7200,
+                Some("plan doc on main"),
+                "dismiss-enforce-worktree",
+                "2h"
+            ),
+            Ok(None)
+        );
+        assert_eq!(
+            reason_gate(60, Some("quick fix"), "dismiss-enforce-worktree", "1m"),
+            Ok(None)
+        );
+    }
+
+    #[test]
+    fn long_without_reason_errors() {
+        // Over 1h without a reason → Err teaching the --reason form.
+        let err = reason_gate(3601, None, "dismiss-enforce-worktree", "3601s").unwrap_err();
+        assert!(err.contains("--reason is required"), "{err}");
+        assert!(
+            err.contains("dismiss-enforce-worktree --for 3601s --reason"),
+            "{err}"
+        );
+    }
+
+    #[test]
+    fn empty_reason_counts_as_absent() {
+        // A whitespace-only reason doesn't satisfy the long-snooze requirement.
+        assert!(reason_gate(7200, Some("   "), "dismiss-enforce-worktree", "2h").is_err());
+    }
+
+    #[test]
+    fn short_without_reason_nudges_but_proceeds() {
+        // At or under 1h without a reason → Ok(Some(nudge)): proceed + teach.
+        let nudge = reason_gate(3600, None, "dismiss-main-branch-warn", "1h")
+            .expect("boundary is allowed")
+            .expect("carries a nudge");
+        assert!(nudge.contains("no --reason recorded"), "{nudge}");
+        assert!(
+            nudge.contains("dismiss-main-branch-warn --for 1h --reason"),
+            "{nudge}"
+        );
+    }
+
+    #[test]
+    fn threshold_boundary_is_inclusive_for_nudge() {
+        // Exactly 3600s is "at the threshold" → nudge, not error. 3601s errors.
+        assert!(reason_gate(3600, None, "x", "1h").unwrap().is_some());
+        assert!(reason_gate(3601, None, "x", "3601s").is_err());
+    }
+
+    #[test]
+    fn normalize_reason_trims_and_empties() {
+        assert_eq!(normalize_reason(Some("  why  ")), Some("why".to_string()));
+        assert_eq!(normalize_reason(Some("   ")), None);
+        assert_eq!(normalize_reason(Some("")), None);
+        assert_eq!(normalize_reason(None), None);
+    }
+
+    #[test]
+    fn sidecar_is_marker_sibling() {
+        let marker = Path::new("/repo/.git/cadence-hooks/enforce-worktree-snoozed-until");
+        assert_eq!(
+            sidecar_for(marker),
+            Path::new("/repo/.git/cadence-hooks/enforce-worktree-snoozed-until.meta.json")
+        );
+    }
+}

--- a/crates/guardrails/src/warn_main_branch.rs
+++ b/crates/guardrails/src/warn_main_branch.rs
@@ -18,7 +18,7 @@
 //! branch. That work is never the branch-worthy product change the warning targets.
 
 use crate::dismiss_main_branch_warn;
-use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
+use cadence_hooks_core::{BypassKind, BypassProvenance, Check, CheckResult, HookInput, Outcome};
 use std::path::{Component, Path, PathBuf};
 use std::process::Command;
 
@@ -234,6 +234,23 @@ impl Check for WarnMainBranch {
 
         if result.outcome == Outcome::Nudge {
             let _ = cadence_hooks_core::markers::write_marker(&marker, "");
+            return result;
+        }
+
+        // The nudge was suppressed. Attribute it to an active dismissal when that
+        // is *why* it went quiet — a default branch, not already warned this
+        // session, and snoozed. A permanent `CADENCE_ALLOW_MAIN` allow is the
+        // by-design config for main-mode repos (dotfiles, vaults), not a bypass
+        // worth a line per edit, so it stays a bare allow.
+        if snoozed && is_default_branch(&branch) && !already_warned {
+            let meta = dismiss_main_branch_warn::read_meta(input, Path::new(&repo_root));
+            return CheckResult::allow_bypassed(BypassProvenance {
+                kind: BypassKind::Dismissal,
+                mechanism: "dismiss-main-branch-warn".to_string(),
+                reason: meta.as_ref().and_then(|m| m.reason.clone()),
+                expires_at: meta.as_ref().and_then(|m| m.expires_at),
+                armed_by_session: meta.and_then(|m| m.session_id),
+            });
         }
 
         result
@@ -719,5 +736,159 @@ mod tests {
         // A leading `..` with no preceding component to pop leaves `docs/plans`
         // intact, so a relative plan-doc path stays exempt.
         assert!(is_plan_doc_dir(Path::new("../docs/plans")));
+    }
+
+    // --- bypass attribution via run() (real repo on main) ---
+    //
+    // The `should_warn` tests above cover the pure decision; these exercise the
+    // full `run()` path where a suppressed nudge is (or isn't) attributed to an
+    // active dismissal. A real git repo on `main` is needed because run() shells
+    // out for branch + toplevel.
+
+    /// Init a git repo checked out on `main` in a fresh tempdir; return the
+    /// tempdir plus the git-resolved (canonical) repo root.
+    fn init_repo_on_main() -> (tempfile::TempDir, String) {
+        let tmp = tempfile::tempdir().unwrap();
+        let git = |args: &[&str]| {
+            let ok = Command::new("git")
+                .arg("-C")
+                .arg(tmp.path())
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "t@t"]);
+        git(&["config", "user.name", "t"]);
+        std::fs::write(tmp.path().join("f.txt"), "x").unwrap();
+        git(&["add", "f.txt"]);
+        git(&["commit", "-q", "-m", "init"]);
+        let root = cadence_hooks_core::shell::git_command(
+            &tmp.path().to_string_lossy(),
+            &["rev-parse", "--show-toplevel"],
+        )
+        .expect("temp repo resolves a toplevel");
+        (tmp, root)
+    }
+
+    fn edit_input_in(repo: &Path, session: &str) -> HookInput {
+        HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some(repo.join("src.rs").to_string_lossy().into_owned()),
+                new_string: Some("x".into()),
+                old_string: Some("y".into()),
+                ..Default::default()
+            }),
+            cwd: Some(repo.to_string_lossy().into_owned()),
+            session_id: Some(session.into()),
+            ..Default::default()
+        }
+    }
+
+    /// Write the session-scoped snooze marker + provenance sidecar the guard
+    /// reads, keyed on the same `(input, repo_root)` as the reader.
+    fn arm_snooze(input: &HookInput, repo_root: &str, reason: Option<&str>) {
+        let marker = cadence_hooks_core::markers::session_marker(
+            input,
+            "main-branch-snooze",
+            Some(repo_root),
+        );
+        let until = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        cadence_hooks_core::markers::write_marker(&marker, &format!("{until}\n")).unwrap();
+        let sidecar = crate::snooze_meta::sidecar_for(&marker);
+        let meta = crate::snooze_meta::SnoozeMeta {
+            reason: reason.map(str::to_string),
+            session_id: input.session_id().map(str::to_string),
+            armed_at: Some(1),
+            expires_at: Some(until as i64),
+        };
+        cadence_hooks_core::markers::write_marker(&sidecar, &meta.to_json()).unwrap();
+    }
+
+    #[test]
+    fn snooze_suppressed_nudge_attributes_dismissal() {
+        let (tmp, root) = init_repo_on_main();
+        let input = edit_input_in(tmp.path(), "warn-bypass-a");
+        arm_snooze(&input, &root, Some("wrap-up edits on dotfiles"));
+
+        let r = WarnMainBranch.run(&input);
+        assert_eq!(
+            r.outcome,
+            Outcome::Allow,
+            "active snooze suppresses the nudge"
+        );
+        let prov = r.bypass.expect("suppressed nudge carries provenance");
+        assert_eq!(prov.kind, BypassKind::Dismissal);
+        assert_eq!(prov.mechanism, "dismiss-main-branch-warn");
+        assert_eq!(prov.reason.as_deref(), Some("wrap-up edits on dotfiles"));
+        assert_eq!(prov.armed_by_session.as_deref(), Some("warn-bypass-a"));
+    }
+
+    #[test]
+    fn snooze_without_sidecar_attributes_dismissal_with_none_reason() {
+        // A snooze armed before the sidecar existed still attributes a Dismissal,
+        // just with no reason/session (the guard tolerates a missing sidecar).
+        let (tmp, root) = init_repo_on_main();
+        let input = edit_input_in(tmp.path(), "warn-bypass-legacy");
+        let marker =
+            cadence_hooks_core::markers::session_marker(&input, "main-branch-snooze", Some(&root));
+        let until = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs()
+            + 3600;
+        cadence_hooks_core::markers::write_marker(&marker, &format!("{until}\n")).unwrap();
+
+        let r = WarnMainBranch.run(&input);
+        assert_eq!(r.outcome, Outcome::Allow);
+        let prov = r.bypass.expect("still attributes a dismissal");
+        assert_eq!(prov.kind, BypassKind::Dismissal);
+        assert_eq!(prov.reason, None, "missing sidecar → no reason");
+        assert_eq!(prov.armed_by_session, None);
+    }
+
+    #[test]
+    fn already_warned_allow_carries_no_bypass() {
+        // Once the session has been warned, a later edit is a plain dedup allow —
+        // NOT a bypass — even if a snooze is also present. The `!already_warned`
+        // guard on attribution must hold.
+        let (tmp, root) = init_repo_on_main();
+        let input = edit_input_in(tmp.path(), "warn-bypass-warned");
+        arm_snooze(&input, &root, Some("some reason"));
+        // Pre-plant the once-per-session "warned" marker.
+        let warned =
+            cadence_hooks_core::markers::session_marker(&input, "main-branch-warned", Some(&root));
+        cadence_hooks_core::markers::write_marker(&warned, "").unwrap();
+
+        let r = WarnMainBranch.run(&input);
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(
+            r.bypass.is_none(),
+            "an already-warned dedup allow is not a bypass"
+        );
+    }
+
+    #[test]
+    fn feature_branch_edit_carries_no_bypass() {
+        // Off a default branch there's nothing to bypass — bare allow.
+        let (tmp, _root) = init_repo_on_main();
+        Command::new("git")
+            .arg("-C")
+            .arg(tmp.path())
+            .args(["checkout", "-q", "-b", "feat/x"])
+            .output()
+            .unwrap();
+        let input = edit_input_in(tmp.path(), "warn-bypass-feat");
+        let r = WarnMainBranch.run(&input);
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(r.bypass.is_none(), "feature-branch allow is not a bypass");
     }
 }

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -12,6 +12,8 @@ mod common;
 pub mod compute_cost;
 /// Append AskUserQuestion stance/shape records to `askuserquestion.jsonl`.
 pub mod log_askuserquestion;
+/// Append guard-bypass audit records (armed/used) to `bypasses.jsonl`.
+pub mod log_bypass;
 /// Append cost-per-commit records to `commits.jsonl`.
 pub mod log_commit;
 /// Append guard-denial audit records to `denials.jsonl`.
@@ -40,6 +42,7 @@ pub mod snapshot;
 pub mod warn_stale;
 
 pub use log_askuserquestion::LogAskUserQuestion;
+pub use log_bypass::{BypassEvent, log_bypass};
 pub use log_commit::LogCommit;
 pub use log_denial::log_denial;
 pub use log_plan_phase::LogPlanPhase;

--- a/crates/metrics/src/log_bypass.rs
+++ b/crates/metrics/src/log_bypass.rs
@@ -1,0 +1,332 @@
+//! Append-only audit log for guard *bypasses* — the events a bare denial log
+//! cannot see: a guardrail was stepped outside of, either **armed** (a
+//! `dismiss-*` snooze was set) or **used** (a write rode through an active
+//! dismissal / env switch, which surfaces at the dispatch seam as a bare
+//! `Allow`). One line per event to `<metrics_dir>/bypasses.jsonl`.
+//!
+//! Sibling of [`crate::log_denial`], and shares its two doctrines:
+//!
+//! - **Fail-open (ADR-0001):** every step degrades to a no-op — a full disk or a
+//!   read-only metrics dir must never perturb the allow it is recording, nor the
+//!   dismiss CLI's own exit.
+//! - **Privacy by construction:** the record names *which guard was bypassed, how,
+//!   in which repo, by which session* — plus a **user-authored** `reason`. It
+//!   never reads the command text, file path, or edited content off the input; a
+//!   unit test asserts those keys are absent.
+//!
+//! Called from the **binary** (`src/dispatch.rs` for `used`, the `dismiss-*`
+//! CLI arm in `src/main.rs` for `armed`), never from a guard: only the binary
+//! reaches the metrics writer, and only it knows the canonical registry name.
+
+use crate::common;
+use cadence_hooks_core::{BypassProvenance, HookInput};
+use serde_json::{Value, json};
+use std::io::Write;
+
+/// One bypass event, ready to serialize. Built via [`BypassEvent::used`] (at the
+/// dispatch seam) or [`BypassEvent::armed`] (at dismiss time). Fields the event
+/// kind doesn't carry are `None` (e.g. `tool`/`agent` on an `armed` event —
+/// arming a snooze is not a tool call).
+pub struct BypassEvent {
+    /// `"armed"` (a dismissal was set) or `"used"` (a bypass was ridden through).
+    event: &'static str,
+    /// Canonical guard name the bypass applies to (e.g. `enforce-worktree`).
+    hook: Option<String>,
+    /// Tool that rode through, for a `used` event (`None` for `armed`).
+    tool: Option<String>,
+    /// Repo basename (never the full path).
+    repo: Option<String>,
+    /// Session that triggered / armed the bypass.
+    session: Option<String>,
+    /// Subagent that rode through, when the payload carried one.
+    agent: Option<String>,
+    /// `"dismissal"` | `"env_switch"`.
+    kind: &'static str,
+    /// Concrete mechanism (`dismiss-enforce-worktree`, `CADENCE_ALLOW_MAIN`, …).
+    mechanism: String,
+    /// User-authored `--reason`, when present.
+    reason: Option<String>,
+    /// Unix epoch seconds the dismissal expires, when known.
+    expires_at: Option<i64>,
+    /// Unix epoch seconds the dismissal was armed, when known (`armed` events).
+    armed_at: Option<i64>,
+}
+
+impl BypassEvent {
+    /// A bypass that was **used**: an operation rode through an active dismissal
+    /// or env switch, surfacing at the dispatch seam as an allow carrying
+    /// [`BypassProvenance`]. Reads only non-sensitive context off the input
+    /// (tool, session, agent, cwd→repo basename) — never the command or path.
+    pub fn used(hook: &str, input: &HookInput, prov: &BypassProvenance) -> Self {
+        Self {
+            event: "used",
+            hook: Some(hook.to_string()),
+            tool: input.tool_name().map(str::to_string),
+            repo: Some(common::repo_basename(input.cwd.as_deref())),
+            session: input.session_id().map(str::to_string),
+            agent: input.agent_id().map(str::to_string),
+            kind: prov.kind.as_str(),
+            mechanism: prov.mechanism.clone(),
+            reason: prov.reason.clone(),
+            expires_at: prov.expires_at,
+            armed_at: None,
+        }
+    }
+
+    /// A dismissal that was **armed**: a `dismiss-*` snooze was set (records the
+    /// arming even if the snooze is never ridden through). Always a `dismissal`
+    /// kind. `repo_root` is resolved to a basename here so the caller never has
+    /// to reach into the privacy contract.
+    #[allow(clippy::too_many_arguments)]
+    pub fn armed(
+        hook: &str,
+        mechanism: &str,
+        reason: Option<&str>,
+        session: Option<&str>,
+        repo_root: Option<&str>,
+        armed_at: i64,
+        expires_at: i64,
+    ) -> Self {
+        Self {
+            event: "armed",
+            hook: Some(hook.to_string()),
+            tool: None,
+            repo: Some(common::repo_basename(repo_root)),
+            session: session.map(str::to_string),
+            agent: None,
+            kind: "dismissal",
+            mechanism: mechanism.to_string(),
+            reason: reason.map(str::to_string),
+            expires_at: Some(expires_at),
+            armed_at: Some(armed_at),
+        }
+    }
+
+    /// Build the `bypasses.jsonl` record. Pure — no I/O beyond the git query
+    /// behind [`common::repo_basename`] the constructors already ran. Emits only
+    /// non-sensitive context plus the user-authored reason.
+    fn to_record(&self) -> Value {
+        json!({
+            "ts": common::utc_timestamp(),
+            "event": self.event,
+            "hook": self.hook,
+            "tool": self.tool,
+            "repo": self.repo,
+            "sessionId": self.session,
+            "agentId": self.agent,
+            "kind": self.kind,
+            "mechanism": self.mechanism,
+            "reason": self.reason,
+            "expiresAt": self.expires_at,
+            "armedAt": self.armed_at,
+        })
+    }
+}
+
+/// Append one bypass event to `<metrics_dir>/bypasses.jsonl`.
+///
+/// Fully fail-open (ADR-0001): a missing dir it can't create, or a failed open /
+/// write, degrades to a no-op — the caller's allow and exit code are untouched.
+pub fn log_bypass(event: BypassEvent) {
+    let record = event.to_record();
+
+    let dir = common::metrics_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join("bypasses.jsonl");
+
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        // One `write_all` of the record + newline, so a concurrent append from
+        // another session can't interleave a record with its trailing newline.
+        let mut line = record.to_string();
+        line.push('\n');
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::ENV_LOCK;
+    use cadence_hooks_core::{BypassKind, ToolInput};
+
+    fn used_input() -> HookInput {
+        // A payload carrying sensitive fields — the record must expose none.
+        HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(ToolInput {
+                file_path: Some("/secret/path/notes.md".into()),
+                command: Some("rm -rf /secret".into()),
+                new_string: Some("allowlist the host".into()),
+                ..Default::default()
+            }),
+            cwd: Some("/tmp".into()),
+            session_id: Some("sess-1".into()),
+            agent_id: Some("agent-9".into()),
+            ..Default::default()
+        }
+    }
+
+    fn dismissal_prov() -> BypassProvenance {
+        BypassProvenance {
+            kind: BypassKind::Dismissal,
+            mechanism: "dismiss-enforce-worktree".into(),
+            reason: Some("dogfooding vault symlink".into()),
+            expires_at: Some(2_000_000_000),
+            armed_by_session: Some("sess-1".into()),
+        }
+    }
+
+    // --- record shape ---
+
+    #[test]
+    fn used_record_has_expected_fields() {
+        let ev = BypassEvent::used("enforce-worktree", &used_input(), &dismissal_prov());
+        let rec = ev.to_record();
+        assert_eq!(rec["event"], "used");
+        assert_eq!(rec["hook"], "enforce-worktree");
+        assert_eq!(rec["tool"], "Edit");
+        assert_eq!(rec["sessionId"], "sess-1");
+        assert_eq!(rec["agentId"], "agent-9");
+        assert_eq!(rec["kind"], "dismissal");
+        assert_eq!(rec["mechanism"], "dismiss-enforce-worktree");
+        assert_eq!(rec["reason"], "dogfooding vault symlink");
+        assert_eq!(rec["expiresAt"], 2_000_000_000_i64);
+        assert!(rec["armedAt"].is_null(), "used events carry no armedAt");
+        assert!(rec["ts"].is_string());
+        assert!(rec["repo"].is_string());
+    }
+
+    #[test]
+    fn armed_record_has_expected_fields() {
+        let ev = BypassEvent::armed(
+            "enforce-worktree",
+            "dismiss-enforce-worktree",
+            Some("plan doc on main"),
+            Some("sess-7"),
+            Some("/tmp"),
+            1_700_000_000,
+            1_700_003_600,
+        );
+        let rec = ev.to_record();
+        assert_eq!(rec["event"], "armed");
+        assert_eq!(rec["kind"], "dismissal");
+        assert_eq!(rec["reason"], "plan doc on main");
+        assert_eq!(rec["sessionId"], "sess-7");
+        assert_eq!(rec["armedAt"], 1_700_000_000_i64);
+        assert_eq!(rec["expiresAt"], 1_700_003_600_i64);
+        assert!(rec["tool"].is_null(), "arming is not a tool call");
+        assert!(rec["agentId"].is_null());
+    }
+
+    #[test]
+    fn env_switch_used_has_no_reason() {
+        let prov = BypassProvenance {
+            kind: BypassKind::EnvSwitch,
+            mechanism: "CADENCE_ALLOW_MAIN".into(),
+            reason: None,
+            expires_at: None,
+            armed_by_session: None,
+        };
+        let rec = BypassEvent::used("enforce-worktree", &used_input(), &prov).to_record();
+        assert_eq!(rec["kind"], "env_switch");
+        assert_eq!(rec["mechanism"], "CADENCE_ALLOW_MAIN");
+        assert!(rec["reason"].is_null());
+        assert!(rec["expiresAt"].is_null());
+    }
+
+    #[test]
+    fn record_omits_sensitive_keys() {
+        // Privacy by construction: never carry command content, file paths, or
+        // edited text — only which guard was bypassed, how, and the user reason.
+        let rec =
+            BypassEvent::used("enforce-worktree", &used_input(), &dismissal_prov()).to_record();
+        let obj = rec.as_object().expect("record is an object");
+        for forbidden in ["command", "file_path", "filePath", "content", "new_string"] {
+            assert!(
+                !obj.contains_key(forbidden),
+                "record must not carry '{forbidden}': {rec}"
+            );
+        }
+        let serialized = rec.to_string();
+        assert!(
+            !serialized.contains("/secret/path"),
+            "leaked file path: {serialized}"
+        );
+        assert!(
+            !serialized.contains("rm -rf"),
+            "leaked command: {serialized}"
+        );
+        assert!(
+            !serialized.contains("allowlist the host"),
+            "leaked content: {serialized}"
+        );
+    }
+
+    // --- log_bypass end-to-end (tempdir) ---
+
+    fn with_metrics_dir<F: FnOnce()>(dir: &std::path::Path, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test via ENV_LOCK.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", dir);
+        }
+        f();
+        // SAFETY: serialized against every other env-mutating test via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+        }
+    }
+
+    fn read_lines(dir: &std::path::Path) -> Vec<Value> {
+        let path = dir.join("bypasses.jsonl");
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str(l).expect("each line is valid JSON"))
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    #[test]
+    fn used_writes_one_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_bypass(BypassEvent::used(
+                "enforce-worktree",
+                &used_input(),
+                &dismissal_prov(),
+            ));
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["event"], "used");
+        assert_eq!(rows[0]["mechanism"], "dismiss-enforce-worktree");
+    }
+
+    #[test]
+    fn armed_writes_one_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_bypass(BypassEvent::armed(
+                "warn-main-branch",
+                "dismiss-main-branch-warn",
+                None,
+                Some("s"),
+                Some("/tmp"),
+                100,
+                200,
+            ));
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["event"], "armed");
+    }
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -184,9 +184,14 @@ cadence-hooks guardrails dismiss-main-branch-warn
 
 # Explicit duration: 2h, 1d, 45s, etc. Capped at 24h.
 cadence-hooks guardrails dismiss-main-branch-warn --for 2h
+
+# Longer dismissals must say why (recorded in the bypass log):
+cadence-hooks guardrails dismiss-main-branch-warn --for 4h --reason "wrap-up edits on dotfiles"
 ```
 
 The snooze marker lives at `<repo>/.git/cadence-hooks/main-branch-snoozed-until`, so it's per-repo and ignored by default (`.git/` is never committed). The hook's own warn output also points at the command, so it's discoverable when the warning fires.
+
+`--reason` is **required for a dismissal longer than 1h** and nudged (but optional) at or under it. The reason, the arming session, and the expiry are written to a provenance sidecar next to the marker and recorded in the bypass log (see [Bypass provenance](#bypass-provenance) below).
 
 For a repo where `main` is the working branch by design, set `CADENCE_ALLOW_MAIN=true` in `.claude/settings.json` to silence the warning permanently instead.
 
@@ -200,6 +205,19 @@ cadence-hooks guardrails dismiss-enforce-worktree
 
 # Explicit duration: 2h, 1d, 45s, etc. Capped at 24h.
 cadence-hooks guardrails dismiss-enforce-worktree --for 2h
+
+# Longer dismissals must say why (recorded in the repo-visible bypass log):
+cadence-hooks guardrails dismiss-enforce-worktree --for 4h --reason "committing approved plan doc on main"
 ```
 
 The marker lives at `<repo>/.git/cadence-hooks/enforce-worktree-snoozed-until` — independent of the `warn-main-branch` snooze, so unblocking the guard doesn't also silence the nudge. For a repo where `main` is the working branch by design, `CADENCE_ALLOW_MAIN=true` exempts it permanently; `CADENCE_NO_ENFORCE_WORKTREE=1` (user-global) disables the guard everywhere.
+
+This dismissal is **repo-scoped** — on a shared checkout it lowers the guard for every session, not just yours — so `--reason` is **required over 1h** (nudged at or under). The reason, arming session, and expiry land in a provenance sidecar (`enforce-worktree-snoozed-meta.json`, next to the marker) and in the bypass log below.
+
+## Bypass provenance
+
+Every guard bypass — a `dismiss-*` snooze being **armed**, and an operation later **riding through** an active dismissal or env switch — is recorded to `<metrics_dir>/bypasses.jsonl`, one JSON line per event. This answers *who / why / how long / which guard* for the times a guardrail was stepped outside of, which the denial log (`denials.jsonl`) can't see because a bypass is an allow.
+
+Each line carries `event` (`armed` | `used`), the `hook` (guard) and `mechanism` (`dismiss-enforce-worktree`, `CADENCE_ALLOW_MAIN`, …), the `kind` (`dismissal` | `env_switch`), the `sessionId`, the repo **basename**, the user-authored `reason`, and the expiry. Following the denial log's **privacy-by-construction** contract, it never records a command, file path, or edited content — only which guard was bypassed, how, and why.
+
+Writes are fully fail-open (ADR-0001): an unwritable metrics dir degrades to a no-op and never perturbs the operation or its exit code. The log lives under the metrics directory (`CADENCE_METRICS_DIR`, else `<config_dir>/metrics`).

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -50,6 +50,15 @@ pub fn run_logged_check(check: &dyn Check, event: HookEvent, hook: Option<&str>)
             // can perturb the block message or the exit code that follows.
             let hook_name = hook.unwrap_or_else(|| check.name());
             cadence_hooks_metrics::log_denial(hook_name, event, &input, result.outcome);
+            // A bypass-allow rode through an active dismissal / env switch. Record
+            // *that a guard was stepped outside of* — the one event the denial log
+            // can't see (it drops Allow). Fully fail-open, same as log_denial: a
+            // failed write never perturbs the allow or its exit code (ADR-0001).
+            if let Some(prov) = &result.bypass {
+                cadence_hooks_metrics::log_bypass(cadence_hooks_metrics::BypassEvent::used(
+                    hook_name, &input, prov,
+                ));
+            }
             cadence_hooks_metrics::log_timing(
                 hook_name,
                 crate::registry::plugin_for(hook_name).unwrap_or("unknown"),

--- a/src/main.rs
+++ b/src/main.rs
@@ -212,6 +212,10 @@ enum GuardrailsCommands {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
         #[arg(long = "for", default_value = "30m", value_name = "DURATION")]
         for_: String,
+        /// Why the guard is being dismissed. Required for snoozes over 1h;
+        /// recorded in the bypass provenance log.
+        #[arg(long, value_name = "TEXT")]
+        reason: Option<String>,
     },
     /// Block mutations in a primary checkout of a branch-mode repo
     EnforceWorktree,
@@ -220,6 +224,10 @@ enum GuardrailsCommands {
         /// Duration to snooze, e.g. `30m`, `2h`, `1d`. Capped at 24h.
         #[arg(long = "for", default_value = "30m", value_name = "DURATION")]
         for_: String,
+        /// Why the guard is being dismissed. Required for snoozes over 1h;
+        /// recorded in the repo-visible bypass provenance log.
+        #[arg(long, value_name = "TEXT")]
+        reason: Option<String>,
     },
 }
 
@@ -859,11 +867,21 @@ fn main() {
                 pre,
                 canonical_hook,
             ),
-            GuardrailsCommands::DismissMainBranchWarn { for_ } => {
-                cadence_hooks_guardrails::dismiss_main_branch_warn::run_dismiss(&for_);
+            GuardrailsCommands::DismissMainBranchWarn { for_, reason } => {
+                finish_dismiss(
+                    cadence_hooks_guardrails::dismiss_main_branch_warn::perform_dismiss(
+                        &for_,
+                        reason.as_deref(),
+                    ),
+                );
             }
-            GuardrailsCommands::DismissEnforceWorktree { for_ } => {
-                cadence_hooks_guardrails::dismiss_enforce_worktree::run_dismiss(&for_);
+            GuardrailsCommands::DismissEnforceWorktree { for_, reason } => {
+                finish_dismiss(
+                    cadence_hooks_guardrails::dismiss_enforce_worktree::perform_dismiss(
+                        &for_,
+                        reason.as_deref(),
+                    ),
+                );
             }
         },
         Commands::Rules(cmd) => match cmd {
@@ -1011,6 +1029,31 @@ fn main() {
                 cadence_hooks_session::cli::run_status();
             }
         },
+    }
+}
+
+/// Finish a `dismiss-*` CLI action. On success, record the `bypass_armed` event
+/// (the binary owns the metrics writer — this keeps the guardrails crate
+/// metrics-free, mirroring the used-at-seam pattern in [`dispatch`]) and print
+/// the confirmation before exiting 0. On a handled error — already reported to
+/// stderr by `perform_dismiss` — exit 1. The armed write is fire-and-forget
+/// inside [`cadence_hooks_metrics::log_bypass`]: a failure never affects the exit.
+fn finish_dismiss(result: Result<cadence_hooks_guardrails::snooze_meta::DismissArmed, ()>) -> ! {
+    match result {
+        Ok(armed) => {
+            cadence_hooks_metrics::log_bypass(cadence_hooks_metrics::BypassEvent::armed(
+                armed.guard_hook,
+                armed.mechanism,
+                armed.reason.as_deref(),
+                armed.session_id.as_deref(),
+                armed.repo_root.as_deref(),
+                armed.armed_at,
+                armed.expires_at,
+            ));
+            println!("{}", armed.confirmation);
+            std::process::exit(0);
+        }
+        Err(()) => std::process::exit(1),
     }
 }
 


### PR DESCRIPTION
Closes #220

## What

Guard-bypass provenance: every guardrail bypass — a `dismiss-*` snooze **armed**, and an operation **riding through** an active dismissal or env switch — now leaves a durable, privacy-safe line in `bypasses.jsonl`, and long dismissals require a stated `--reason`.

This closes the gap where stepping outside a guardrail (most visibly `dismiss-enforce-worktree --for 4h`) left almost no trace: the dismiss marker stored only an expiry epoch, and a write riding through an active dismissal returned a bare `Allow` with zero side effects — nothing recorded who / why / how long / which guard. On a shared checkout the enforce-worktree dismissal is repo-scoped, so one session's dismissal silently lowers the guard for everyone; that case is exactly where attributable provenance matters.

## How

- **core** — `BypassKind` (`Dismissal`/`EnvSwitch`), `BypassProvenance`, an optional `CheckResult.bypass` field (all existing constructors default it `None`), and `CheckResult::allow_bypassed(prov)`. No new `Outcome` variant — exit code stays 0.
- **dispatch seam** — emits a `used` line whenever `result.bypass.is_some()`, fully fail-open (ADR-0001): a failed audit write never turns an allow into a block.
- **metrics** — new `log_bypass` sink writing `bypasses.jsonl`, sibling of `log_denial`, same privacy-by-construction contract: mechanism / reason / session / repo **basename** only — never command, path, or content (asserted by a forbidden-key test).
- **dismiss commands** — both gain `--reason` (required over 1h, nudged at or under it) and write a provenance sidecar beside the unchanged `{epoch}` marker (the guards' first-line parse is untouched). The `armed` event is logged from the binary (`main::finish_dismiss`), so the guardrails crate stays metrics-free — `run_dismiss` became `perform_dismiss`, returning a plain-data `DismissArmed`.
- **guards** — `enforce-worktree` and `warn-main-branch` return `allow_bypassed(..)` when a dismissal (or, for enforce, an env switch) is what suppressed the block/nudge. A normal worktree allow stays bare.

v1 wires the two highest-value guards; the remaining ~15 guards, the global gates (`CADENCE_BYPASS`/`CADENCE_DISABLE`), exemptions/effort-skips, and read-side surfacing are a tracked follow-up.

## Verification

- `cargo build` + `cargo test` green (guardrails 739 / core 374 / metrics 117, 0 failed); `clippy -D warnings` and `cargo fmt --check` clean.
- New unit tests cover the reason gate (threshold boundary, empty-reason), sidecar round-trip + missing-sidecar tolerance, `allow_bypassed` provenance, both guards' attribution paths (including the no-bypass cases), and `perform_dismiss` validation.
- End-to-end in a scratch repo confirmed: `--for 4h` with no reason **errors** teaching `--reason`; with `--reason` writes marker + sidecar + one `armed` line carrying reason + session; an edit on `main` rides through the dismissal → **allowed**, one `used` line carrying mechanism + reason + session; a worktree edit produces **no** bypass line; and no command/path/content leaks into the log.

A design + adversarial-review pass ran before this PR: an Opus security review (privacy, fail-open, path safety) came back clean, and a code review's findings were applied (env-switch asymmetry rationale documented, `warn-main-branch` attribution tests added, CHANGELOG entry).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added provenance tracking for guard bypasses, including when a snooze is armed and later used.
  * Added optional `--reason` support for longer dismissals.
  * Added a new audit log stream for bypass events.
  * Improved confirmation output and metadata captured for dismiss actions.

* **Bug Fixes**
  * Preserved bypass attribution when snooze metadata is missing.
  * Made audit logging fail open so guard behavior is not disrupted by logging issues.

* **Documentation**
  * Updated configuration docs with the new snooze reason requirement and bypass audit details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->