### PR TITLE
fix(markers): key polish marker on git-common-dir, not show-toplevel

### DIFF
--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -107,8 +107,8 @@ fn nudge_message() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use cadence_hooks_core::gitstate::GitState;
     use cadence_hooks_core::markers::{polish_marker, write_marker};
-    use cadence_hooks_core::shell::git_command;
     use cadence_hooks_core::test_builders::{make_bash, make_bash_with_cwd};
     use cadence_hooks_core::{Outcome, ToolInput};
     use std::process::Command;
@@ -206,10 +206,12 @@ mod tests {
     // --- integration through run() with a real temp git repo (#146 fixture) ---
 
     /// Init a git repo in a fresh tempdir, checked out on `branch` (no commit
-    /// needed — `branch --show-current` reports an unborn branch, and the gate
-    /// only reads `--show-toplevel` + `--show-current`). Returns the tempdir and
-    /// the git-resolved repo root (canonicalized, so it matches what `run()`
-    /// resolves — critical on macOS where `/tmp` → `/private/tmp`).
+    /// needed — an unborn HEAD still resolves a branch name via [`GitState`],
+    /// and the gate only reads the common dir + current branch). Returns the
+    /// tempdir and the git-resolved `git_common_dir` (canonicalized, so it
+    /// matches what `run()` resolves — critical on macOS where `/tmp` →
+    /// `/private/tmp` — and the same key `polish_marker_present` now uses,
+    /// cadence-hooks#324).
     fn init_repo_on_branch(branch: &str) -> (tempfile::TempDir, String) {
         let tmp = tempfile::tempdir().unwrap();
         let dir = tmp.path().to_str().unwrap().to_string();
@@ -226,8 +228,8 @@ mod tests {
         };
         git(&["init", "-q"]);
         git(&["checkout", "-q", "-b", branch]);
-        let root = git_command(&dir, &["rev-parse", "--show-toplevel"])
-            .expect("temp repo resolves a toplevel");
+        let state = GitState::resolve(tmp.path()).expect("temp repo resolves git state");
+        let root = state.git_common_dir.to_string_lossy().into_owned();
         (tmp, root)
     }
 
@@ -316,6 +318,148 @@ mod tests {
             ..Default::default()
         };
         assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Nudge);
+    }
+
+    // --- worktree-stable keying (cadence-hooks#324) ---
+
+    /// `git -C primary <args>`, asserting success. Shared by the worktree
+    /// fixtures below.
+    fn git_in(dir: &std::path::Path, args: &[&str]) {
+        assert!(
+            Command::new("git")
+                .arg("-C")
+                .arg(dir)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success(),
+            "git {args:?} failed"
+        );
+    }
+
+    /// A primary checkout with one commit — `git worktree add` refuses an
+    /// unborn branch, unlike [`init_repo_on_branch`]'s marker-only fixtures.
+    fn init_primary_with_commit(primary: &std::path::Path) {
+        std::fs::create_dir_all(primary).unwrap();
+        git_in(primary, &["init", "-q", "-b", "main"]);
+        git_in(primary, &["config", "user.email", "t@t"]);
+        git_in(primary, &["config", "user.name", "t"]);
+        git_in(primary, &["commit", "-q", "--allow-empty", "-m", "init"]);
+    }
+
+    #[test]
+    fn run_worktree_marker_satisfies_primary_ship_command() {
+        // #324: a marker recorded from a linked worktree must satisfy the ship
+        // command run from the primary checkout, once the primary is on the
+        // same branch — the common-dir key is shared across both checkouts.
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("primary");
+        init_primary_with_commit(&primary);
+        let wt = tmp.path().join("wt");
+        git_in(
+            &primary,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                wt.to_str().unwrap(),
+                "-b",
+                "feat/thing",
+            ],
+        );
+
+        let wt_state = GitState::resolve(&wt).expect("worktree resolves");
+        write_marker(
+            &polish_marker(&wt_state.git_common_dir.to_string_lossy(), "feat/thing"),
+            "{}",
+        )
+        .unwrap();
+
+        git_in(
+            &primary,
+            &["worktree", "remove", "--force", wt.to_str().unwrap()],
+        );
+        git_in(&primary, &["checkout", "-q", "feat/thing"]);
+
+        let input = make_bash_with_cwd("gh pr create --title x", primary.to_str().unwrap());
+        let result = NudgePolishBeforePr.run(&input);
+        assert_eq!(
+            result.outcome,
+            Outcome::Allow,
+            "a worktree-recorded marker must satisfy the primary checkout on the same branch"
+        );
+    }
+
+    #[test]
+    fn run_primary_marker_satisfies_worktree_ship_command() {
+        // #324 inverse: a marker recorded from the PRIMARY checkout must
+        // satisfy a ship command run from a linked WORKTREE on the same branch.
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("primary");
+        init_primary_with_commit(&primary);
+        git_in(&primary, &["checkout", "-q", "-b", "feat/y"]);
+
+        let primary_state = GitState::resolve(&primary).expect("primary resolves");
+        write_marker(
+            &polish_marker(&primary_state.git_common_dir.to_string_lossy(), "feat/y"),
+            "{}",
+        )
+        .unwrap();
+
+        // Free `feat/y` from the primary so a worktree can check it out.
+        git_in(&primary, &["checkout", "-q", "main"]);
+        let wt = tmp.path().join("wt");
+        git_in(
+            &primary,
+            &["worktree", "add", "-q", wt.to_str().unwrap(), "feat/y"],
+        );
+
+        let input = make_bash_with_cwd("gh pr create --title x", wt.to_str().unwrap());
+        let result = NudgePolishBeforePr.run(&input);
+        assert_eq!(
+            result.outcome,
+            Outcome::Allow,
+            "a primary-recorded marker must satisfy a linked worktree on the same branch"
+        );
+    }
+
+    #[test]
+    fn run_worktree_marker_does_not_satisfy_different_branch() {
+        // The common-dir re-key must not loosen branch scoping: a marker
+        // recorded from a worktree on branch A must still miss when the ship
+        // command runs on a different branch, even in the same repo.
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("primary");
+        init_primary_with_commit(&primary);
+        let wt = tmp.path().join("wt");
+        git_in(
+            &primary,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                wt.to_str().unwrap(),
+                "-b",
+                "feat/a",
+            ],
+        );
+
+        let wt_state = GitState::resolve(&wt).expect("worktree resolves");
+        write_marker(
+            &polish_marker(&wt_state.git_common_dir.to_string_lossy(), "feat/a"),
+            "{}",
+        )
+        .unwrap();
+
+        // Primary stays on `main` — a different branch from the marker.
+        let input = make_bash_with_cwd("gh pr create --title x", primary.to_str().unwrap());
+        let result = NudgePolishBeforePr.run(&input);
+        assert_eq!(
+            result.outcome,
+            Outcome::Nudge,
+            "a marker for a different branch must not satisfy the ship command"
+        );
     }
 
     // --- preserved matcher tests (is_polish_ship_anchor) ---

--- a/crates/cadence/src/record_polish.rs
+++ b/crates/cadence/src/record_polish.rs
@@ -6,24 +6,35 @@
 //! gate ([`crate::nudge_polish_before_pr`]) then reads that marker instead of
 //! scanning the session transcript.
 //!
-//! The marker key is `(repo_root, branch)` (see [`markers::polish_marker`]), so
-//! detection is invocation-agnostic (Skill call, `/polish` slash-command, or a
-//! delegated subagent all end by running this) and branch-scoped (a marker for
-//! branch A cannot satisfy a PR on branch B).
+//! The marker key is `(repo_root, branch)` (see [`markers::polish_marker`]),
+//! where `repo_root` is the canonicalized `git rev-parse --git-common-dir`
+//! (cadence-hooks#324) — stable across every worktree of a repo, not
+//! `--show-toplevel` (a linked worktree's own path). Detection is therefore
+//! invocation-agnostic (Skill call, `/polish` slash-command, or a delegated
+//! subagent all end by running this), worktree-agnostic (recording from a
+//! worktree satisfies a ship command run from the primary checkout, and vice
+//! versa), and branch-scoped (a marker for branch A cannot satisfy a PR on
+//! branch B).
 //!
 //! Advisory, always — this must never fail the user's polish pass. Every error
 //! path (not a repo, detached HEAD, unwritable marker dir) prints one stderr
 //! line and exits 0 (ADR-0001).
 
+use cadence_hooks_core::gitstate::GitState;
 use cadence_hooks_core::markers::{polish_marker, write_marker};
 use cadence_hooks_core::shell::git_command;
 use cadence_hooks_core::time::utc_timestamp;
 use serde_json::json;
 
-/// Resolve `repo_root`, `branch`, and `head_sha` from `dir` via git, letting
-/// explicit overrides bypass the shell-out so tests need no real repository.
+/// Resolve `repo_root`, `branch`, and `head_sha` from `dir`, letting explicit
+/// overrides bypass resolution so tests need no real repository.
 ///
-/// `head_sha` is best-effort: a repo with no commits yet has no `HEAD`, so it
+/// `repo_root` and `branch` come from [`GitState::resolve`] — a pure
+/// filesystem walk keyed on the canonicalized `git_common_dir`, matching the
+/// read side ([`cadence_hooks_core::markers::polish_marker_present`]) so a
+/// worktree and its primary checkout key to the same marker. `head_sha` is
+/// still resolved via a `git` shell-out: it's provenance metadata, not part of
+/// the key, and best-effort — a repo with no commits yet has no `HEAD`, so it
 /// resolves to `None` and the field is recorded as an empty string rather than
 /// failing the record. `repo_root` and `branch` are the load-bearing key; when
 /// either can't be resolved the caller degrades to a no-op (exit 0).
@@ -32,8 +43,10 @@ fn resolve(
     repo_root: Option<String>,
     branch: Option<String>,
 ) -> Option<(String, String, String)> {
-    let repo_root = repo_root.or_else(|| git_command(dir, &["rev-parse", "--show-toplevel"]))?;
-    let branch = branch.or_else(|| git_command(dir, &["branch", "--show-current"]))?;
+    let git_state = || GitState::resolve(std::path::Path::new(dir));
+    let repo_root = repo_root
+        .or_else(|| git_state().map(|state| state.git_common_dir.to_string_lossy().into_owned()))?;
+    let branch = branch.or_else(|| git_state().and_then(|state| state.branch))?;
     // Polish does not commit (SKILL.md), so this is the pre-polish base SHA — a
     // provenance breadcrumb for CP2, never an exact-match key. Empty when the
     // repo has no HEAD yet.
@@ -141,5 +154,85 @@ mod tests {
         // marker. Asserts the call simply returns (fail-open) without unwinding;
         // a bad marker dir would likewise exit via the write_marker arm.
         run_record(None, None, Some("full".into()));
+    }
+
+    // --- worktree-stable keying (cadence-hooks#324) ---
+
+    /// Init a primary checkout with one commit (a real commit is required —
+    /// `git worktree add` refuses an unborn branch), plus a `git` closure bound
+    /// to that checkout.
+    fn init_primary_with_commit(primary: &std::path::Path) {
+        std::fs::create_dir_all(primary).unwrap();
+        let git = |args: &[&str]| {
+            let ok = std::process::Command::new("git")
+                .arg("-C")
+                .arg(primary)
+                .args(args)
+                .output()
+                .unwrap()
+                .status
+                .success();
+            assert!(ok, "git {args:?} failed");
+        };
+        git(&["init", "-q", "-b", "main"]);
+        git(&["config", "user.email", "t@t"]);
+        git(&["config", "user.name", "t"]);
+        git(&["commit", "-q", "--allow-empty", "-m", "init"]);
+    }
+
+    #[test]
+    fn worktree_record_satisfies_primary_check_same_branch() {
+        // RED (#324): a polish recorded from a LINKED WORKTREE must satisfy a
+        // ship command run from the PRIMARY checkout on the same branch — the
+        // marker key must be common-dir-based, not `--show-toplevel`-based
+        // (a worktree's toplevel is its own path, not the shared repo).
+        let tmp = tempfile::tempdir().unwrap();
+        let primary = tmp.path().join("primary");
+        init_primary_with_commit(&primary);
+
+        let wt = tmp.path().join("wt");
+        let git = |args: &[&str]| {
+            assert!(
+                std::process::Command::new("git")
+                    .arg("-C")
+                    .arg(&primary)
+                    .args(args)
+                    .output()
+                    .unwrap()
+                    .status
+                    .success(),
+                "git {args:?} failed"
+            );
+        };
+        git(&[
+            "worktree",
+            "add",
+            "-q",
+            wt.to_str().unwrap(),
+            "-b",
+            "feat/thing",
+        ]);
+
+        // Record from the WORKTREE path — the record side's own resolution.
+        let wt_str = wt.to_str().unwrap().to_string();
+        let (repo_root, branch, head_sha) =
+            resolve(&wt_str, None, None).expect("worktree resolves repo/branch");
+        assert_eq!(branch, "feat/thing");
+        let content = marker_content(&branch, &head_sha, "full");
+        write_marker(&polish_marker(&repo_root, &branch), &content).unwrap();
+
+        // Free the branch from the worktree and check it out on the primary —
+        // the realistic sequel to "finished the worktree, shipping from primary".
+        git(&["worktree", "remove", "--force", wt.to_str().unwrap()]);
+        git(&["checkout", "-q", "feat/thing"]);
+
+        assert!(
+            cadence_hooks_core::markers::polish_marker_present(
+                "gh pr create --title x",
+                Some(primary.to_str().unwrap()),
+            ),
+            "a polish marker recorded from a linked worktree must satisfy a ship \
+             command run from the primary checkout on the same branch"
+        );
     }
 }

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -19,8 +19,9 @@
 //! that can't be written just means the nudge may re-fire, never a block.
 
 use crate::HookInput;
+use crate::gitstate::GitState;
 use crate::paths;
-use crate::shell::{git_command, parse_work_dir};
+use crate::shell::parse_work_dir;
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 use std::io;
@@ -146,20 +147,22 @@ pub fn polish_marker(repo_root: &str, branch: &str) -> PathBuf {
 /// record for this PR's branch" — the pre-PR gate acts on it and the
 /// polish-nudge metric records it, so the two cannot disagree (#177).
 ///
-/// Resolves `repo_root` (`git rev-parse --show-toplevel`) and `branch`
-/// (`git branch --show-current`) from `cwd`, honoring a `cd`-prefixed command
-/// via [`parse_work_dir`] — mirrors the record side. Any missing piece (no cwd,
-/// not a repo, detached HEAD) yields `false` (fail-open, ADR-0001).
+/// Resolves the repo identity via [`crate::gitstate::GitState`] — keyed on the
+/// canonicalized `git rev-parse --git-common-dir`, not `--show-toplevel`
+/// (cadence-hooks#324) — so a linked worktree and its primary checkout key to
+/// the same marker; `branch` comes from `cwd` too, honoring a `cd`-prefixed
+/// command via [`parse_work_dir`] — mirrors the record side. Any missing piece
+/// (no cwd, not a repo, detached HEAD) yields `false` (fail-open, ADR-0001).
 pub fn polish_marker_present(command: &str, cwd: Option<&str>) -> bool {
     let Some(cwd) = cwd else { return false };
     let dir = parse_work_dir(command, cwd);
-    let Some(repo_root) = git_command(&dir, &["rev-parse", "--show-toplevel"]) else {
+    let Some(state) = GitState::resolve(Path::new(&dir)) else {
         return false;
     };
-    let Some(branch) = git_command(&dir, &["branch", "--show-current"]) else {
+    let Some(branch) = state.branch else {
         return false;
     };
-    polish_marker(&repo_root, &branch).is_file()
+    polish_marker(&state.git_common_dir.to_string_lossy(), &branch).is_file()
 }
 
 /// Write `contents` to a marker path symlink-safely.
@@ -375,8 +378,9 @@ mod tests {
     // --- polish_marker_present (shared gate/metric helper, #177) ---
 
     /// Init a git repo in a fresh tempdir, checked out on `branch`, and return
-    /// the tempdir plus the git-resolved (canonicalized) repo root — mirrors the
-    /// gate's own `init_repo_on_branch` so both sides key markers identically.
+    /// the tempdir plus the git-resolved (canonicalized) `git_common_dir` — the
+    /// same key `polish_marker_present` now resolves via [`GitState`], so both
+    /// sides key markers identically (no hand-rolled second resolution).
     fn init_repo_on_branch(branch: &str) -> (tempfile::TempDir, String) {
         use std::process::Command;
         let tmp = tempfile::tempdir().unwrap();
@@ -394,8 +398,8 @@ mod tests {
         };
         git(&["init", "-q"]);
         git(&["checkout", "-q", "-b", branch]);
-        let root = crate::shell::git_command(&dir, &["rev-parse", "--show-toplevel"])
-            .expect("temp repo resolves a toplevel");
+        let state = GitState::resolve(tmp.path()).expect("temp repo resolves git state");
+        let root = state.git_common_dir.to_string_lossy().into_owned();
         (tmp, root)
     }
 
@@ -433,5 +437,16 @@ mod tests {
     fn polish_marker_present_false_when_cwd_none() {
         // No cwd → unresolved → false (fail-open, ADR-0001).
         assert!(!polish_marker_present("gh pr create --title x", None));
+    }
+
+    #[test]
+    fn polish_marker_present_false_for_non_repo_cwd() {
+        // A real directory that is not a git repo → GitState::resolve is None
+        // → false (fail-open, ADR-0001) — still holds after the #324 re-key.
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(!polish_marker_present(
+            "gh pr create --title x",
+            Some(tmp.path().to_str().unwrap())
+        ));
     }
 }


### PR DESCRIPTION
## Summary

The polish marker (`crates/core/src/markers.rs`) was keyed on `git rev-parse --show-toplevel` plus branch. A linked worktree's toplevel is its own path, not the shared repository, so a marker written from a worktree did not satisfy a check run from the primary checkout on the same branch, and vice versa.

This re-keys both the read side (`polish_marker_present`) and the record side (`crates/cadence/src/record_polish.rs`) on the canonicalized `git rev-parse --git-common-dir`, resolved via the existing pure-filesystem `GitState::resolve` primitive rather than a fresh `git` shell-out. `git-common-dir` is shared across a repository's primary checkout and every linked worktree, so it is stable regardless of which checkout wrote or reads the marker. The branch stays part of the key, so different branches still miss.

No compatibility shim: the marker is an ephemeral per-branch breadcrumb, so markers keyed on the old hash simply age out.

## Changes

- `crates/core/src/markers.rs`: `polish_marker_present` resolves repo identity via `GitState::resolve` (canonicalized `git_common_dir` + branch) instead of `git rev-parse --show-toplevel` / `git branch --show-current`.
- `crates/cadence/src/record_polish.rs`: the record-side `resolve()` uses the same `GitState`-based resolution for the marker key (HEAD sha stays a `git rev-parse HEAD` shell-out — it's provenance metadata, not part of the key).
- Doc comments updated to describe the new key.
- Existing tests' fixtures now derive their expected marker path via `GitState`, matching production resolution, instead of hand-rolling a second `--show-toplevel` call.

## Test plan

- [x] RED: `worktree_record_satisfies_primary_check_same_branch` (`crates/cadence/src/record_polish.rs`) — marker written from a linked worktree failed to satisfy a check from the primary checkout on the same branch, confirmed failing against the pre-fix code.
- [x] GREEN: same test passes after the re-key.
- [x] Added the inverse case (marker recorded from the primary satisfies a check from a linked worktree) and a different-branch miss case in `crates/cadence/src/nudge_polish_before_pr.rs`.
- [x] `cargo test --workspace` — all tests in the touched crates pass (825 + 494 across `cadence` and `core`); one pre-existing, unrelated test failure (`worktree::tests::primary_checkout_would_block`) reproduces identically on `main` and is caused by running the suite from a checkout nested under a system temp directory, not by this change.
- [x] `cargo clippy --all-targets` — clean.
- [x] `cargo fmt` — applied.

Closes #324