### PR TITLE
feat(metrics): sweep + fail-open telemetry, surfaced in doctor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Added
+
+- **`sweep_stale` (the session-registry reaper behind the PostToolUse heartbeat and `session start`) now logs every reap to `sweeps.jsonl` (cameronsjo/cadence-hooks#259).** Cross-machine/cross-session liveness sweeps were previously invisible. Each row carries the reaping `trigger` (`"heartbeat"` | `"start"`), the reaped file's `sessionId`/`name` when it still parsed, and its age at reap time — a best-effort identity parse that never gates the delete it's recording.
+- **The binary's three fail-open paths — a caught panic, a stdin-parse failure, and clap version-skew — now log to `failopen.jsonl` (cameronsjo/cadence-hooks#259).** Every row carries `reason` (`"panic"|"parse"|"version_mismatch"`), the attempted `namespace`/`subcommand` when known, and the running `binaryVersion`. Both new streams ride the existing JSONL rail on `<metrics_dir>/`, consistent with `denials.jsonl`/`hooks.jsonl`/`bypasses.jsonl` — wiring them into a fuller OTLP-based observability stack is a named follow-up, not this change.
+- **`cadence-hooks doctor` now surfaces both new streams.** An informational (non-blocking) line reports recent session-registry sweep counts. Fail-open counts warn on ≥1 panic, ≥3 parse failures, or ≥1 `version_mismatch` in the last 7 days — the `version_mismatch` check counts only rows tagged with the *currently installed* binary's own version, so a sanctioned new-hooks.json/old-binary release transition doesn't alarm; a recurrence on the current version means the skew didn't resolve.
+
 ## [0.52.0] - 2026-07-07
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,6 +276,7 @@ version = "0.52.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-guardrails",
+ "cadence-hooks-metrics",
  "serde",
  "serde_json",
  "tempfile",

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -18,6 +18,8 @@ pub mod log_bypass;
 pub mod log_commit;
 /// Append guard-denial audit records to `denials.jsonl`.
 pub mod log_denial;
+/// Append fail-open telemetry (panic / parse / version-skew) to `failopen.jsonl`.
+pub mod log_failopen;
 /// Append plan-lifecycle records (EnterPlanMode/ExitPlanMode) to `plan-phases.jsonl`.
 pub mod log_plan_phase;
 /// Append polish-nudge (`gh pr create`) records to `polish_nudges.jsonl`.
@@ -30,6 +32,8 @@ pub mod log_session_start;
 pub mod log_skill;
 /// Append subagent lifecycle records to `subagents.jsonl`.
 pub mod log_subagent;
+/// Append sweep-reap records to `sweeps.jsonl`.
+pub mod log_sweep;
 /// Append threshold-gated hook self-timing records to `hooks.jsonl`.
 pub mod log_timing;
 /// Shared per-model breakdown builders for `byModel[]` / `unpricedModels[]`.
@@ -47,12 +51,14 @@ pub use log_askuserquestion::LogAskUserQuestion;
 pub use log_bypass::{BypassEvent, log_bypass};
 pub use log_commit::LogCommit;
 pub use log_denial::log_denial;
+pub use log_failopen::log_failopen;
 pub use log_plan_phase::LogPlanPhase;
 pub use log_polish_nudge::LogPolishNudge;
 pub use log_session::LogSession;
 pub use log_session_start::LogSessionStart;
 pub use log_skill::LogSkill;
 pub use log_subagent::LogSubagent;
+pub use log_sweep::log_sweep;
 pub use log_timing::log_timing;
 pub use snapshot::Snapshot;
 pub use warn_stale::WarnStale;

--- a/crates/metrics/src/log_failopen.rs
+++ b/crates/metrics/src/log_failopen.rs
@@ -1,0 +1,360 @@
+//! Append-only telemetry for the binary's fail-open paths (panic, stdin-parse
+//! failure, clap version-skew) to `<metrics_dir>/failopen.jsonl` — this JSONL
+//! stream keeps these previously-silent degradations consistent with the
+//! existing denial/timing/bypass rail on `<metrics_dir>/`; wiring these
+//! streams into a fuller OTLP-based observability stack is a named follow-up,
+//! not this change.
+
+use crate::common;
+use serde_json::{Value, json};
+use std::io::Write;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+/// Schema version stamped on every `failopen.jsonl` row. A new stream
+/// (cadence#238 convention) — does not share `common`'s existing version
+/// constants.
+const FAILOPEN_SCHEMA_VERSION: u32 = 1;
+
+/// Build the `failopen.jsonl` record. Pure — no I/O.
+fn build_failopen_record(
+    reason: &str,
+    namespace: Option<&str>,
+    subcommand: Option<&str>,
+    binary_version: &str,
+) -> Value {
+    json!({
+        "schemaVersion": FAILOPEN_SCHEMA_VERSION,
+        "reason": reason,
+        "namespace": namespace,
+        "subcommand": subcommand,
+        "binaryVersion": binary_version,
+        "ts": common::utc_timestamp(),
+    })
+}
+
+/// Append one fail-open event to `<metrics_dir>/failopen.jsonl`.
+///
+/// `reason` names the degradation (`"panic"` | `"parse"` | `"version_mismatch"`),
+/// `namespace` / `subcommand` are the CLI position that triggered it when known
+/// (`None` when the call site can't determine one — e.g. the global panic
+/// hook has no `Check`/`Logger` in scope), and `binary_version` is this
+/// process's own `CARGO_PKG_VERSION` — plain log metadata distinguishing this
+/// row from any session-level version stamp.
+///
+/// Fully fail-open (ADR-0001): a missing dir it can't create, or a failed open
+/// / write, degrades to a no-op — the caller's exit path is untouched.
+pub fn log_failopen(
+    reason: &str,
+    namespace: Option<&str>,
+    subcommand: Option<&str>,
+    binary_version: &str,
+) {
+    let record = build_failopen_record(reason, namespace, subcommand, binary_version);
+
+    let dir = common::metrics_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join("failopen.jsonl");
+
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        // One `write_all` of the record + newline, so a concurrent append from
+        // another session can't interleave a record with its trailing newline.
+        let mut line = record.to_string();
+        line.push('\n');
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+/// Fail-open row counts within a time window, grouped by `reason`.
+///
+/// `version_mismatch` is pre-filtered (by [`recent_failopen_counts`]) to rows
+/// whose `binaryVersion` equals the caller's `current_version` — see that
+/// function's doc for why.
+#[derive(Debug, PartialEq, Eq, Default)]
+pub struct FailopenCounts {
+    pub panic: u64,
+    pub parse: u64,
+    pub version_mismatch: u64,
+}
+
+/// Count `failopen.jsonl` rows within `window` of `now`, filtered by `reason`
+/// and (when `version_filter` is `Some`) an exact `binaryVersion` match. Pure
+/// — operates on file contents, no I/O.
+///
+/// `ts` is compared lexicographically against `cutoff` — valid because both
+/// are the same fixed-width ISO 8601 (`%Y-%m-%dT%H:%M:%SZ`) shape, which sorts
+/// identically to chronological order. Unparsable rows and rows missing a
+/// required field are skipped, not counted.
+fn count_recent(jsonl: &str, cutoff: &str, reason: &str, version_filter: Option<&str>) -> u64 {
+    jsonl
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|v| v.get("reason").and_then(Value::as_str) == Some(reason))
+        .filter(|v| {
+            v.get("ts")
+                .and_then(Value::as_str)
+                .is_some_and(|ts| ts >= cutoff)
+        })
+        .filter(|v| match version_filter {
+            Some(want) => v.get("binaryVersion").and_then(Value::as_str) == Some(want),
+            None => true,
+        })
+        .count() as u64
+}
+
+/// Count `failopen.jsonl` rows within `window` of `now`, grouped by `reason`.
+///
+/// `version_mismatch` counts ONLY rows whose `binaryVersion` equals
+/// `current_version` (the caller's own running binary version) — this is the
+/// deliberate reconciliation for a sanctioned new-hooks.json+old-binary release
+/// transition: a `version_mismatch` row logged by an *older* binary hitting a
+/// subcommand a newer hooks.json expects (or vice versa) is expected noise
+/// during a rollout and must not alarm. A recurrence tagged with the CURRENT
+/// binary's own version means the skew didn't resolve, which is what's worth
+/// surfacing. `panic`/`parse` counts are NOT version-filtered — any occurrence
+/// on any version is worth counting.
+///
+/// Fail-open: a missing/unreadable `<dir>/failopen.jsonl`, or any unparsable
+/// row, contributes 0 / is skipped rather than erroring. Doctor visibility
+/// only — never gates anything.
+pub fn recent_failopen_counts(
+    dir: &Path,
+    window: Duration,
+    now: SystemTime,
+    current_version: &str,
+) -> FailopenCounts {
+    let Ok(contents) = std::fs::read_to_string(dir.join("failopen.jsonl")) else {
+        return FailopenCounts::default();
+    };
+    let cutoff_ts =
+        jiff::Timestamp::try_from(now.checked_sub(window).unwrap_or(SystemTime::UNIX_EPOCH))
+            .unwrap_or(jiff::Timestamp::UNIX_EPOCH);
+    let cutoff = cutoff_ts.strftime("%Y-%m-%dT%H:%M:%SZ").to_string();
+
+    FailopenCounts {
+        panic: count_recent(&contents, &cutoff, "panic", None),
+        parse: count_recent(&contents, &cutoff, "parse", None),
+        version_mismatch: count_recent(
+            &contents,
+            &cutoff,
+            "version_mismatch",
+            Some(current_version),
+        ),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::ENV_LOCK;
+
+    // --- record shape ---
+
+    #[test]
+    fn record_has_expected_fields_for_panic() {
+        let rec = build_failopen_record("panic", Some("cadence"), Some("terminology"), "1.2.3");
+        assert_eq!(rec["schemaVersion"], 1);
+        assert_eq!(rec["reason"], "panic");
+        assert_eq!(rec["namespace"], "cadence");
+        assert_eq!(rec["subcommand"], "terminology");
+        assert_eq!(rec["binaryVersion"], "1.2.3");
+        assert!(rec["ts"].is_string());
+    }
+
+    #[test]
+    fn record_has_expected_fields_for_parse() {
+        let rec = build_failopen_record("parse", Some("metrics"), Some("log-subagent"), "0.50.0");
+        assert_eq!(rec["reason"], "parse");
+        assert_eq!(rec["namespace"], "metrics");
+        assert_eq!(rec["subcommand"], "log-subagent");
+        assert_eq!(rec["binaryVersion"], "0.50.0");
+    }
+
+    #[test]
+    fn record_has_expected_fields_for_version_mismatch() {
+        let rec = build_failopen_record(
+            "version_mismatch",
+            Some("future-plugin"),
+            Some("some-hook"),
+            "0.50.0",
+        );
+        assert_eq!(rec["reason"], "version_mismatch");
+        assert_eq!(rec["namespace"], "future-plugin");
+        assert_eq!(rec["subcommand"], "some-hook");
+    }
+
+    #[test]
+    fn record_nulls_namespace_and_subcommand_when_unknown() {
+        let rec = build_failopen_record("panic", None, None, "0.50.0");
+        assert_eq!(rec["reason"], "panic");
+        assert!(rec["namespace"].is_null());
+        assert!(rec["subcommand"].is_null());
+        assert_eq!(rec["binaryVersion"], "0.50.0");
+    }
+
+    // --- log_failopen end-to-end (tempdir) ---
+
+    fn with_metrics_dir<F: FnOnce()>(dir: &std::path::Path, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test via ENV_LOCK.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", dir);
+        }
+        f();
+        // SAFETY: serialized against every other env-mutating test via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+        }
+    }
+
+    fn read_lines(dir: &std::path::Path) -> Vec<Value> {
+        let path = dir.join("failopen.jsonl");
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str(l).expect("each line is valid JSON"))
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    #[test]
+    fn log_failopen_writes_one_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_failopen("parse", Some("cadence"), Some("terminology"), "1.2.3");
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["reason"], "parse");
+        assert_eq!(rows[0]["namespace"], "cadence");
+        assert_eq!(rows[0]["subcommand"], "terminology");
+        assert_eq!(rows[0]["binaryVersion"], "1.2.3");
+    }
+
+    #[test]
+    fn log_failopen_writes_null_fields_when_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_failopen("panic", None, None, "0.50.0");
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["reason"], "panic");
+        assert!(rows[0]["namespace"].is_null());
+        assert!(rows[0]["subcommand"].is_null());
+    }
+
+    // --- count_recent (pure) ---
+
+    fn sample_jsonl() -> String {
+        [
+            r#"{"reason":"panic","binaryVersion":"1.0.0","ts":"2026-07-08T00:00:00Z"}"#,
+            r#"{"reason":"parse","binaryVersion":"1.0.0","ts":"2026-07-08T00:00:00Z"}"#,
+            r#"{"reason":"parse","binaryVersion":"1.0.0","ts":"2026-07-08T00:00:00Z"}"#,
+            r#"{"reason":"version_mismatch","binaryVersion":"0.9.0","ts":"2026-07-08T00:00:00Z"}"#,
+            r#"{"reason":"version_mismatch","binaryVersion":"1.0.0","ts":"2026-07-08T00:00:00Z"}"#,
+            r#"{"reason":"panic","binaryVersion":"1.0.0","ts":"2000-01-01T00:00:00Z"}"#,
+            "not json at all",
+        ]
+        .join("\n")
+    }
+
+    #[test]
+    fn count_recent_filters_by_reason_and_window() {
+        let jsonl = sample_jsonl();
+        let cutoff = "2026-07-01T00:00:00Z";
+        assert_eq!(count_recent(&jsonl, cutoff, "panic", None), 1);
+        assert_eq!(count_recent(&jsonl, cutoff, "parse", None), 2);
+        assert_eq!(count_recent("", cutoff, "panic", None), 0);
+    }
+
+    #[test]
+    fn count_recent_version_filter_scopes_version_mismatch() {
+        let jsonl = sample_jsonl();
+        let cutoff = "2026-07-01T00:00:00Z";
+        assert_eq!(
+            count_recent(&jsonl, cutoff, "version_mismatch", Some("1.0.0")),
+            1
+        );
+        assert_eq!(
+            count_recent(&jsonl, cutoff, "version_mismatch", Some("0.9.0")),
+            1
+        );
+        assert_eq!(
+            count_recent(&jsonl, cutoff, "version_mismatch", Some("2.0.0")),
+            0
+        );
+        assert_eq!(count_recent(&jsonl, cutoff, "version_mismatch", None), 2);
+    }
+
+    #[test]
+    fn count_recent_garbage_lines_skipped_not_panicking() {
+        assert_eq!(
+            count_recent("not json\n{}\n", "2026-01-01T00:00:00Z", "panic", None),
+            0
+        );
+    }
+
+    // --- recent_failopen_counts end-to-end (tempdir) ---
+
+    #[test]
+    fn recent_failopen_counts_missing_file_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        let counts = recent_failopen_counts(
+            tmp.path(),
+            Duration::from_secs(7 * 86_400),
+            SystemTime::now(),
+            "1.0.0",
+        );
+        assert_eq!(counts, FailopenCounts::default());
+    }
+
+    #[test]
+    fn recent_failopen_counts_groups_by_reason_and_current_version() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_failopen("panic", Some("cadence"), Some("terminology"), "1.0.0");
+            log_failopen("parse", Some("cadence"), Some("terminology"), "1.0.0");
+            // Old-version mismatch: the sanctioned rollout transition — excluded.
+            log_failopen("version_mismatch", Some("future"), Some("hook"), "0.9.0");
+            // Current-version mismatch: didn't resolve — counted.
+            log_failopen("version_mismatch", Some("future"), Some("hook"), "1.0.0");
+        });
+        let counts = recent_failopen_counts(
+            tmp.path(),
+            Duration::from_secs(7 * 86_400),
+            SystemTime::now(),
+            "1.0.0",
+        );
+        assert_eq!(
+            counts,
+            FailopenCounts {
+                panic: 1,
+                parse: 1,
+                version_mismatch: 1,
+            }
+        );
+    }
+
+    #[test]
+    fn recent_failopen_counts_excludes_outside_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old_row = r#"{"schemaVersion":1,"reason":"panic","namespace":null,"subcommand":null,"binaryVersion":"1.0.0","ts":"2000-01-01T00:00:00Z"}"#;
+        std::fs::write(tmp.path().join("failopen.jsonl"), format!("{old_row}\n")).unwrap();
+        let counts = recent_failopen_counts(
+            tmp.path(),
+            Duration::from_secs(7 * 86_400),
+            SystemTime::now(),
+            "1.0.0",
+        );
+        assert_eq!(counts, FailopenCounts::default());
+    }
+}

--- a/crates/metrics/src/log_sweep.rs
+++ b/crates/metrics/src/log_sweep.rs
@@ -1,0 +1,250 @@
+//! Append-only telemetry for `sweep_stale` (the reaper that removes aged-out
+//! session-registry files) — one line per reaped file to
+//! `<metrics_dir>/sweeps.jsonl`. Cross-machine/cross-session liveness sweeps
+//! were previously invisible; this makes them observable.
+//!
+//! A **free function**, not a [`cadence_hooks_core::Logger`] impl: unlike the
+//! `Logger` loggers (wired through the normal hook-dispatch path), this is
+//! called directly from `cadence-hooks-session`'s `sweep_stale`, which fires
+//! from both the PostToolUse heartbeat and `session start` — neither of which
+//! is itself a dispatched `Logger`.
+//!
+//! Fully fail-open (ADR-0001): every step degrades to a no-op — a full disk or
+//! a read-only metrics dir must never perturb the reap it is recording.
+
+use crate::common;
+use serde_json::{Value, json};
+use std::io::Write;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+
+/// Schema version stamped on every `sweeps.jsonl` row. A new stream (cadence#238
+/// convention) — does not share `common`'s existing version constants.
+const SWEEP_SCHEMA_VERSION: u32 = 1;
+
+/// Build the `sweeps.jsonl` record. Pure — no I/O.
+fn build_sweep_record(
+    trigger: &str,
+    session_id: Option<&str>,
+    name: Option<&str>,
+    age_secs: u64,
+) -> Value {
+    json!({
+        "schemaVersion": SWEEP_SCHEMA_VERSION,
+        "trigger": trigger,
+        "sessionId": session_id,
+        "name": name,
+        "ageSecs": age_secs,
+        "ts": common::utc_timestamp(),
+    })
+}
+
+/// Append one sweep event to `<metrics_dir>/sweeps.jsonl`.
+///
+/// `trigger` names the call site (`"heartbeat"` | `"start"`), `session_id` /
+/// `name` are the reaped record's identity when it could be parsed (`None`
+/// when the file was garbage or unreadable — the parse is best-effort and
+/// must never gate the delete it's recording), and `age_secs` is the file's
+/// mtime age at reap time.
+///
+/// Fully fail-open (ADR-0001): a missing dir it can't create, or a failed open
+/// / write, degrades to a no-op — the caller's delete is untouched.
+pub fn log_sweep(trigger: &str, session_id: Option<&str>, name: Option<&str>, age_secs: u64) {
+    let record = build_sweep_record(trigger, session_id, name, age_secs);
+
+    let dir = common::metrics_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    let path = dir.join("sweeps.jsonl");
+
+    if let Ok(mut file) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(&path)
+    {
+        // One `write_all` of the record + newline, so a concurrent append from
+        // another session can't interleave a record with its trailing newline.
+        let mut line = record.to_string();
+        line.push('\n');
+        let _ = file.write_all(line.as_bytes());
+    }
+}
+
+/// Count `sweeps.jsonl` rows whose `ts` is within `window` of `now`. Pure —
+/// operates on file contents, no I/O. Patterned on `log_session::count_commits`.
+///
+/// A row's `ts` is compared lexicographically against `cutoff` — valid because
+/// both are the same fixed-width ISO 8601 (`%Y-%m-%dT%H:%M:%SZ`) shape, which
+/// sorts identically to chronological order. Unparsable rows and rows missing
+/// `ts` are skipped, not counted.
+fn count_recent(jsonl: &str, cutoff: &str) -> u64 {
+    jsonl
+        .lines()
+        .filter_map(|line| serde_json::from_str::<Value>(line).ok())
+        .filter(|v| {
+            v.get("ts")
+                .and_then(Value::as_str)
+                .is_some_and(|ts| ts >= cutoff)
+        })
+        .count() as u64
+}
+
+/// Count `sweeps.jsonl` rows within `window` of `now`.
+///
+/// Fail-open: a missing/unreadable `<dir>/sweeps.jsonl`, or any unparsable
+/// row, contributes 0 / is skipped rather than erroring. Doctor visibility
+/// only — never gates anything.
+pub fn recent_sweep_count(dir: &Path, window: Duration, now: SystemTime) -> u64 {
+    let Ok(contents) = std::fs::read_to_string(dir.join("sweeps.jsonl")) else {
+        return 0;
+    };
+    let cutoff_ts =
+        jiff::Timestamp::try_from(now.checked_sub(window).unwrap_or(SystemTime::UNIX_EPOCH))
+            .unwrap_or(jiff::Timestamp::UNIX_EPOCH);
+    let cutoff = cutoff_ts.strftime("%Y-%m-%dT%H:%M:%SZ").to_string();
+    count_recent(&contents, &cutoff)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::common::ENV_LOCK;
+
+    // --- record shape ---
+
+    #[test]
+    fn record_has_expected_fields_with_identity() {
+        let rec = build_sweep_record("heartbeat", Some("sess-1"), Some("quiet-loom"), 1800);
+        assert_eq!(rec["schemaVersion"], 1);
+        assert_eq!(rec["trigger"], "heartbeat");
+        assert_eq!(rec["sessionId"], "sess-1");
+        assert_eq!(rec["name"], "quiet-loom");
+        assert_eq!(rec["ageSecs"], 1800);
+        assert!(rec["ts"].is_string());
+    }
+
+    #[test]
+    fn record_nulls_identity_when_unparsable() {
+        let rec = build_sweep_record("start", None, None, 42);
+        assert_eq!(rec["trigger"], "start");
+        assert!(rec["sessionId"].is_null());
+        assert!(rec["name"].is_null());
+        assert_eq!(rec["ageSecs"], 42);
+    }
+
+    // --- log_sweep end-to-end (tempdir) ---
+
+    fn with_metrics_dir<F: FnOnce()>(dir: &std::path::Path, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test via ENV_LOCK.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", dir);
+        }
+        f();
+        // SAFETY: serialized against every other env-mutating test via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+        }
+    }
+
+    fn read_lines(dir: &std::path::Path) -> Vec<Value> {
+        let path = dir.join("sweeps.jsonl");
+        match std::fs::read_to_string(&path) {
+            Ok(contents) => contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str(l).expect("each line is valid JSON"))
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    #[test]
+    fn log_sweep_writes_one_line() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_sweep("heartbeat", Some("sess-1"), Some("quiet-loom"), 1800);
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["trigger"], "heartbeat");
+        assert_eq!(rows[0]["sessionId"], "sess-1");
+        assert_eq!(rows[0]["name"], "quiet-loom");
+        assert_eq!(rows[0]["ageSecs"], 1800);
+    }
+
+    #[test]
+    fn log_sweep_writes_null_identity_when_none() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_sweep("start", None, None, 99);
+        });
+        let rows = read_lines(tmp.path());
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["trigger"], "start");
+        assert!(rows[0]["sessionId"].is_null());
+        assert!(rows[0]["name"].is_null());
+    }
+
+    // --- count_recent (pure) ---
+
+    #[test]
+    fn count_recent_counts_rows_at_or_after_cutoff() {
+        let jsonl = [
+            r#"{"ts":"2026-07-01T00:00:00Z"}"#,
+            r#"{"ts":"2026-07-08T00:00:00Z"}"#,
+            r#"{"ts":"2026-07-09T00:00:00Z"}"#,
+            "not json at all",
+            r#"{"noTs":true}"#,
+        ]
+        .join("\n");
+        assert_eq!(count_recent(&jsonl, "2026-07-08T00:00:00Z"), 2);
+        assert_eq!(count_recent(&jsonl, "2026-07-09T00:00:00Z"), 1);
+        assert_eq!(count_recent(&jsonl, "2026-07-10T00:00:00Z"), 0);
+        assert_eq!(count_recent("", "2026-07-08T00:00:00Z"), 0);
+    }
+
+    // --- recent_sweep_count end-to-end (tempdir) ---
+
+    #[test]
+    fn recent_sweep_count_missing_file_is_zero() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert_eq!(
+            recent_sweep_count(
+                tmp.path(),
+                Duration::from_secs(7 * 86_400),
+                SystemTime::now()
+            ),
+            0
+        );
+    }
+
+    #[test]
+    fn recent_sweep_count_counts_within_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        with_metrics_dir(tmp.path(), || {
+            log_sweep("heartbeat", Some("sess-1"), Some("quiet-loom"), 1800);
+            log_sweep("start", None, None, 42);
+        });
+        let count = recent_sweep_count(
+            tmp.path(),
+            Duration::from_secs(7 * 86_400),
+            SystemTime::now(),
+        );
+        assert_eq!(count, 2);
+    }
+
+    #[test]
+    fn recent_sweep_count_excludes_outside_window() {
+        let tmp = tempfile::tempdir().unwrap();
+        let old_row = r#"{"schemaVersion":1,"trigger":"start","sessionId":null,"name":null,"ageSecs":1,"ts":"2000-01-01T00:00:00Z"}"#;
+        std::fs::write(tmp.path().join("sweeps.jsonl"), format!("{old_row}\n")).unwrap();
+        let count = recent_sweep_count(
+            tmp.path(),
+            Duration::from_secs(7 * 86_400),
+            SystemTime::now(),
+        );
+        assert_eq!(count, 0);
+    }
+}

--- a/crates/session/Cargo.toml
+++ b/crates/session/Cargo.toml
@@ -7,6 +7,7 @@ description = "Multi-session coordination hooks: identity registry, disclosure, 
 
 [dependencies]
 cadence-hooks-core.workspace = true
+cadence-hooks-metrics.workspace = true
 serde = { workspace = true }
 serde_json.workspace = true
 

--- a/crates/session/src/heartbeat.rs
+++ b/crates/session/src/heartbeat.rs
@@ -84,7 +84,7 @@ pub fn run_heartbeat(
     // exclusion in `sweep_stale` is then defense-in-depth — our file is fresh
     // regardless.
     let _ = registry::touch_own(dir, session_id, branch, is_self_switch);
-    registry::sweep_stale(dir, stale_secs, session_id);
+    registry::sweep_stale(dir, stale_secs, session_id, "heartbeat");
 }
 
 #[cfg(test)]
@@ -319,8 +319,12 @@ mod tests {
         registry::write_record(dir, &live).unwrap();
 
         // Our heartbeat fires with a zero-second staleness threshold: any
-        // measurable age (whole seconds) is stale.
-        run_heartbeat(dir, "self-session", Some("main".into()), None, 0);
+        // measurable age (whole seconds) is stale. Reaping fires log_sweep
+        // (#259) — scratch-dir-scoped so this doesn't race the sweep-telemetry
+        // tests in `registry` over the process-global CADENCE_METRICS_DIR.
+        registry::test_metrics_env::with_scratch_metrics_dir(|| {
+            run_heartbeat(dir, "self-session", Some("main".into()), None, 0);
+        });
 
         assert!(
             registry::find_own(dir, "dead-sess").is_none(),
@@ -355,7 +359,11 @@ mod tests {
         }
         std::thread::sleep(std::time::Duration::from_millis(1100));
 
-        run_heartbeat(dir, "self-session", Some("main".into()), None, 0);
+        // Reaping fires log_sweep (#259) — scratch-dir-scoped, see the
+        // sibling test above.
+        registry::test_metrics_env::with_scratch_metrics_dir(|| {
+            run_heartbeat(dir, "self-session", Some("main".into()), None, 0);
+        });
 
         assert!(
             registry::find_own(dir, "sess-a").is_none(),

--- a/crates/session/src/registry.rs
+++ b/crates/session/src/registry.rs
@@ -293,7 +293,15 @@ pub fn touch_own(
 /// (`session start` and the PostToolUse heartbeat) refresh their own mtime
 /// first, so the exclusion is defense-in-depth against a self-sweep. Pass
 /// `""` to sweep everything (CLI/tests with no own session).
-pub fn sweep_stale(dir: &Path, stale_secs: u64, own_session_id: &str) {
+///
+/// `trigger` names the call site (`"heartbeat"` | `"start"`) and is threaded
+/// through to [`cadence_hooks_metrics::log_sweep`] for every reaped file, so
+/// cross-machine/cross-session liveness sweeps become observable (#259). Each
+/// reaped file is best-effort re-parsed as a [`SessionRecord`] to recover its
+/// `name`/`session_id` for the log row — this parse is ONLY for telemetry and
+/// never gates or blocks the delete; an unparsable file still logs (with
+/// `None`/`None`) and still gets reaped.
+pub fn sweep_stale(dir: &Path, stale_secs: u64, own_session_id: &str, trigger: &str) {
     let Ok(entries) = fs::read_dir(dir) else {
         return;
     };
@@ -315,6 +323,15 @@ pub fn sweep_stale(dir: &Path, stale_secs: u64, own_session_id: &str) {
         if let Some(age) = mtime_age_secs(&path)
             && age > stale_secs
         {
+            let record = fs::read_to_string(&path)
+                .ok()
+                .and_then(|t| serde_json::from_str::<SessionRecord>(&t).ok());
+            cadence_hooks_metrics::log_sweep(
+                trigger,
+                record.as_ref().map(|r| r.session_id.as_str()),
+                record.as_ref().map(|r| r.name.as_str()),
+                age,
+            );
             let _ = fs::remove_file(&path);
         }
     }
@@ -380,6 +397,48 @@ fn is_symlink(path: &Path) -> bool {
     fs::symlink_metadata(path)
         .map(|m| m.file_type().is_symlink())
         .unwrap_or(false)
+}
+
+/// Shared test support for `CADENCE_METRICS_DIR`, the process-global env var
+/// [`cadence_hooks_metrics::log_sweep`] reads. `sweep_stale` now fires that
+/// logger on every real reap (#259), so ANY test in this crate that ages a
+/// file past its staleness threshold — not just the sweep-telemetry tests
+/// below — touches this var and must serialize against every other one, or
+/// race and either pollute the real `~/.claude/metrics` dir or write into a
+/// sibling test's tempdir. `pub(crate)` so `heartbeat` and `start`'s test
+/// modules (separate files) can reuse the same lock instance — a second,
+/// unrelated `Mutex` would not actually serialize anything.
+#[cfg(test)]
+pub(crate) mod test_metrics_env {
+    use std::sync::Mutex;
+
+    pub(crate) static METRICS_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+    /// Run `f` with `CADENCE_METRICS_DIR` pinned to `dir` for its duration.
+    pub(crate) fn with_metrics_dir<T>(dir: &std::path::Path, f: impl FnOnce() -> T) -> T {
+        let _guard = METRICS_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test via
+        // METRICS_ENV_LOCK.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", dir);
+        }
+        let result = f();
+        // SAFETY: serialized against every other env-mutating test via
+        // METRICS_ENV_LOCK.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+        }
+        result
+    }
+
+    /// Convenience for a test that doesn't inspect `sweeps.jsonl` itself but
+    /// still reaps a real file (and so fires `log_sweep`) — a throwaway
+    /// tempdir keeps the write off the real metrics dir and off the lock
+    /// window without the caller needing to build its own `TempDir`.
+    pub(crate) fn with_scratch_metrics_dir<T>(f: impl FnOnce() -> T) -> T {
+        let tmp = tempfile::TempDir::new().unwrap();
+        with_metrics_dir(tmp.path(), f)
+    }
 }
 
 #[cfg(test)]
@@ -693,7 +752,9 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(1100));
         write_record(&dir, &record("fresh-face", "new-session")).unwrap();
         // stale_secs = 0: the old file (age ≥ 1s) is stale, the fresh one (age 0) is not.
-        sweep_stale(&dir, 0, "");
+        // Reaping fires log_sweep (#259) — scratch-dir-scoped so this doesn't
+        // race the sweep-telemetry tests below over CADENCE_METRICS_DIR.
+        test_metrics_env::with_scratch_metrics_dir(|| sweep_stale(&dir, 0, "", "test"));
         assert!(find_own(&dir, "old-session").is_none(), "stale swept");
         assert!(find_own(&dir, "new-session").is_some(), "fresh kept");
     }
@@ -708,7 +769,7 @@ mod tests {
         write_record(&dir, &record("the-peer", "peer-session")).unwrap();
         std::thread::sleep(std::time::Duration::from_millis(1100));
         // stale_secs = 0: both files have aged ≥ 1s, but own is excluded by sid.
-        sweep_stale(&dir, 0, "own-session");
+        test_metrics_env::with_scratch_metrics_dir(|| sweep_stale(&dir, 0, "own-session", "test"));
         assert!(
             find_own(&dir, "own-session").is_some(),
             "own aged file is NOT swept"
@@ -732,7 +793,7 @@ mod tests {
         let peer_file = dir.join("beta-anvil.session-.json");
         std::thread::sleep(std::time::Duration::from_millis(1100));
         // stale_secs = 0: both files have aged ≥ 1s; own is spared by session_id.
-        sweep_stale(&dir, 0, "session-1");
+        test_metrics_env::with_scratch_metrics_dir(|| sweep_stale(&dir, 0, "session-1", "test"));
         assert!(
             own_file.exists(),
             "own file kept (spared by exact session_id)"
@@ -745,7 +806,95 @@ mod tests {
 
     #[test]
     fn sweep_missing_directory_is_noop() {
-        sweep_stale(Path::new("/nonexistent/sessions"), 0, "");
+        sweep_stale(Path::new("/nonexistent/sessions"), 0, "", "test");
+    }
+
+    // --- sweep telemetry (#259) ---
+    //
+    // `CADENCE_METRICS_DIR` is process-global. These tests use the shared
+    // `test_metrics_env::with_metrics_dir` (rather than a module-local lock)
+    // because it's the SAME lock every other test in this crate that reaps a
+    // real file serializes against — a second, independent `Mutex` here would
+    // not actually prevent a concurrent unrelated reap from racing these
+    // assertions (see `test_metrics_env`'s doc comment).
+
+    use test_metrics_env::with_metrics_dir;
+
+    fn read_sweep_lines(metrics_dir: &std::path::Path) -> Vec<serde_json::Value> {
+        let path = metrics_dir.join("sweeps.jsonl");
+        match fs::read_to_string(&path) {
+            Ok(contents) => contents
+                .lines()
+                .filter(|l| !l.is_empty())
+                .map(|l| serde_json::from_str(l).expect("each line is valid JSON"))
+                .collect(),
+            Err(_) => vec![],
+        }
+    }
+
+    #[test]
+    fn sweep_logs_reaped_file_identity_and_trigger() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("sessions");
+        write_record(&dir, &record("old-timer", "old-session")).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        let metrics_dir = tmp.path().join("metrics");
+        with_metrics_dir(&metrics_dir, || {
+            sweep_stale(&dir, 0, "", "heartbeat");
+        });
+
+        assert!(find_own(&dir, "old-session").is_none(), "stale file reaped");
+        let rows = read_sweep_lines(&metrics_dir);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["trigger"], "heartbeat");
+        assert_eq!(rows[0]["sessionId"], "old-session");
+        assert_eq!(rows[0]["name"], "old-timer");
+    }
+
+    #[test]
+    fn sweep_reaps_file_even_when_metrics_dir_uncreatable() {
+        // A pre-existing FILE at the metrics-dir path makes `create_dir_all`
+        // fail inside `log_sweep`. The reap itself must be entirely unaffected
+        // by that failure — log_sweep's fail-open contract (ADR-0001).
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("sessions");
+        write_record(&dir, &record("old-timer", "old-session")).unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        let blocked_metrics_path = tmp.path().join("metrics-blocked");
+        fs::write(&blocked_metrics_path, b"not a directory").unwrap();
+
+        with_metrics_dir(&blocked_metrics_path, || {
+            sweep_stale(&dir, 0, "", "heartbeat");
+        });
+
+        assert!(
+            find_own(&dir, "old-session").is_none(),
+            "stale file reaped even though the metrics dir write failed"
+        );
+    }
+
+    #[test]
+    fn sweep_reaps_and_logs_null_identity_for_unparsable_file() {
+        let tmp = TempDir::new().unwrap();
+        let dir = tmp.path().join("sessions");
+        fs::create_dir_all(&dir).unwrap();
+        let garbage_path = dir.join("garbage.deadbeef.json");
+        fs::write(&garbage_path, "not json {{").unwrap();
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+
+        let metrics_dir = tmp.path().join("metrics");
+        with_metrics_dir(&metrics_dir, || {
+            sweep_stale(&dir, 0, "", "start");
+        });
+
+        assert!(!garbage_path.exists(), "unparsable file still reaped");
+        let rows = read_sweep_lines(&metrics_dir);
+        assert_eq!(rows.len(), 1);
+        assert_eq!(rows[0]["trigger"], "start");
+        assert!(rows[0]["sessionId"].is_null());
+        assert!(rows[0]["name"].is_null());
     }
 
     // --- deregister (remove_own, #97) ---

--- a/crates/session/src/start.rs
+++ b/crates/session/src/start.rs
@@ -110,7 +110,7 @@ pub fn run_start(
 
     // Housekeeping: presumed-dead peers leave the room before roll call. Our
     // own (just-refreshed) file is excluded by sid as defense-in-depth.
-    registry::sweep_stale(dir, stale_secs, sid);
+    registry::sweep_stale(dir, stale_secs, sid, "start");
 
     // Disclose live peers, if any.
     let peers = registry::live_peers(dir, sid, stale_secs);
@@ -341,8 +341,13 @@ mod tests {
         std::thread::sleep(std::time::Duration::from_millis(1100));
 
         // stale_secs = 0: any measurable age (whole seconds) counts as stale.
+        // Reaping fires log_sweep (#259) — scratch-dir-scoped so this doesn't
+        // race the sweep-telemetry tests in `registry` over the
+        // process-global CADENCE_METRICS_DIR.
         let input = make_session_with_cwd("self-session", "startup", "/tmp");
-        let r = run_start(&input, tmp.path(), None, 0);
+        let r = registry::test_metrics_env::with_scratch_metrics_dir(|| {
+            run_start(&input, tmp.path(), None, 0)
+        });
         assert_eq!(r.outcome, Outcome::Allow, "stale peers are ignored");
         assert!(
             registry::read_own(tmp.path(), "peer-session").is_none(),

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -35,10 +35,19 @@ use std::time::Instant;
 pub fn run_logged_check(check: &dyn Check, event: HookEvent, hook: Option<&str>) -> ! {
     let started = Instant::now();
     guard_interactive_terminal(check.name(), Some(event), None);
+    // Hoisted above the stdin parse so both the parse-failure arm and the
+    // decided-result arm below can record against the same canonical name.
+    let hook_name = hook.unwrap_or_else(|| check.name());
     let input = match HookInput::from_stdin() {
         Ok(input) => input,
         Err(e) => {
             eprintln!("cadence-hooks: {e}");
+            cadence_hooks_metrics::log_failopen(
+                "parse",
+                crate::registry::plugin_for(hook_name),
+                Some(hook_name),
+                env!("CARGO_PKG_VERSION"),
+            );
             process::exit(0); // Fail open on parse errors (ADR-0001)
         }
     };
@@ -48,7 +57,6 @@ pub fn run_logged_check(check: &dyn Check, event: HookEvent, hook: Option<&str>)
         Some(result) => {
             // Record before emitting. Both writes are fully fail-open, so neither
             // can perturb the block message or the exit code that follows.
-            let hook_name = hook.unwrap_or_else(|| check.name());
             cadence_hooks_metrics::log_denial(hook_name, event, &input, result.outcome);
             // A bypass-allow rode through an active dismissal / env switch. Record
             // *that a guard was stepped outside of* — the one event the denial log
@@ -91,21 +99,40 @@ pub fn run_logged_logger(
 ) -> ! {
     let started = Instant::now();
     guard_interactive_terminal(logger.name(), None, sample_override);
+    let namespace = crate::registry::plugin_for(hook.unwrap_or(""));
     // Capture the session id (when the payload carries one) for the timing row;
     // a parse failure leaves it `None`, matching core's fail-open-to-exit-0 path.
     let mut session_id: Option<String> = None;
-    if let Ok(input) = MetricsInput::from_stdin() {
-        session_id = input.session_id.clone();
-        // A panicking logger must not skip the timing write or the exit-0 below.
-        // Catch the unwind so the contract holds even on a buggy implementation.
-        // `AssertUnwindSafe` is required because `&dyn Logger` is not
-        // `UnwindSafe`; we exit immediately afterward, so there is no post-panic
-        // state to corrupt.
-        let _ = catch_unwind(AssertUnwindSafe(|| logger.run(&input)));
+    match MetricsInput::from_stdin() {
+        Ok(input) => {
+            session_id = input.session_id.clone();
+            // A panicking logger must not skip the timing write or the exit-0
+            // below. Catch the unwind so the contract holds even on a buggy
+            // implementation. `AssertUnwindSafe` is required because
+            // `&dyn Logger` is not `UnwindSafe`; we exit immediately
+            // afterward, so there is no post-panic state to corrupt.
+            let result = catch_unwind(AssertUnwindSafe(|| logger.run(&input)));
+            if result.is_err() {
+                cadence_hooks_metrics::log_failopen(
+                    "panic",
+                    namespace,
+                    hook,
+                    env!("CARGO_PKG_VERSION"),
+                );
+            }
+        }
+        Err(_) => {
+            cadence_hooks_metrics::log_failopen(
+                "parse",
+                namespace,
+                hook,
+                env!("CARGO_PKG_VERSION"),
+            );
+        }
     }
     cadence_hooks_metrics::log_timing(
         hook.unwrap_or("unknown"),
-        crate::registry::plugin_for(hook.unwrap_or("")).unwrap_or("metrics"),
+        namespace.unwrap_or("metrics"),
         "logger",
         started.elapsed().as_millis(),
         session_id.as_deref(),

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -458,6 +458,99 @@ fn staleness_finding(dir: &Path, threshold: Duration, now: SystemTime) -> Option
     })
 }
 
+/// Fail-open telemetry as doctor `Finding`s — up to 3 (one per `reason`), or
+/// none when all counts are below their thresholds. `panic` and `parse` are
+/// warned on any/moderate occurrence; `version_mismatch` only counts rows
+/// tagged with the CURRENT binary's own version (see
+/// `log_failopen::recent_failopen_counts`'s doc) — an older-version row is the
+/// sanctioned release-transition case and is excluded by construction.
+fn failopen_findings(
+    dir: &Path,
+    window: Duration,
+    now: SystemTime,
+    current_version: &str,
+) -> Vec<Finding> {
+    let counts = cadence_hooks_metrics::log_failopen::recent_failopen_counts(
+        dir,
+        window,
+        now,
+        current_version,
+    );
+    let days = window.as_secs() / 86_400;
+    let mut findings = Vec::new();
+
+    if counts.panic >= 1 {
+        findings.push(Finding {
+            severity: Severity::Warning,
+            plugin: "cadence-metrics".to_string(),
+            file: dir.to_path_buf(),
+            line: None,
+            snippet: format!("panic: {}", counts.panic),
+            diagnosis: format!(
+                "{} panic(s) in the last {days} days (failopen.jsonl)",
+                counts.panic
+            ),
+            remediation: "a panic in a check/logger is always a bug — inspect \
+                          failopen.jsonl for the namespace/subcommand and file an issue"
+                .to_string(),
+        });
+    }
+
+    if counts.parse >= 3 {
+        findings.push(Finding {
+            severity: Severity::Warning,
+            plugin: "cadence-metrics".to_string(),
+            file: dir.to_path_buf(),
+            line: None,
+            snippet: format!("parse: {}", counts.parse),
+            diagnosis: format!(
+                "{} stdin-parse failure(s) in the last {days} days (failopen.jsonl)",
+                counts.parse
+            ),
+            remediation: "occasional malformed payloads are tolerated; 3+ suggests \
+                          a wiring problem feeding this binary bad stdin — inspect \
+                          failopen.jsonl"
+                .to_string(),
+        });
+    }
+
+    if counts.version_mismatch >= 1 {
+        findings.push(Finding {
+            severity: Severity::Warning,
+            plugin: "cadence-metrics".to_string(),
+            file: dir.to_path_buf(),
+            line: None,
+            snippet: format!("version_mismatch: {}", counts.version_mismatch),
+            diagnosis: format!(
+                "{} version_mismatch failopen(s) on this binary's own version \
+                 ({current_version}) in the last {days} days — a hooks.json/binary \
+                 skew that hasn't resolved",
+                counts.version_mismatch
+            ),
+            remediation: "compare installed plugin hooks.json subcommand references \
+                          against 'cadence-hooks list' — this binary doesn't \
+                          recognize something a plugin expects"
+                .to_string(),
+        });
+    }
+
+    findings
+}
+
+/// Prints an informational (non-blocking, not a `Finding`) count of recent
+/// registry-file reaps when nonzero. No threshold — reaping is normal
+/// operation; this is visibility, not an alarm.
+fn print_sweep_summary(dir: &Path, window: Duration, now: SystemTime) {
+    let count = cadence_hooks_metrics::log_sweep::recent_sweep_count(dir, window, now);
+    if count == 0 {
+        return;
+    }
+    let days = window.as_secs() / 86_400;
+    println!(
+        "cadence-hooks doctor: {count} session-registry sweep(s) in the last {days} days (sweeps.jsonl)"
+    );
+}
+
 /// Sum the byte size of every regular file under `dir`, walking recursively.
 ///
 /// Symlinks are skipped (mirrors [`scan_root`]'s cycle guard) — including
@@ -1014,6 +1107,25 @@ pub fn run(root_override: Option<&Path>, quiet: bool, prune: bool, apply: bool) 
         findings.push(finding);
     }
 
+    // Fail-open / sweep telemetry: same live-machine-only rationale as
+    // staleness above — under `--root` this would read the dev machine's real
+    // metrics dir, not the fixture.
+    if root_override.is_none() {
+        let metrics_dir = cadence_hooks_metrics::warn_stale::metrics_dir();
+        let now = SystemTime::now();
+        let window = Duration::from_secs(7 * 24 * 60 * 60);
+
+        findings.extend(failopen_findings(
+            &metrics_dir,
+            window,
+            now,
+            env!("CARGO_PKG_VERSION"),
+        ));
+        if !quiet {
+            print_sweep_summary(&metrics_dir, window, now);
+        }
+    }
+
     // Plugin-cache health: orphaned/missing version dirs and canonical-remote
     // drift. Same live-machine-only rationale as staleness above — under
     // `--root` this would read the dev machine's real cache, not the fixture.
@@ -1138,6 +1250,102 @@ mod tests {
         let tmp = tempfile::tempdir().unwrap();
         let missing = tmp.path().join("does-not-exist");
         assert!(staleness_finding(&missing, Duration::ZERO, SystemTime::now()).is_none());
+    }
+
+    // ── failopen_findings tests ─────────────────────────────────────────────
+
+    const WEEK: Duration = Duration::from_secs(7 * 86_400);
+
+    #[test]
+    fn failopen_findings_missing_file_is_empty() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(failopen_findings(tmp.path(), WEEK, SystemTime::now(), "1.0.0").is_empty());
+    }
+
+    #[test]
+    fn failopen_findings_one_panic_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let row = r#"{"reason":"panic","namespace":"cadence","subcommand":"terminology","binaryVersion":"1.0.0","ts":"TS"}"#
+            .replace("TS", &cadence_hooks_core::time::utc_timestamp());
+        fs::write(tmp.path().join("failopen.jsonl"), format!("{row}\n")).unwrap();
+
+        let findings = failopen_findings(tmp.path(), WEEK, SystemTime::now(), "1.0.0");
+        assert_eq!(findings.len(), 1);
+        assert_eq!(findings[0].severity, Severity::Warning);
+        assert!(findings[0].diagnosis.contains("panic"));
+    }
+
+    #[test]
+    fn failopen_findings_parse_below_threshold_is_silent() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ts = cadence_hooks_core::time::utc_timestamp();
+        let rows: String = (0..2)
+            .map(|_| {
+                format!(
+                    r#"{{"reason":"parse","namespace":null,"subcommand":null,"binaryVersion":"1.0.0","ts":"{ts}"}}"#
+                )
+            })
+            .map(|r| r + "\n")
+            .collect();
+        fs::write(tmp.path().join("failopen.jsonl"), rows).unwrap();
+
+        assert!(failopen_findings(tmp.path(), WEEK, SystemTime::now(), "1.0.0").is_empty());
+    }
+
+    #[test]
+    fn failopen_findings_parse_at_threshold_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ts = cadence_hooks_core::time::utc_timestamp();
+        let rows: String = (0..3)
+            .map(|_| {
+                format!(
+                    r#"{{"reason":"parse","namespace":null,"subcommand":null,"binaryVersion":"1.0.0","ts":"{ts}"}}"#
+                )
+            })
+            .map(|r| r + "\n")
+            .collect();
+        fs::write(tmp.path().join("failopen.jsonl"), rows).unwrap();
+
+        let findings = failopen_findings(tmp.path(), WEEK, SystemTime::now(), "1.0.0");
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].diagnosis.contains("parse"));
+    }
+
+    #[test]
+    fn failopen_findings_version_mismatch_old_version_excluded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ts = cadence_hooks_core::time::utc_timestamp();
+        let row = format!(
+            r#"{{"reason":"version_mismatch","namespace":"future","subcommand":"hook","binaryVersion":"0.9.0","ts":"{ts}"}}"#
+        );
+        fs::write(tmp.path().join("failopen.jsonl"), format!("{row}\n")).unwrap();
+
+        // The current binary is 1.0.0; the row is tagged 0.9.0 — a sanctioned
+        // rollout-transition row, excluded by construction.
+        assert!(failopen_findings(tmp.path(), WEEK, SystemTime::now(), "1.0.0").is_empty());
+    }
+
+    #[test]
+    fn failopen_findings_version_mismatch_current_version_warns() {
+        let tmp = tempfile::tempdir().unwrap();
+        let ts = cadence_hooks_core::time::utc_timestamp();
+        let row = format!(
+            r#"{{"reason":"version_mismatch","namespace":"future","subcommand":"hook","binaryVersion":"1.0.0","ts":"{ts}"}}"#
+        );
+        fs::write(tmp.path().join("failopen.jsonl"), format!("{row}\n")).unwrap();
+
+        let findings = failopen_findings(tmp.path(), WEEK, SystemTime::now(), "1.0.0");
+        assert_eq!(findings.len(), 1);
+        assert!(findings[0].diagnosis.contains("version_mismatch"));
+    }
+
+    #[test]
+    fn failopen_findings_outside_window_excluded() {
+        let tmp = tempfile::tempdir().unwrap();
+        let row = r#"{"reason":"panic","namespace":null,"subcommand":null,"binaryVersion":"1.0.0","ts":"2000-01-01T00:00:00Z"}"#;
+        fs::write(tmp.path().join("failopen.jsonl"), format!("{row}\n")).unwrap();
+
+        assert!(failopen_findings(tmp.path(), WEEK, SystemTime::now(), "1.0.0").is_empty());
     }
 
     // ── extract_invocation table tests ──────────────────────────────────────

--- a/src/main.rs
+++ b/src/main.rs
@@ -534,6 +534,19 @@ fn main() {
             "cadence-hooks: internal error (panic). This hook will not block your operation.\n\
              {payload}"
         );
+        // Best-effort argv re-read: this closure has no access to the `Check`/
+        // `Logger`/`hook` context computed elsewhere in `main` (a panic can
+        // strike anywhere), so it re-derives the attempted subcommand purely
+        // for diagnostic tagging — not validated against the registry.
+        let mut argv = std::env::args().skip(1);
+        let namespace = argv.next();
+        let subcommand = argv.next();
+        cadence_hooks_metrics::log_failopen(
+            "panic",
+            namespace.as_deref(),
+            subcommand.as_deref(),
+            env!("CARGO_PKG_VERSION"),
+        );
         process::exit(1);
     }));
 
@@ -597,6 +610,18 @@ fn main() {
                          \x20 https://github.com/cameronsjo/cadence-hooks/releases/latest\n\
                          \n\
                          Underlying error: {e}"
+                    );
+                    // Best-effort argv re-read, same as the panic hook — a
+                    // clap parse failure means `cli`/`hook_name` were never
+                    // computed, so the raw argv position is all we have.
+                    let mut argv = std::env::args().skip(1);
+                    let namespace = argv.next();
+                    let subcommand = argv.next();
+                    cadence_hooks_metrics::log_failopen(
+                        "version_mismatch",
+                        namespace.as_deref(),
+                        subcommand.as_deref(),
+                        installed,
                     );
                     process::exit(1);
                 }

--- a/tests/failopen_telemetry.rs
+++ b/tests/failopen_telemetry.rs
@@ -1,0 +1,126 @@
+//! Integration tests for the `failopen.jsonl` telemetry stream — the
+//! fire-and-forget record of the binary's fail-open paths (panic, stdin-parse
+//! failure, clap version-skew). Companion to `version_mismatch.rs`, which
+//! covers the same fail-open *behavior* (exit codes, stderr) without asserting
+//! on the telemetry rows.
+//!
+//! The panic path is not covered here — no CLI-reachable trigger exists to
+//! spawn-test it, matching `version_mismatch.rs`'s note that the panic-hook
+//! arm is exercised only indirectly.
+
+use std::io::Write;
+use std::process::{Command, Output};
+
+fn cadence_hooks() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_cadence-hooks"))
+}
+
+fn failopen_rows(metrics_dir: &std::path::Path) -> Vec<serde_json::Value> {
+    let path = metrics_dir.join("failopen.jsonl");
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => contents
+            .lines()
+            .filter(|l| !l.is_empty())
+            .map(|l| serde_json::from_str(l).expect("each failopen.jsonl line is valid JSON"))
+            .collect(),
+        Err(_) => vec![],
+    }
+}
+
+#[test]
+fn unknown_subcommand_writes_version_mismatch_row() {
+    let tmp = tempfile::tempdir().unwrap();
+    let out: Output = cadence_hooks()
+        .args(["future-plugin", "some-hook"])
+        .env("CADENCE_METRICS_DIR", tmp.path())
+        .output()
+        .expect("failed to execute binary");
+
+    assert_eq!(
+        out.status.code(),
+        Some(1),
+        "unknown subcommand still exits 1 (warn): {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let rows = failopen_rows(tmp.path());
+    assert_eq!(rows.len(), 1, "exactly one failopen row: {rows:?}");
+    let row = &rows[0];
+    assert_eq!(row["reason"], "version_mismatch");
+    assert_eq!(row["namespace"], "future-plugin");
+    assert_eq!(row["subcommand"], "some-hook");
+    assert_eq!(row["binaryVersion"], env!("CARGO_PKG_VERSION"));
+    assert!(row["ts"].is_string());
+}
+
+#[test]
+fn malformed_stdin_on_a_check_writes_parse_row() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cmd = cadence_hooks();
+    cmd.args(["cadence", "terminology"]);
+    cmd.env("CADENCE_METRICS_DIR", tmp.path());
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn binary");
+    if let Some(ref mut stdin) = child.stdin {
+        match stdin.write_all(b"not valid json") {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(e) => panic!("failed to write child stdin: {e}"),
+        }
+    }
+    let out = child.wait_with_output().expect("failed to wait on binary");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "malformed stdin fails open (exit 0), never blocks: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let rows = failopen_rows(tmp.path());
+    assert_eq!(rows.len(), 1, "exactly one failopen row: {rows:?}");
+    let row = &rows[0];
+    assert_eq!(row["reason"], "parse");
+    assert_eq!(row["namespace"], "cadence");
+    assert_eq!(row["subcommand"], "terminology");
+    assert_eq!(row["binaryVersion"], env!("CARGO_PKG_VERSION"));
+}
+
+#[test]
+fn malformed_stdin_on_a_logger_writes_parse_row() {
+    let tmp = tempfile::tempdir().unwrap();
+    let mut cmd = cadence_hooks();
+    cmd.args(["metrics", "log-subagent"]);
+    cmd.env("CADENCE_METRICS_DIR", tmp.path());
+    cmd.stdin(std::process::Stdio::piped());
+    cmd.stdout(std::process::Stdio::piped());
+    cmd.stderr(std::process::Stdio::piped());
+
+    let mut child = cmd.spawn().expect("failed to spawn binary");
+    if let Some(ref mut stdin) = child.stdin {
+        match stdin.write_all(b"not valid json") {
+            Ok(()) => {}
+            Err(e) if e.kind() == std::io::ErrorKind::BrokenPipe => {}
+            Err(e) => panic!("failed to write child stdin: {e}"),
+        }
+    }
+    let out = child.wait_with_output().expect("failed to wait on binary");
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "malformed stdin fails open (exit 0), never blocks: {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let rows = failopen_rows(tmp.path());
+    assert_eq!(rows.len(), 1, "exactly one failopen row: {rows:?}");
+    let row = &rows[0];
+    assert_eq!(row["reason"], "parse");
+    assert_eq!(row["namespace"], "metrics");
+    assert_eq!(row["subcommand"], "log-subagent");
+    assert_eq!(row["binaryVersion"], env!("CARGO_PKG_VERSION"));
+}


### PR DESCRIPTION
## Summary
- Adds sweep-reap telemetry (`sweeps.jsonl`) — every `sweep_stale` reap (PostToolUse heartbeat + `session start`) now logs its trigger, the reaped session's identity (when parseable), and its age.
- Adds fail-open telemetry (`failopen.jsonl`) — the binary's three fail-open paths (panic, stdin-parse failure, clap version-skew) now log their reason, attempted namespace/subcommand, and running binary version.
- Surfaces both streams in `cadence-hooks doctor`: an informational sweep-count line, plus warnings on ≥1 panic, ≥3 parse failures, or ≥1 version_mismatch (in the last 7 days) tagged with the *currently installed* binary's own version — so a sanctioned new-hooks.json/old-binary release transition doesn't alarm.

## Scope

This is the binary-side build of the liveness & enforcement telemetry plan (#259), landed per the plan's Step-0 gate trims:
- The version-skew stamp on session records is cut entirely (a collector with no consumer).
- Telemetry ships on the existing JSONL rail (`<metrics_dir>/`), not OTLP — a named follow-up, not this change.
- The version_mismatch doctor threshold is reconciled against the binary's own version so upgrade transitions don't false-alarm.

The plugin-side wiring (widening a hook matcher, a README fix, and metrics-schema docs) lives in a different repo and is deferred to a follow-up session.

## Test plan

- [x] `make ci` (fmt-check + clippy -D warnings + full workspace test suite) — green, verified from a carve-out-free clone
- [x] New unit tests for the pure record-builders and threshold/window logic in both new metrics streams
- [x] New integration tests spawning the real binary: unknown subcommand → version_mismatch row; malformed stdin on a Check and a Logger → parse rows
- [x] New doctor tests: panic/parse thresholds, and the version-reconciliation exclusion (an old-version version_mismatch row is silently excluded; a current-version one warns)

Refs cameronsjo/cadence-hooks#259
