### PR TITLE
plan(guard-rm): path-aware rm triage replacing blanket ask rules

### DIFF
--- a/docs/plans/2026-07-08-guard-rm.md
+++ b/docs/plans/2026-07-08-guard-rm.md
@@ -1,0 +1,76 @@
+# guard-rm: path-aware rm triage — implementation plan
+
+> **Plan PR (draft).** Ships as `docs/plans/2026-07-08-guard-rm.md` on `cameronsjo/cadence-hooks`. This document is the whole contract — a fresh implementer session executes it with zero prior context.
+> **Refs (never `Closes` — this is a plan, not the fix):** `Refs` epic `cameronsjo/claude-configurations#361` (joins as cluster F). Not from the blind-spot audit — from live friction: the blanket `ask` rules on recursive rm interrupt Fable/background sessions on every scratchpad wipe and temp cleanup.
+> **Implementer note:** Two repos plus dotfiles. Binary = `/Users/cameronsjo/Projects/claude-configurations/cadence-hooks` (Rust; released 0.52.0 — re-check `gh release view -R cameronsjo/cadence-hooks` before planning versions). Plugin wiring = `/Users/cameronsjo/Projects/claude-configurations/cadence` `plugins/cadence-guardrails/hooks/hooks.json`. Settings change = `~/.dotfiles` chezmoi source for `~/.claude/settings.json` (**reconcile the modify_ overlay drift first** — see the standing settings-overlay-drift caution). Read `crates/obsidian/src/trash_guard.rs`, `crates/guardrails/src/enforce_worktree.rs:141` (`is_temp_root`), `crates/guardrails/src/warn_main_branch.rs:100` (`is_claude_managed_dir`), `crates/guardrails/src/guard_dotfiles.rs` (pure decision-fn template), and `crates/core/src/shell.rs` (`tokenize`, `command_segments`) before touching anything.
+> **Planned 2026-07-08.**
+
+## Context
+
+Cameron's `~/.claude/settings.json` carries `ask` rules `Bash(rm -rf:*)` and `Bash(rm -r:*)` (plus catastrophic `deny` rows: `rm -rf /`, `/var/log` forms). Every recursive rm — session-scratchpad cleanup, `/tmp` teardown, worktree removal fallbacks — prompts. In background/auto sessions that is a blocking interruption on a structurally-safe operation, many times a day.
+
+**Platform facts that shape the design (verified against code.claude.com/docs/en/permissions, 2026-07-08):**
+
+1. **Hook `allow` cannot bypass `ask` or `deny` rules** — both are evaluated regardless of hook output. A hook that "softens" the ask rule is a silent no-op. So this is a **replacement, not a complement**: the blanket ask rules must come out, an `allow` rule goes in, and the hook becomes the sole discriminator.
+2. **Hook exit-2 block pre-empts allow rules** (runs before permission evaluation). This is what makes "allow `Bash(rm:*)` + blocking hook" safe — the docs recommend exactly this shape.
+3. **Built-in circuit breakers survive everything:** `rm -rf /` and `rm -rf ~` always prompt, even under `bypassPermissions`. The catastrophic floor does not depend on this guard.
+4. A hook returning `permissionDecision: "ask"` forces a prompt. **Claim-to-verify at build time:** confirm ask-over-allow ordering with a live probe (the docs confirm block-over-allow explicitly; ask-over-allow is implied but not quoted).
+
+**Charter (named before hardening, per standing practice):** this is a *discipline guard with an allow-granting edge*, not a security boundary. It fails open per ADR-0001 — and because its allow decision pairs with a settings `allow` rule, fail-open + missing binary = silent allows for rm. The catastrophic floor (fact 3 + retained deny rows) bounds that window; the sequencing below shrinks it further.
+
+## Decision table (the guard's whole contract)
+
+Judged **per command segment** (`command_segments` — so `cd /tmp && rm -rf x` and `bash -lc 'rm -rf y'` are each seen), with paths resolved against the segment's effective cwd (`parse_work_dir`):
+
+| Target class | Verdict | Mechanism |
+|---|---|---|
+| Under a temp root (`/tmp`, `/private/tmp`, `$TMPDIR` incl. `/var/folders` canonicalization) | **ALLOW** (exit 0, silent) | reuse `is_temp_root` |
+| Under a `.claude`-managed dir (worktrees, session dirs, scratchpads) | **ALLOW** | reuse `is_claude_managed_dir` |
+| Under a per-repo declared safe path | **ALLOW** | exemption config (below) |
+| Path is `/`, `~`, `$HOME`, or a first-level home child (`~/Documents` etc.) | **BLOCK** (exit 2, disclosed message + escape hatches) | pure decision fn, `PROTECTED`-style const list |
+| Inside `$OBSIDIAN_VAULT` | **BLOCK** | same env-read shape as trash_guard (empty/unset → skip) |
+| A git repo root, or any path containing `.git` | **BLOCK** | `git -C <target> rev-parse --show-toplevel` comparison, or component match on `.git` |
+| Contains unexpanded variables, command substitution, or an unresolvable/relative-escaping path | **ASK** (`permissionDecision: "ask"`) | can't prove safety → today's behavior |
+| Everything else | **ASK** | default preserves the prompt for the genuine middle |
+
+No new false-block on the common path: the ALLOW rows are the friction; the ASK default means nothing that prompts today stops prompting unless structurally proven safe.
+
+## Reuse ledger (use / abuse / reuse / rework)
+
+| Change | Mode | Existing mechanism |
+|---|---|---|
+| Destructive-verb classification | **Reuse** | `trash_guard.rs` `is_destructive` (rm/unlink/shred/truncate/`find -delete`, basename-matched) — promote to `crates/core` or duplicate with attribution; trash_guard is the template with polarity inverted |
+| Temp-root safety | **Reuse** | `enforce_worktree.rs::is_temp_root` (already handles macOS `/var/folders`) |
+| `.claude`-managed safety | **Reuse** | `warn_main_branch.rs::is_claude_managed_dir` |
+| Command parsing | **Reuse** | `core/shell.rs` `command_segments` + `tokenize` + `parse_work_dir` — adversarially reviewed; do NOT roll new recursion (a transform that sees less of a command is a silent miss, not fail-open) |
+| Pure decision fn shape | **Reuse** | `guard_dotfiles.rs::judge_dotfile` pattern — I/O-free `judge_rm(cwd, env, segments) -> Verdict`, table-driven tests |
+| Per-repo safe paths + block→nudge demotion | **Reuse** | the terminology-check JSON exemption pattern (`paths`/`mode`, softening-only) as `.claude/rm-exemptions.json` — or fold into the same file; implementer's call, but no new config *mechanism* |
+| Escape hatches | **Reuse** | `CADENCE_BYPASS`, `CADENCE_DISABLE` (do NOT list in `PROTECTED_GUARDS` — this is discipline, not security), per-repo settings env per the ADR-0030 `CADENCE_ALLOW_MAIN` model |
+| Wiring | **Reuse** | `hooks.json` `if:` prefilter shape — `"if": "Bash(* rm *|*rm *)"` style (alternation ok, literal `\|` not); binary does precision |
+| **Net-new** | — | the `guard-rm` check itself + its registry/clap entries (the finding *is* the absence); and the settings posture change (dotfiles-side, not code) |
+
+## Task breakdown
+
+| # | Task | Repo | Dispatch |
+|---|---|---|---|
+| 1 | `crates/guardrails/src/guard_rm.rs`: pure `judge_rm` decision fn + the decision table above as table-driven tests (every row, plus adversarial shapes: `bash -c`, heredocs, `cd`-chains, quoted paths, `--` terminator, multiple targets — mixed-verdict multi-target resolves to the *most severe*) | cadence-hooks | Sonnet implementer, worktree |
+| 2 | clap variant + dispatch arm (`src/main.rs`), `HOOKS` registry entry (`src/registry.rs`, `registry_matches_clap_dispatch` enforces), `sample_for` payload, CHANGELOG `[Unreleased]` | cadence-hooks | fold into task 1 |
+| 3 | **Adversarial security review** — mandatory: this parser predicate gates an ALLOW decision (the sharpest trigger per the standing parser lesson). Dispatch the security-reviewer against the diff; separately a code-review pass (layered, two gates) | cadence-hooks | 🔒 Opus reviewers |
+| 4 | Live probe: `cadence-hooks try guardrails guard-rm --payload` decision table (command → verdict → exit code), including the ask-over-allow ordering claim from Context | cadence-hooks | fold into 3's session |
+| 5 | Release (`make bump` in a worktree; check for parallel-session bumps) | cadence-hooks | orchestrator |
+| 6 | Wiring PR: `PreToolUse` `Bash` matcher + `if:` prefilter in `plugins/cadence-guardrails/hooks/hooks.json` — **new subcommand ⇒ doctor CI release-gated: merge only after task 5 ships** | cadence | Sonnet implementer |
+| 7 | **Proving period** (guard live, ask rules still in place — prompts continue, but the guard's blocks/nudges are observable in denials.jsonl; a week of real sessions with zero false-blocks is the bar) | — | calendar, not code |
+| 8 | Settings posture change, **last**: remove `Bash(rm -rf:*)` + `Bash(rm -r:*)` from `ask`; add `Bash(rm:*)` to `allow`; keep every existing `deny` row. Via chezmoi source (reconcile the modify_ overlay drift first), then apply on both machines | dotfiles | Cameron + orchestrator |
+
+Sequencing is the point: the replacement ships and proves itself before the incumbent retires; the rm surface is never unguarded between the two.
+
+## Verification
+
+- Task 1: `cargo test -p cadence-hooks-guardrails` table green; every decision-table row has a test.
+- Task 4: rendered `try` harness table attached to the PR (evidence-first: command → verdict, version pinned).
+- Task 7→8 gate: `denials.jsonl` shows guard-rm activity and zero false-blocks over the proving period; only then does the settings change land.
+- End state: a scratchpad `rm -rf` in a fresh session runs silently; `rm -rf ~/Documents` blocks with a disclosed message naming the escape hatches; an ambiguous `rm -rf $BUILD_DIR` prompts exactly as today.
+
+## Orchestrator
+
+Sonnet-drivable. Named Opus triggers: task 3 adjudication (security findings on the allow-gating parser), and any replan if the ask-over-allow probe (task 4) refutes the Context claim.


### PR DESCRIPTION
Cluster-plan draft PR (F) — a path-aware `guard-rm` check replacing blanket recursive-rm `ask` rules that interrupt background sessions on every temp/scratch cleanup.

Key platform fact shaping the design (verified against the current permissions docs): a PreToolUse hook's allow decision cannot bypass settings `ask`/`deny` rules — only an exit-2 block pre-empts (and only over allow rules). So this is a **replacement, not a complement**: the guard becomes the sole discriminator (allow temp roots and managed scratch dirs; block home/vault/repo-root targets; ask the ambiguous middle), paired with an allow rule — and the blanket ask rules retire only after a proving period, so the surface is never unguarded between the two.

Reuse ledger: no new parsing (reuses the existing segment tokenizer), temp-root and managed-dir predicates reused from existing guards, the vault trash-guard as a polarity-inverted template, existing exemption/escape-hatch patterns. Net-new: the check itself plus registry entries.

Mandatory adversarial security review is written into the plan: this is a parser predicate gating an ALLOW decision.

Refs cameronsjo/claude-configurations#361 (epic, cluster F).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
