### PR TITLE
feat(metrics): add log-skill subcommand + skills.jsonl stream (#215)

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -192,6 +192,11 @@ pub struct ToolInput {
     /// means the spawn gets a fresh agent-owned worktree; absent means the
     /// subagent inherits the spawning session's working directory.
     pub isolation: Option<String>,
+    /// Skill tool: the invoked skill id (e.g. `cadence:attune`).
+    pub skill: Option<String>,
+    /// Skill tool: the skill's argument string. NEVER logged raw — only a
+    /// non-reversible hash of it is recorded (see `log_skill`).
+    pub args: Option<String>,
 }
 
 /// A single edit operation within a MultiEdit tool call.

--- a/crates/metrics/src/common.rs
+++ b/crates/metrics/src/common.rs
@@ -151,6 +151,9 @@ pub fn utc_timestamp() -> String {
 /// Schema version stamped on every `plan-phases.jsonl` row.
 pub const PLAN_PHASE_SCHEMA_VERSION: u32 = 1;
 
+/// Schema version stamped on every `skills.jsonl` row.
+pub const SKILL_SCHEMA_VERSION: u32 = 1;
+
 /// Crate-wide serialization lock for env-mutating tests.
 ///
 /// `CADENCE_METRICS_DIR` and its siblings are process-global, so every test that

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -26,6 +26,8 @@ pub mod log_polish_nudge;
 pub mod log_session;
 /// Stamp this session's start timestamp at `SessionStart`.
 pub mod log_session_start;
+/// Append Skill tool invocation records to `skills.jsonl`.
+pub mod log_skill;
 /// Append subagent lifecycle records to `subagents.jsonl`.
 pub mod log_subagent;
 /// Append threshold-gated hook self-timing records to `hooks.jsonl`.
@@ -49,6 +51,7 @@ pub use log_plan_phase::LogPlanPhase;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_session::LogSession;
 pub use log_session_start::LogSessionStart;
+pub use log_skill::LogSkill;
 pub use log_subagent::LogSubagent;
 pub use log_timing::log_timing;
 pub use snapshot::Snapshot;

--- a/crates/metrics/src/log_skill.rs
+++ b/crates/metrics/src/log_skill.rs
@@ -1,0 +1,193 @@
+//! `Skill` tool invocations — append one line per call to
+//! `<metrics_dir>/skills.jsonl`.
+//!
+//! A lifecycle audit log only — no token or cost data (sibling of
+//! [`crate::log_subagent`]). Privacy-by-construction (D5): the skill id is
+//! recorded in clear (it's not sensitive — it's a plugin:directory name), but
+//! the skill's `args` string is NEVER logged raw. Instead, `argsHash` carries a
+//! non-reversible [`std::collections::hash_map::DefaultHasher`] digest of it —
+//! the same fixed-key, stable-across-processes hash [`cadence_hooks_core::markers`]
+//! uses for its marker filenames.
+//!
+//! Stamps `schemaVersion` (`common::SKILL_SCHEMA_VERSION`) on every row. Unlike
+//! its [`crate::log_subagent`] sibling, the record also carries a `repo` field
+//! (basename of the cwd) — a skill invocation is meaningful *per repo* (the
+//! co-fire matrix groups by project), whereas a subagent lifecycle event is
+//! already attributable via its `parentSessionId` chain.
+
+use crate::common;
+use cadence_hooks_core::{Logger, MetricsInput};
+use serde_json::{Value, json};
+use std::collections::hash_map::DefaultHasher;
+use std::hash::{Hash, Hasher};
+use std::io::Write;
+
+/// Appends a line to `skills.jsonl` for each `Skill` tool invocation.
+pub struct LogSkill;
+
+impl Logger for LogSkill {
+    fn name(&self) -> &str {
+        "log-skill"
+    }
+
+    fn run(&self, input: &MetricsInput) {
+        if input.hook_event_name.as_deref() != Some("PostToolUse") {
+            return;
+        }
+        if input.tool_name.as_deref() != Some("Skill") {
+            return;
+        }
+
+        let dir = common::metrics_dir();
+        if std::fs::create_dir_all(&dir).is_err() {
+            return;
+        }
+
+        let debug = std::env::var("CADENCE_METRICS_DEBUG").as_deref() == Ok("1");
+        let record = build_skill_record(input, &common::utc_timestamp(), debug);
+
+        if let Ok(mut file) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(dir.join("skills.jsonl"))
+        {
+            // Build the whole line (record + newline) and write it in one
+            // write_all, matching log_subagent.rs — a single O_APPEND write is
+            // atomic, so concurrent appends can't interleave a record with its
+            // trailing newline (#94).
+            let mut line = record.to_string();
+            line.push('\n');
+            let _ = file.write_all(line.as_bytes());
+        }
+    }
+}
+
+/// Non-reversible digest of a skill's `args` string, hex-encoded. `None`
+/// (JSON `null`) when `args` is absent — never hash an absent value into a
+/// spurious "empty string" digest.
+fn args_hash(args: Option<&str>) -> Option<String> {
+    args.map(|s| {
+        let mut h = DefaultHasher::new();
+        s.hash(&mut h);
+        format!("{:016x}", h.finish())
+    })
+}
+
+/// Build the JSONL record for a skill invocation. Pure — no I/O.
+fn build_skill_record(input: &MetricsInput, ts: &str, include_keys: bool) -> Value {
+    let skill = input.tool_input.as_ref().and_then(|ti| ti.skill.clone());
+    let args = input.tool_input.as_ref().and_then(|ti| ti.args.as_deref());
+
+    let mut record = json!({
+        "schemaVersion": common::SKILL_SCHEMA_VERSION,
+        "ts": ts,
+        "event": "skill",
+        "sessionId": input.session_id,
+        "repo": common::repo_basename(input.cwd.as_deref()),
+        "skill": skill,
+        "argsHash": args_hash(args),
+        "agentId": input.agent_id,
+        "agentType": input.agent_type,
+        "parentSessionId": input.parent_session_id,
+    });
+
+    if include_keys && let Some(obj) = record.as_object_mut() {
+        obj.insert("_keys".to_string(), json!(input.raw_keys));
+    }
+
+    record
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::ToolInput;
+
+    fn skill_event() -> MetricsInput {
+        MetricsInput {
+            hook_event_name: Some("PostToolUse".into()),
+            tool_name: Some("Skill".into()),
+            session_id: Some("s1".into()),
+            agent_id: Some("a1".into()),
+            agent_type: Some("Explore".into()),
+            tool_input: Some(ToolInput {
+                skill: Some("cadence:attune".into()),
+                args: Some("execute C8".into()),
+                ..Default::default()
+            }),
+            raw_keys: vec!["hook_event_name".into(), "tool_name".into()],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn name_is_log_skill() {
+        assert_eq!(LogSkill.name(), "log-skill");
+    }
+
+    #[test]
+    fn record_carries_skill_in_clear_and_hashed_args() {
+        let record = build_skill_record(&skill_event(), "2026-07-07T00:00:00Z", false);
+        assert_eq!(record["schemaVersion"], common::SKILL_SCHEMA_VERSION);
+        assert_eq!(record["event"], "skill");
+        assert_eq!(record["skill"], "cadence:attune");
+        assert_eq!(record["ts"], "2026-07-07T00:00:00Z");
+        let hash = record["argsHash"].as_str().expect("argsHash present");
+        assert_ne!(hash, "execute C8", "raw args must never be logged");
+        assert!(record.get("_keys").is_none());
+    }
+
+    #[test]
+    fn args_hash_is_stable_across_builds() {
+        let a = build_skill_record(&skill_event(), "2026-07-07T00:00:00Z", false);
+        let b = build_skill_record(&skill_event(), "2026-07-07T00:00:00Z", false);
+        assert_eq!(a["argsHash"], b["argsHash"]);
+    }
+
+    #[test]
+    fn wrong_hook_event_is_noop() {
+        let input = MetricsInput {
+            hook_event_name: Some("PreToolUse".into()),
+            tool_name: Some("Skill".into()),
+            ..Default::default()
+        };
+        LogSkill.run(&input);
+    }
+
+    #[test]
+    fn wrong_tool_name_is_noop() {
+        let input = MetricsInput {
+            hook_event_name: Some("PostToolUse".into()),
+            tool_name: Some("Bash".into()),
+            ..Default::default()
+        };
+        LogSkill.run(&input);
+    }
+
+    #[test]
+    fn absent_args_yields_null_hash() {
+        let mut input = skill_event();
+        input.tool_input = Some(ToolInput {
+            skill: Some("cadence:attune".into()),
+            args: None,
+            ..Default::default()
+        });
+        let record = build_skill_record(&input, "2026-07-07T00:00:00Z", false);
+        assert!(record["argsHash"].is_null());
+    }
+
+    #[test]
+    fn debug_adds_keys() {
+        let record = build_skill_record(&skill_event(), "2026-07-07T00:00:00Z", true);
+        let keys = record["_keys"].as_array().unwrap();
+        assert!(keys.contains(&json!("tool_name")));
+    }
+
+    #[test]
+    fn record_serializes_to_single_line() {
+        // #94: the single-write_all fix is only atomic-per-record if the record
+        // has no embedded newline. Compact JSON guarantees this; lock it down.
+        let line = build_skill_record(&skill_event(), "2026-07-07T00:00:00Z", true).to_string();
+        assert!(!line.contains('\n'), "record must be one line: {line}");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -292,6 +292,8 @@ enum MetricsCommands {
     LogPolishNudge,
     /// Log AskUserQuestion stance + shape on every call (PreToolUse)
     LogAskUserQuestion,
+    /// Log skill invocations (PostToolUse:Skill)
+    LogSkill,
     /// Warn at SessionStart when metrics telemetry has gone stale (SessionStart)
     WarnStale,
 }
@@ -412,6 +414,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             MetricsCommands::LogPlanPhase { .. } => "log-plan-phase",
             MetricsCommands::LogPolishNudge => "log-polish-nudge",
             MetricsCommands::LogAskUserQuestion => "log-ask-user-question",
+            MetricsCommands::LogSkill => "log-skill",
             MetricsCommands::WarnStale => "warn-stale",
         }),
         Commands::Lab(l) => Some(match l {
@@ -974,6 +977,11 @@ fn main() {
             MetricsCommands::LogAskUserQuestion => dispatch::run_logged_logger(
                 &cadence_hooks_metrics::LogAskUserQuestion,
                 registry::sample_for("metrics", "log-ask-user-question"),
+                canonical_hook,
+            ),
+            MetricsCommands::LogSkill => dispatch::run_logged_logger(
+                &cadence_hooks_metrics::LogSkill,
+                registry::sample_for("metrics", "log-skill"),
                 canonical_hook,
             ),
             // warn-stale is a SessionStart *check*, not a logger — it reads the

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -333,6 +333,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: None,
     },
     HookEntry {
+        name: "log-skill",
+        description: "Log skill invocations (PostToolUse:Skill)",
+        plugin: "metrics",
+        event: None,
+    },
+    HookEntry {
         name: "warn-stale",
         description: "Warn at SessionStart when metrics telemetry has gone stale",
         plugin: "metrics",
@@ -465,6 +471,11 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         // shape; the generic logger sample carries no `questions` and would no-op.
         ("metrics", "log-ask-user-question") => Some(
             r#"{"session_id":"test","hook_event_name":"PreToolUse","model":"claude-opus-4-8","tool_input":{"questions":[{"question":"Which approach?","header":"Approach","multiSelect":false,"options":[{"label":"Option A","description":"first"},{"label":"Option B","description":"second"}]}]}}"#,
+        ),
+        // log-skill gates on tool_name == "Skill"; the generic PostToolUse
+        // logger sample carries no tool_name and would no-op.
+        ("metrics", "log-skill") => Some(
+            r#"{"session_id":"test","hook_event_name":"PostToolUse","tool_name":"Skill","cwd":"/tmp","tool_input":{"skill":"cadence:attune","args":"execute C8"}}"#,
         ),
         // warn-branch-drift early-exits unless the command is a git commit —
         // the generic PreToolUse sample (`git status`) would never reach the
@@ -641,6 +652,7 @@ mod tests {
             "log-plan-phase",
             "log-polish-nudge",
             "log-ask-user-question",
+            "log-skill",
             "heartbeat",
             "end",
             "backstop-record",


### PR DESCRIPTION
## What

New `skills.jsonl` metrics stream — one row per `Skill` tool invocation, born with `schemaVersion` (which is why cadence#238 landed first). Adds a `metrics log-skill` subcommand + `LogSkill` logger, modeled on the lightweight-audit `log_subagent` pattern (no token/cost scan).

## Privacy design (Decision D5)

- **`skill` recorded in clear** — it's a `plugin:directory` id, not sensitive, and the co-fire matrix (claude-configurations#347) keys on it.
- **`args` are NEVER logged raw** — only `argsHash`, a non-reversible `DefaultHasher` digest (the same fixed-key, stable-across-processes hash the marker scheme uses). No new dependency.

## Implementation

- `crates/core/src/lib.rs` — additive `skill`/`args` `Option<String>` fields on the shared `ToolInput` (a Skill payload's fields were being silently dropped by serde).
- `crates/metrics/src/log_skill.rs` — the logger; `crates/metrics/src/common.rs` — `SKILL_SCHEMA_VERSION`.
- `src/main.rs` + `src/registry.rs` — subcommand wiring (the registry entry satisfies the repo's `registry_matches_clap_dispatch` enforcement test).

## Verification

- `cargo test -p cadence-hooks-metrics` → 139 passed (8 new log_skill tests); 90 binary tests pass (registry enforcement included); `cargo build --release` clean.
- Rendered row from the built binary: `{"schemaVersion":1,"event":"skill","skill":"cadence:attune","argsHash":"<hex>", …}` — `argsHash` ≠ the raw args; a non-`Skill` payload writes nothing.
- **Security review (independent):** PASS, no Critical/Important. Privacy invariant held under adversarial probing — raw secret-shaped args, malformed JSON, missing fields, and `CADENCE_METRICS_DEBUG=1` (which confirmed `_keys` carries top-level key *names* only, never values). Fail-open on bad input, no payload-derived write path.

## Scope

Binary side of the C8 metrics/provenance cluster (plan: cameronsjo/cadence#285), release **R2**. The plugin `Skill` matcher wiring is a follow-up PR, release-gated on this shipping. (#221's `plan_exit_rejected` is deferred pending an interactive platform probe — see cadence-hooks#221.)

Refs cameronsjo/cadence-hooks#215


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for logging skill tool invocations as a new metrics event.
  * Expanded the CLI with a new metrics command for recording skill-related activity.

* **Bug Fixes**
  * Improved log writing to keep each record on a single line, reducing the chance of mixed or corrupted entries during concurrent writes.
  * Added support for preserving missing skill arguments as empty values in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->