### PR TITLE
feat(guardrails): fold worktree-first nudge into warn-branch-base

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Changed
+
+- **`warn-branch-base` folds in an early worktree-first nudge (Refs #276).** `git checkout -b`/`git switch -c` in a **primary checkout** under worktree discipline — the same state `enforce-worktree` would gate a mutation in, via the shared `would_block_here` primitive — now nudges toward creating a worktree instead, regardless of which base is named. This replaces the guard's old "switch to main first" advice for that case, which wrongly presumed branching in place was fine as long as the base was main; in a primary checkout, branching in place at all is the anti-pattern `enforce-worktree` exists to prevent. A linked worktree, an exempted repo (`CADENCE_ALLOW_MAIN`, `CADENCE_NO_ENFORCE_WORKTREE`, temp root), or an unresolvable cwd falls through to the original base-branch check, unchanged.
+
 ## [0.55.0] - 2026-07-10
 
 ### Fixed

--- a/crates/guardrails/src/warn_branch_base.rs
+++ b/crates/guardrails/src/warn_branch_base.rs
@@ -576,6 +576,14 @@ mod tests {
         });
     }
 
+    // Unix-only: core's temp-root detection (`path_under_temp_root`) keys off
+    // `/tmp`/`/private/tmp` and `$TMPDIR`, with no Windows `TEMP`/`TMP`
+    // handling — so `std::env::temp_dir()` (a `C:\…\Temp` path on Windows) is
+    // not seen as a temp root and this suppression can't be exercised there.
+    // No D3 coverage is lost: the `would_block_here`-false fall-through this
+    // asserts is also covered cross-platform by the `allow_main` and
+    // `kill_switch` suppression tests above.
+    #[cfg(unix)]
     #[test]
     fn checkout_b_temp_root_suppresses_worktree_first_nudge() {
         with_clean_worktree_env(|| {

--- a/crates/guardrails/src/warn_branch_base.rs
+++ b/crates/guardrails/src/warn_branch_base.rs
@@ -1,10 +1,21 @@
 //! Warn when creating a branch from a non-main base.
 //!
-//! Detects `git checkout -b` and `git switch -c` commands and checks
-//! whether the current branch is `main` or `master`. Nudges to switch
-//! to main first to avoid stacking branches.
+//! Detects `git checkout -b` and `git switch -c` commands. In a **primary
+//! checkout** under worktree discipline — the state `enforce-worktree` would
+//! otherwise gate a mutation in, via [`would_block_here`] — branching in
+//! place at all is the anti-pattern, regardless of the base named: the
+//! primary checkout is meant to stay on `main`/`master` while feature work
+//! happens in a worktree. That case gets a worktree-first nudge, replacing
+//! the older "switch to main first" advice, which wrongly presumed
+//! branching in-place was fine as long as the base was main. Everywhere
+//! else (a linked worktree, an exempted repo, no resolvable cwd), the
+//! original base-branch check is unchanged: whether the current branch (or
+//! an explicit base argument) is `main`/`master`, nudging to switch to main
+//! first to avoid stacking branches.
 
+use cadence_hooks_core::worktree::would_block_here;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
+use std::path::Path;
 use std::process::Command;
 
 /// Warns when creating a new branch from a non-main base.
@@ -22,6 +33,19 @@ impl Check for WarnBranchBase {
 
         if !is_branch_create(command) {
             return CheckResult::allow();
+        }
+
+        // Branching in place in a primary checkout under worktree discipline
+        // is the pattern `enforce-worktree` exists to prevent — checked
+        // first, ahead of the base-branch logic below, since it applies
+        // regardless of which base is named. Only when the cwd resolves to
+        // a repo `would_block_here` can judge; no cwd falls through to the
+        // existing behavior (fail open, ADR-0001).
+        // TODO(#164): GitState will absorb this suppression gate.
+        if let Some(cwd) = input.cwd.as_deref()
+            && would_block_here(Path::new(cwd))
+        {
+            return CheckResult::nudge(worktree_first_message());
         }
 
         // If an explicit base is given (e.g., `git checkout -b feat main`), check that
@@ -52,6 +76,17 @@ impl Check for WarnBranchBase {
              Otherwise: `git checkout main && git pull` first."
         ))
     }
+}
+
+/// The worktree-first nudge for a primary checkout under worktree
+/// discipline: names the anti-pattern (branching in place) rather than
+/// the base branch, and points at the worktree-entry playbook.
+fn worktree_first_message() -> String {
+    "⚠️  Branching in a primary checkout is the pattern `enforce-worktree` prevents.\n   \
+     Create a worktree instead: `git worktree add .claude/worktrees/<slug> -b <branch>` \
+     (or EnterWorktree), then create the branch there.\n   \
+     See cadence-forge:using-worktrees § Session Entry Posture."
+        .to_string()
 }
 
 /// Check if command creates a new branch.
@@ -133,7 +168,7 @@ fn current_branch(cwd: Option<&str>) -> Option<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cadence_hooks_core::test_builders::make_bash;
+    use cadence_hooks_core::test_builders::{make_bash, make_bash_with_cwd};
 
     // --- is_branch_create ---
 
@@ -341,5 +376,247 @@ mod tests {
     #[test]
     fn upstream_master_is_main() {
         assert!(is_main_branch("upstream/master"));
+    }
+
+    // --- worktree-first nudge (folded enforce-worktree suppression gate) ---
+    //
+    // `would_block_here` reads real repo state and process env, so these
+    // fixtures live under `target/`, not a tempdir — the temp-root exemption
+    // would otherwise mask every primary-checkout case (the documented
+    // Scratch/E2E gotcha `enforce_worktree`'s own tests carry the same note
+    // for).
+
+    use std::path::PathBuf;
+
+    struct Scratch(PathBuf);
+
+    impl Scratch {
+        fn new(tag: &str) -> Self {
+            let root = Path::new(env!("CARGO_MANIFEST_DIR"))
+                .join("../../target/warn-branch-base-scratch")
+                .join(format!("{tag}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&root);
+            std::fs::create_dir_all(&root).unwrap();
+            Self(root)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    fn git_in(dir: &Path, args: &[&str]) {
+        let ok = std::process::Command::new("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .map(|o| o.status.success())
+            .unwrap_or(false);
+        assert!(ok, "git {args:?} failed in {dir:?}");
+    }
+
+    fn init_repo(dir: &Path) {
+        git_in(dir, &["init", "-q", "-b", "main"]);
+        git_in(dir, &["config", "user.email", "t@t"]);
+        git_in(dir, &["config", "user.name", "t"]);
+        std::fs::write(dir.join("f.txt"), "x").unwrap();
+        git_in(dir, &["add", "f.txt"]);
+        git_in(dir, &["commit", "-q", "-m", "init"]);
+    }
+
+    /// Primary repo + linked worktree under a non-temp scratch root.
+    fn primary_and_worktree(scratch: &Scratch) -> (PathBuf, PathBuf) {
+        let primary = scratch.0.join("repo");
+        std::fs::create_dir(&primary).unwrap();
+        init_repo(&primary);
+        let wt = scratch.0.join("wt");
+        git_in(
+            &primary,
+            &["worktree", "add", &wt.to_string_lossy(), "-b", "feat/x"],
+        );
+        (primary, wt)
+    }
+
+    // `would_block_here` reads real process env (`CADENCE_ALLOW_MAIN`,
+    // `CADENCE_NO_ENFORCE_WORKTREE`), unlike `enforce_worktree`'s own tests
+    // (which inject an `EnvConfig`) — so these tests pin real env, serialized
+    // via ENV_LOCK and restored on drop, panic included. Mirrors
+    // `session::start`'s `with_worktree_env`/`WorktreeEnvGuard` pattern —
+    // that helper is private to its own crate, so this is a local copy, not
+    // a shared abstraction.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    struct WorktreeEnvGuard {
+        allow: Option<std::ffi::OsString>,
+        kill: Option<std::ffi::OsString>,
+    }
+
+    impl Drop for WorktreeEnvGuard {
+        fn drop(&mut self) {
+            // SAFETY: only constructed inside `with_worktree_env`, which
+            // holds ENV_LOCK for this guard's whole lifetime (declared after
+            // the lock, so it drops before the lock releases — panic
+            // included).
+            unsafe {
+                match self.allow.take() {
+                    Some(v) => std::env::set_var("CADENCE_ALLOW_MAIN", v),
+                    None => std::env::remove_var("CADENCE_ALLOW_MAIN"),
+                }
+                match self.kill.take() {
+                    Some(v) => std::env::set_var("CADENCE_NO_ENFORCE_WORKTREE", v),
+                    None => std::env::remove_var("CADENCE_NO_ENFORCE_WORKTREE"),
+                }
+            }
+        }
+    }
+
+    fn with_worktree_env<T>(allow: Option<&str>, kill: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _lock = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _restore = WorktreeEnvGuard {
+            allow: std::env::var_os("CADENCE_ALLOW_MAIN"),
+            kill: std::env::var_os("CADENCE_NO_ENFORCE_WORKTREE"),
+        };
+        // SAFETY: serialized via ENV_LOCK; `_restore` puts the caller's
+        // values back on scope exit.
+        unsafe {
+            match allow {
+                Some(v) => std::env::set_var("CADENCE_ALLOW_MAIN", v),
+                None => std::env::remove_var("CADENCE_ALLOW_MAIN"),
+            }
+            match kill {
+                Some(v) => std::env::set_var("CADENCE_NO_ENFORCE_WORKTREE", v),
+                None => std::env::remove_var("CADENCE_NO_ENFORCE_WORKTREE"),
+            }
+        }
+        f()
+    }
+
+    fn with_clean_worktree_env<T>(f: impl FnOnce() -> T) -> T {
+        with_worktree_env(None, None, f)
+    }
+
+    #[test]
+    fn checkout_b_in_primary_checkout_nudges_worktree_first() {
+        with_clean_worktree_env(|| {
+            let scratch = Scratch::new("checkout-b-primary");
+            let (primary, _wt) = primary_and_worktree(&scratch);
+            let input = make_bash_with_cwd("git checkout -b feat/x", primary.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+            let msg = result.message.unwrap();
+            assert!(msg.contains("enforce-worktree"), "names the guard: {msg}");
+            assert!(msg.contains("worktree add"), "points at the fix: {msg}");
+        });
+    }
+
+    #[test]
+    fn switch_c_in_primary_checkout_nudges_worktree_first() {
+        with_clean_worktree_env(|| {
+            let scratch = Scratch::new("switch-c-primary");
+            let (primary, _wt) = primary_and_worktree(&scratch);
+            let input = make_bash_with_cwd("git switch -c feat/x", primary.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+            assert!(
+                result.message.unwrap().contains("enforce-worktree"),
+                "switch -c gets the same worktree-first nudge as checkout -b"
+            );
+        });
+    }
+
+    #[test]
+    fn checkout_b_in_linked_worktree_keeps_existing_behavior() {
+        with_clean_worktree_env(|| {
+            let scratch = Scratch::new("checkout-b-wt");
+            let (_primary, wt) = primary_and_worktree(&scratch);
+            // `wt` is checked out on `feat/x` (non-main) — since
+            // `would_block_here` is false here (linked worktree, `.git` is a
+            // file), this falls through to the original current-branch base
+            // nudge, unchanged.
+            let input = make_bash_with_cwd("git checkout -b feat/y", wt.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+            let msg = result.message.unwrap();
+            assert!(
+                !msg.contains("enforce-worktree"),
+                "linked worktree must not get the primary-only nudge: {msg}"
+            );
+            assert!(msg.contains("feat/x"), "names the actual base: {msg}");
+        });
+    }
+
+    #[test]
+    fn checkout_b_allow_main_suppresses_worktree_first_nudge() {
+        with_worktree_env(Some("true"), None, || {
+            let scratch = Scratch::new("checkout-b-allow-main");
+            let (primary, _wt) = primary_and_worktree(&scratch);
+            // Base is main and CADENCE_ALLOW_MAIN exempts the primary from
+            // `would_block_here` — falls through to the unchanged
+            // explicit-base-is-main Allow.
+            let input =
+                make_bash_with_cwd("git checkout -b feat/x main", primary.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn checkout_b_kill_switch_suppresses_worktree_first_nudge() {
+        with_worktree_env(None, Some("1"), || {
+            let scratch = Scratch::new("checkout-b-kill-switch");
+            let (primary, _wt) = primary_and_worktree(&scratch);
+            let input = make_bash_with_cwd("git checkout -b feat/x", primary.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            // CADENCE_NO_ENFORCE_WORKTREE exempts the primary, so this falls
+            // through to the original current-branch check — current branch
+            // is main, so it's silent.
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn checkout_b_temp_root_suppresses_worktree_first_nudge() {
+        with_clean_worktree_env(|| {
+            let root =
+                std::env::temp_dir().join(format!("warn-branch-base-temp-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&root);
+            std::fs::create_dir_all(&root).unwrap();
+            init_repo(&root);
+            let input = make_bash_with_cwd("git checkout -b feat/x", root.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            // A temp-root repo is exempt from `would_block_here`, so this
+            // falls through — current branch is main, so it's silent.
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+            let _ = std::fs::remove_dir_all(&root);
+        });
+    }
+
+    #[test]
+    fn explicit_non_main_base_outside_primary_unchanged() {
+        with_clean_worktree_env(|| {
+            let scratch = Scratch::new("explicit-base-wt");
+            let (_primary, wt) = primary_and_worktree(&scratch);
+            let input = make_bash_with_cwd("git checkout -b feature develop", wt.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Nudge);
+            let msg = result.message.unwrap();
+            assert!(!msg.contains("enforce-worktree"), "not a primary: {msg}");
+            assert!(msg.contains("develop"), "names the explicit base: {msg}");
+        });
+    }
+
+    #[test]
+    fn plain_checkout_in_primary_stays_silent() {
+        with_clean_worktree_env(|| {
+            let scratch = Scratch::new("plain-checkout-primary");
+            let (primary, _wt) = primary_and_worktree(&scratch);
+            // No `-b`/`-c` — is_branch_create gates before the worktree-first
+            // check ever runs.
+            let input = make_bash_with_cwd("git checkout main", primary.to_str().unwrap());
+            let result = WarnBranchBase.run(&input);
+            assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+        });
     }
 }


### PR DESCRIPTION
## What

`warn-branch-base` already fires on `git checkout -b` / `git switch -c` and nudged *"switch to main first"* — advice that wrongly presumes branching in-place is fine as long as the base is main. In a **primary checkout** under worktree discipline, branching in-place *at all* is the exact anti-pattern `enforce-worktree` prevents, regardless of base.

This folds an early worktree-first nudge into the existing guard rather than adding a new one (a new guard would double-fire on the same command shape and contradict the old advice). It closes the coverage seam #276 flagged: the guard now signals *early* (at branch-create) that a worktree is wanted, instead of only at the late `commit`/`Write` block.

## Change

In `warn_branch_base.rs` `run()`, after `is_branch_create` matches and **before** the base-branch logic, branch on cwd:

- If the cwd resolves to a state `enforce-worktree` would gate a mutation in — via `cadence_hooks_core::worktree::would_block_here` (primary checkout, not `CADENCE_ALLOW_MAIN`-exempt (env or repo-declared), not `CADENCE_NO_ENFORCE_WORKTREE`, not temp-root, not snoozed) → emit the **worktree-first nudge** pointing at `cadence-forge:using-worktrees` § Session Entry Posture.
- Otherwise the existing non-main-base behavior is **unchanged** (explicit-base / current-branch nudge, or silent). No cwd → falls through (fail open, ADR-0001).

**Reuse over reimplementation:** the composite suppression predicate is the existing `would_block_here` — the same one `enforce-worktree` and the SessionStart posture line use — imported straight, not hand-assembled. `is_primary_checkout` visibility untouched.

**Fires regardless of named base** (even `git checkout -b feat main`) — inside a primary checkout, the base doesn't make in-place branching acceptable.

## Coordination

- The minimal suppression gate here is what **#164**'s `GitState` will centralize — marked `// TODO(#164): GitState will absorb this suppression gate`, deliberately not built as a cross-guard borrow now.
- No wiring change (already registered + wired in `hooks.json`), no cadence-guardrails companion, no release-gating.

## Verification

- `cargo fmt --all -- --check` clean; `cargo clippy -p cadence-hooks-guardrails -D warnings` clean; `cargo build --bin cadence-hooks` 0 warnings.
- `cargo test -p cadence-hooks-guardrails warn_branch_base` — 40 passed / 0 failed (24 pre-existing + 16 new). Full crate: 877 passed / 0 failed.
- New tests build real git fixtures under `target/` (not tempdir — `would_block_here` reads real repo state + process env, so a tempdir would trip the temp-root exemption and mask every case). Env-mutating cases use a panic-safe serialized env guard.
- Cases: `checkout -b`/`switch -c` in primary → worktree-first nudge; linked worktree → existing base nudge unchanged; `CADENCE_ALLOW_MAIN`/kill-switch/temp-root → suppressed; explicit non-main base outside a primary → existing base nudge; plain `git checkout main` (no `-b`) → silent.

Bundled into one cadence-hooks release with the #234 subprocess-mutation nudge — version held until both merge.

Refs cameronsjo/cadence#276

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added worktree-first guidance when creating branches from a primary checkout.
  * Users are now prompted to create a worktree instead of switching to the main branch first when applicable.

* **Bug Fixes**
  * Preserved existing branch-base checks for linked worktrees, configured exemptions, and unresolved working directories.
  * Commands outside supported branch-creation patterns remain unaffected.

* **Documentation**
  * Updated the changelog and guidance to describe the revised worktree-first behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->