### PR TITLE
fix(guardrails): treat POSIX-literal paths as absolute on Windows (#235)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`enforce-worktree`'s commit-target resolver no longer misjudges POSIX-shaped shell paths as relative on Windows (#235).** The `-C <path>` redirect decision used `Path::new(path).is_absolute()`, which is `false` on Windows for a leading-`/` path like `/some/worktree` (no drive letter) — so a POSIX shell path (WSL, Git-Bash) resolved as if relative to `effective_dir`, breaking `Check (windows-latest)` on `main` since #226. A new `is_shell_absolute` helper treats a leading `/` as absolute on every platform (these are shell paths a command string carries, not OS paths) before falling back to the platform's own `is_absolute` for native `C:\…` paths — no behavior change on unix. Six fixture tests that construct real Windows-shaped disk paths through `tokenize` (which is documented escape-unaware for backslashes) are `#[cfg(unix)]`-gated rather than fixed at the tokenizer level — a guard-feeding parser change is out of scope here and deferred; a new `#[cfg(windows)]` test proves a native drive-lettered path still resolves correctly through the same helper.
+
 ## [0.49.0] - 2026-07-06
 
 ### Fixed

--- a/crates/guardrails/src/enforce_worktree.rs
+++ b/crates/guardrails/src/enforce_worktree.rs
@@ -233,6 +233,16 @@ fn skip_transparent_prefixes(tokens: &[String]) -> &[String] {
     &tokens[start..]
 }
 
+/// A shell path is absolute if git will treat it as absolute: a leading `/`
+/// (POSIX / WSL / Git-Bash shell paths — `Path::is_absolute` is false for these
+/// on Windows, no drive letter) OR a platform-absolute path (native `C:\…`).
+/// These are shell paths a command string carries, not OS paths, so the
+/// decision is made on the string first, falling back to the platform's own
+/// notion of absolute for native-Windows drive paths (issue #235).
+fn is_shell_absolute(path: &str) -> bool {
+    path.starts_with('/') || Path::new(path).is_absolute()
+}
+
 fn git_commit_targets(command: &str, cwd: &str) -> Vec<CommitTarget> {
     let mut targets = Vec::new();
     let mut effective_dir = cwd.to_string();
@@ -316,7 +326,7 @@ fn git_commit_targets(command: &str, cwd: &str) -> Vec<CommitTarget> {
         }
         if argv.get(idx).map(String::as_str) == Some("commit") {
             let target = match redirect {
-                Some(path) if Path::new(path).is_absolute() => path.to_string(),
+                Some(path) if is_shell_absolute(path) => path.to_string(),
                 Some(path) => format!("{effective_dir}/{path}"),
                 None => effective_dir.clone(),
             };
@@ -836,6 +846,19 @@ mod tests {
         );
     }
 
+    #[cfg(windows)]
+    #[test]
+    fn native_windows_drive_path_commit_targets_redirect() {
+        // A native Windows drive path is absolute via `Path::is_absolute`'s own
+        // arm of `is_shell_absolute` (no leading `/` needed) — proves the
+        // `#[cfg(unix)]`-gated fixtures above aren't the only Windows coverage
+        // for this branch (issue #235).
+        assert_eq!(
+            git_commit_targets(r"git -C C:\repo\wt commit -m x", r"C:\cwd"),
+            vec![r"C:\repo\wt".to_string()]
+        );
+    }
+
     // --- git_commit_targets: grouping / prefixes / quoting (#239 F4/F5/F9) ---
 
     #[test]
@@ -1347,6 +1370,10 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    // unix-shaped fixture: builds POSIX command strings through an
+    // escape-unaware tokenizer; native-Windows path coverage is
+    // native_windows_drive_path_commit_targets_redirect.
     #[test]
     fn cd_into_other_primary_blocks_and_names_target_repo() {
         // Issue #224: the target repo of a `cd <dir> && git commit` may be a
@@ -1384,6 +1411,10 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    // unix-shaped fixture: builds POSIX command strings through an
+    // escape-unaware tokenizer; native-Windows path coverage is
+    // native_windows_drive_path_commit_targets_redirect.
     #[test]
     fn cd_before_or_true_still_blocks_other_primary() {
         // Issue-review finding on the #213/#224 fix: `cd <dir> || true &&
@@ -1489,6 +1520,10 @@ mod tests {
         assert_eq!(r.outcome, Outcome::Allow);
     }
 
+    #[cfg(unix)]
+    // unix-shaped fixture: builds POSIX command strings through an
+    // escape-unaware tokenizer; native-Windows path coverage is
+    // native_windows_drive_path_commit_targets_redirect.
     #[test]
     fn dismiss_repo_flag_snoozes_target_not_cwd() {
         // Mirrors what `dismiss-enforce-worktree --repo <other_primary>` writes
@@ -1570,6 +1605,10 @@ mod tests {
 
     // --- repo-scoped CADENCE_ALLOW_MAIN (cameronsjo/cadence-hooks#232) ---
 
+    #[cfg(unix)]
+    // unix-shaped fixture: builds POSIX command strings through an
+    // escape-unaware tokenizer; native-Windows path coverage is
+    // native_windows_drive_path_commit_targets_redirect.
     #[test]
     fn cross_repo_commit_reads_target_repos_own_settings() {
         // Headline repro: shell rooted in primary A, mutation targets a
@@ -1814,6 +1853,10 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    // unix-shaped fixture: builds POSIX command strings through an
+    // escape-unaware tokenizer; native-Windows path coverage is
+    // native_windows_drive_path_commit_targets_redirect.
     #[test]
     fn cross_repo_block_message_names_target_repos_settings_path() {
         let scratch = Scratch::new("cross-repo-block-message");
@@ -2001,6 +2044,10 @@ mod tests {
         );
     }
 
+    #[cfg(unix)]
+    // unix-shaped fixture: builds POSIX command strings through an
+    // escape-unaware tokenizer; native-Windows path coverage is
+    // native_windows_drive_path_commit_targets_redirect.
     #[test]
     fn commit_with_cwd_under_claude_or_plans_in_primary_still_blocks() {
         // F6/F7: the `.claude`/`docs/plans` carve-out is Edit-arm-only now. A


### PR DESCRIPTION
## Summary

`Check (windows-latest)` has been red on `main` since #226 — 12 `enforce_worktree` tests fail on Windows, all path/shell tests, nothing else.

Closes cameronsjo/cadence-hooks#235

## Root cause

`git_commit_targets`'s `-C <path>` redirect decision used `Path::new(path).is_absolute()`. On Windows that's `false` for a leading-`/` path like `/some/worktree` (no drive letter) — these are shell paths (POSIX/WSL/Git-Bash), not OS paths, so the platform check is wrong for them.

## Fix

Added `is_shell_absolute(path: &str) -> bool`: `path.starts_with('/') || Path::new(path).is_absolute()`. Used at the one `is_absolute()` call site in `git_commit_targets`. No behavior change on unix (a leading `/` was already absolute there).

## Two-facet test triage (12 failing tests)

**Facet 1 — pure-string tests, fixed by the helper (6):**
- `dash_c_commit_targets_redirect`
- `dash_c_still_overrides_cd`
- `inline_config_commit_targets_cwd`
- `multiple_commits_all_reported`
- `quoted_dash_c_path_with_space_detected` (added by #241, same root cause)
- `separate_value_git_globals_do_not_hide_commit` (added by #241, same root cause)

These assert on POSIX literals directly (e.g. `git -C /some/worktree commit`) — no OS filesystem involved. The helper fixes them outright; they stay cross-platform (not gated).

**Facet 2 — real Windows-shaped disk paths through the tokenizer, `#[cfg(unix)]`-gated (6):**
- `cd_into_other_primary_blocks_and_names_target_repo`
- `cd_before_or_true_still_blocks_other_primary`
- `dismiss_repo_flag_snoozes_target_not_cwd`
- `cross_repo_commit_reads_target_repos_own_settings`
- `cross_repo_block_message_names_target_repos_settings_path`
- `commit_with_cwd_under_claude_or_plans_in_primary_still_blocks` (added by #241, same root cause — a `Scratch`-fixture test building a real `cd <native-path> && git commit` string)

These build real command strings from `Scratch`-fixture disk paths (native Windows paths on that runner), which `core::shell::tokenize` mangles because it's documented escape-unaware for backslashes. Fixing this would mean teaching the tokenizer to preserve backslash runs in path position — a guard-feeding shell-parser change that needs its own adversarial security review, not something to bundle into a CI-unblock patch (per the approved plan's Decision Point 2). Each gated test carries a one-line comment explaining why and pointing at the new coverage.

Added `#[cfg(windows)]` test `native_windows_drive_path_commit_targets_redirect` proving a native `C:\...` drive path still resolves correctly through `is_shell_absolute`'s `Path::is_absolute` fallback arm — so the gated tests aren't the only Windows coverage for this branch.

## Verification

- `cargo test -p cadence-hooks-guardrails enforce_worktree` — 94 passed, 0 failed (unix).
- `cargo fmt --all` + `make ci` — green (fmt-check + clippy `-D warnings` + full workspace tests).
- Watching `gh pr checks` for `Check (windows-latest)` — will iterate if still red.

## Deviations from spec

None. Anchors matched the spec exactly: `is_absolute()` call site at line 319 (pre-edit), `git_commit_targets` at line 236, import line 70. The three PR #241-added failing tests (`quoted_dash_c_path_with_space_detected`, `separate_value_git_globals_do_not_hide_commit`, `commit_with_cwd_under_claude_or_plans_in_primary_still_blocks`) triaged cleanly into the existing two-facet framework — two into facet 1, one into facet 2 — no new facet needed.