### PR TITLE
feat(metrics): centralize schemaVersion convention + bump policy (cadence#238)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **The `schemaVersion` metrics-stream convention is now centralized with an explicit bump policy (cameronsjo/cadence#238).** `plan-phases.jsonl` piloted a per-file `SCHEMA_VERSION` constant (shipped 0.47.0); that value now lives in `crates/metrics/src/common.rs` as `PLAN_PHASE_SCHEMA_VERSION`, read from one source, alongside a documented additive-vs-breaking bump policy (Keep-a-Changelog for the data contract). No row shape changes — `plan-phases.jsonl` still emits `schemaVersion: 1`. New streams are born versioned; the four pre-existing v0 streams (`commits`/`subagents`/`denials`/`sessions`) adopt the field on their *next* shape change (opportunistic adoption), and historical un-stamped lines are never backfilled.
+
 ## [0.50.0] - 2026-07-07
 
 ### Added

--- a/crates/metrics/src/common.rs
+++ b/crates/metrics/src/common.rs
@@ -124,6 +124,33 @@ pub fn utc_timestamp() -> String {
     cadence_hooks_core::time::utc_timestamp()
 }
 
+// ---------------------------------------------------------------------------
+// Schema versioning (the metrics data contract)
+// ---------------------------------------------------------------------------
+//
+// A metrics stream MAY stamp an explicit integer `schemaVersion` on every row
+// so consumers branch on a declared contract version instead of probing field
+// presence. Each stream's version is a `*_SCHEMA_VERSION` constant defined here
+// — one greppable source of truth — read by that stream's logger. Keep the
+// constant and the stream's row in `plugins/cadence-metrics/docs/schema.md`
+// (cadence repo) in lockstep.
+//
+// Bump policy (Keep-a-Changelog for the data contract):
+//   - ADDITIVE change (new nullable field, new `event` enum value): DO NOT bump.
+//     Old consumers keep working; the field/value is simply absent or unseen on
+//     older rows.
+//   - BREAKING change (field renamed / removed / retyped, or a field's meaning
+//     changes): bump the stream's constant by 1 and document the cutover in a
+//     "Schema version history" note in `schema.md`.
+//
+// Streams predating this convention (`commits` / `subagents` / `denials` /
+// `sessions`) are implicitly version 0. They adopt a constant here on their
+// *next* shape change (opportunistic adoption, cadence#238) — historical
+// un-stamped lines are never backfilled.
+
+/// Schema version stamped on every `plan-phases.jsonl` row.
+pub const PLAN_PHASE_SCHEMA_VERSION: u32 = 1;
+
 /// Crate-wide serialization lock for env-mutating tests.
 ///
 /// `CADENCE_METRICS_DIR` and its siblings are process-global, so every test that

--- a/crates/metrics/src/log_plan_phase.rs
+++ b/crates/metrics/src/log_plan_phase.rs
@@ -9,8 +9,9 @@
 //! / `costUsd` / `model` to `null` rather than skipping the write, so a
 //! plan-phase transition is never silently dropped for lack of pricing data.
 //!
-//! Pilots the `schemaVersion` convention (stamped `1` on every row) — not yet
-//! adopted by the other metrics streams.
+//! Stamps `schemaVersion` (`common::PLAN_PHASE_SCHEMA_VERSION`) on every row.
+//! The shared per-stream version convention and its bump policy live in
+//! [`crate::common`] (schema versioning section).
 
 use crate::common;
 use crate::compute_cost::compute_cost_by_model;
@@ -19,9 +20,6 @@ use crate::scan_tokens::{ScanResult, scan_tokens};
 use cadence_hooks_core::{Logger, MetricsInput};
 use serde_json::{Value, json};
 use std::io::Write;
-
-/// Schema version stamped on every `plan-phases.jsonl` row.
-const SCHEMA_VERSION: u32 = 1;
 
 /// Appends a line to `plan-phases.jsonl` for each plan lifecycle event. Holds
 /// the optional price table override path supplied via `--prices`, mirroring
@@ -139,7 +137,7 @@ fn build_plan_phase_record(
     });
 
     let mut record = json!({
-        "schemaVersion": SCHEMA_VERSION,
+        "schemaVersion": common::PLAN_PHASE_SCHEMA_VERSION,
         "ts": ts,
         "event": event,
         "sessionId": input.session_id,
@@ -238,7 +236,7 @@ mod tests {
             None,
             false,
         );
-        assert_eq!(record["schemaVersion"], 1);
+        assert_eq!(record["schemaVersion"], common::PLAN_PHASE_SCHEMA_VERSION);
         assert_eq!(record["ts"], "2026-07-05T00:00:00Z");
         assert_eq!(record["event"], "plan_exit");
         assert_eq!(record["sessionId"], "s1");


### PR DESCRIPTION
## What

Centralizes the `schemaVersion` metrics-stream convention. `plan-phases.jsonl` piloted a per-file `SCHEMA_VERSION` constant; that value now lives in `crates/metrics/src/common.rs` as `PLAN_PHASE_SCHEMA_VERSION`, read from one greppable source, alongside a documented additive-vs-breaking bump policy (Keep-a-Changelog for the data contract).

**No row shape changes** — `plan-phases.jsonl` still emits `schemaVersion: 1`. This lands the versioning contract *before* the new streams (`skills.jsonl`, #215) that will be born versioned.

## Decision

Per **D1 = opportunistic adoption**: new streams are born with the field; the four pre-existing v0 streams (`commits`/`subagents`/`denials`/`sessions`) adopt it on their *next* shape change, not in a bulk sweep. Historical un-stamped lines are never backfilled.

## Verification

- `cargo test -p cadence-hooks-metrics` → 131 passed
- `cargo build --release` clean
- Live row from the built binary: `{ "event": "plan_exit", "schemaVersion": 1 }`
- `grep -rn schemaVersion crates/metrics/src` shows shared-constant use only (the sole literal `1` outside the constant is the existing record-shape assertion)

## Scope

First task of the C8 metrics/provenance cluster (plan: cameronsjo/cadence#285). This is release **R1** of that cluster's two-release cadence (D2).

Refs cameronsjo/cadence#238


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a shared schema version convention for metrics output, with a clear upgrade policy for future changes.
  * Standardized `schemaVersion` in plan phase records to use a single shared value.
* **Documentation**
  * Updated changelog and inline notes to explain how schema versioning works and when it should be bumped.
* **Bug Fixes**
  * Kept existing output shape unchanged while aligning version handling across records.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->