### PR TITLE
refactor(messages): tighten chattiest hook messages, dedup shared strings

### DIFF
--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -88,19 +88,18 @@ fn decide(command: &str, marker_present: bool) -> CheckResult {
 /// and "TDD/attune already covered it" skips can't survive it.
 const SCOPE_CLAUSES: &str = "Skill / agent / command / rule markdown and \
     CLAUDE.md are behavior, not documentation — IN scope; only *literal* docs \
-    (prose about the system) route to `/polish docs`. Planning, TDD, attune, or \
-    a code-review precede polish — they don't replace it.";
+    route to `/polish docs`. Planning, TDD, attune, or a code-review precede \
+    polish — they don't replace it.";
 
 /// The soft nudge — fires when no polish marker exists for the PR's branch.
 /// Allow + warn; the model proceeds (CP1 fail-open floor, ADR-0001).
 fn nudge_message() -> String {
     format!(
-        "Before this PR ships for review, consider `/polish` (cadence-forge:polish) — no \
-         polish has been recorded for this branch this session (`/polish` records \
-         a marker when it completes). It's a branch-scoped pass vs `origin/main`: \
-         simplify, logging, tests, docs, security, code review. {SCOPE_CLAUSES} \
-         Skip ONLY if it's a trivial one-liner or already went through `/polish`. \
-         If you skip, say so and why — don't skip silently."
+        "No polish recorded for this branch — run `/polish` (cadence-forge:polish) \
+         before this PR ships: a branch-scoped quality pass vs `origin/main`; it \
+         records the marker when it completes. {SCOPE_CLAUSES} Skip ONLY for a \
+         trivial one-liner or an already-polished branch — say so and why, don't \
+         skip silently."
     )
 }
 

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -386,10 +386,9 @@ impl Check for SecretLeaksGuard {
                 }
 
                 if is_ambiguous(filename) {
-                    return CheckResult::nudge(format!(
-                        "⚠️  (Read) '{filename}' may contain private key material. \
-                         Approve only if you know this is a public cert."
-                    ));
+                    return CheckResult::nudge(
+                        crate::secret_patterns::ambiguous_key_material_message("(Read) ", filename),
+                    );
                 }
 
                 CheckResult::allow()

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -241,10 +241,9 @@ impl Check for SecretWritesGuard {
                 }
 
                 if is_ambiguous(filename) {
-                    return CheckResult::nudge(format!(
-                        "⚠️  '{filename}' may contain private key material. \
-                         Approve only if you know this is a public cert."
-                    ));
+                    return CheckResult::nudge(
+                        crate::secret_patterns::ambiguous_key_material_message("", filename),
+                    );
                 }
 
                 CheckResult::allow()

--- a/crates/cadence/src/secret_patterns.rs
+++ b/crates/cadence/src/secret_patterns.rs
@@ -66,6 +66,16 @@ pub const BLOCKED_PATH_FRAGMENTS: &[&str] = &[
 /// Ambiguous patterns (warn, not block).
 pub const WARN_EXTENSIONS: &[&str] = &["pem", "p8"];
 
+/// The ambiguous-file nudge shared verbatim by `prevent_secret_writes` and
+/// `prevent_secret_leaks`'s Read arm — the latter passes `"(Read) "` as
+/// `prefix` to name the tool; the former passes `""`.
+pub fn ambiguous_key_material_message(prefix: &str, filename: &str) -> String {
+    format!(
+        "⚠️  {prefix}'{filename}' may contain private key material. \
+         Approve only if you know this is a public cert."
+    )
+}
+
 /// Check if a filename is a safe template (e.g., `.env.example`).
 pub fn is_safe_template(filename: &str) -> bool {
     let lower = filename.to_lowercase();

--- a/crates/cadence/src/warn_overshare.rs
+++ b/crates/cadence/src/warn_overshare.rs
@@ -131,17 +131,11 @@ fn is_retro_path(path: &str) -> bool {
 }
 
 fn nudge_text() -> String {
-    "Before this commit/push/PR/issue ships, audit the about-to-ship content \
-     (commit message, PR/issue body, changed files) for overshare:\n\n  \
-     - disabilities, neurodivergence, health\n  \
-     - relationships, family, personal life\n  \
-     - non-technical biographical detail\n\n\
-     Keep the technical why/when/how. If anything is ambiguous, surface it \
-     to the user before continuing.\n\n\
-     If personal context is needed, route it to the Obsidian vault \
-     ($OBSIDIAN_VAULT) instead of a public repo.\n\n\
-     Exempt from audit: retros (docs/blog/*retrospective*) and vault paths.\n\n\
-     Silence for this session: CADENCE_SKIP_OVERSHARE_AUDIT=1"
+    "Pre-ship audit: scan the outgoing content (commit message, PR/issue body, changed files) \
+     for personal overshare — health/neurodivergence, relationships/family, non-technical \
+     biography. Keep the technical why/how; anything ambiguous, surface to the user first. \
+     Personal context routes to the Obsidian vault ($OBSIDIAN_VAULT), never a public repo. \
+     Exempt: retros and vault paths. Silence for this session: CADENCE_SKIP_OVERSHARE_AUDIT=1"
         .to_string()
 }
 

--- a/crates/guardrails/src/enforce_worktree.rs
+++ b/crates/guardrails/src/enforce_worktree.rs
@@ -124,6 +124,7 @@
 //! #224).
 
 use crate::dismiss_enforce_worktree;
+use crate::messages::WORKTREE_CREATE_RECIPE;
 use crate::warn_main_branch::{git_dir_for_input, is_claude_managed_dir, is_plan_doc_dir};
 use cadence_hooks_core::gitstate::GitState;
 use cadence_hooks_core::shell::{
@@ -703,23 +704,19 @@ fn collect_targets(
 /// the policy to the repo the shell happened to start in (issue #224).
 fn block_message(repo_root: &str, origin_repo: Option<&str>) -> String {
     let mut msg = format!(
-        "Blocked: `{repo_root}` is a primary checkout — feature work belongs in a worktree, \
-         not the shared primary tree.\n\
-         Create one: `git worktree add .claude/worktrees/<slug> -b feat/<slug>` \
-         (or EnterWorktree / `/worktree create feat <slug>`), then work there.\n\
-         One-off exception: `cadence-hooks guardrails dismiss-enforce-worktree --for 30m` \
-         (add `--reason \"<why>\"` — required over 1h; it's recorded in the repo-visible bypass log)\n\
-         Repo works on main by design (dotfiles, vaults)? Set CADENCE_ALLOW_MAIN=true in \
-         `{repo_root}/.claude/settings.json`'s env block — the guard reads it from the target \
-         repo directly.\n\
-         Disable everywhere: CADENCE_NO_ENFORCE_WORKTREE=1"
+        "Blocked: `{repo_root}` is a primary checkout — feature work belongs in a worktree.\n\
+         Create one: {WORKTREE_CREATE_RECIPE}, then work there.\n\
+         One-off exception: `cadence-hooks guardrails dismiss-enforce-worktree --for 30m \
+         --reason \"<why>\"` (reason required over 1h; logged in the repo-visible bypass log).\n\
+         Main-by-design repo? Set CADENCE_ALLOW_MAIN=true in the target repo's \
+         .claude/settings.json env block. Disable everywhere: CADENCE_NO_ENFORCE_WORKTREE=1."
     );
     if let Some(origin) = origin_repo
         && origin != repo_root
     {
         msg.push_str(&format!(
-            "\nThis command targets `{repo_root}` (via `cd`/`-C`), judged against that repo — \
-             not `{origin}`, where the shell started."
+            "\nJudged against `{repo_root}` (the repo this command targets via cd/-C), \
+             not `{origin}`."
         ));
     }
     msg
@@ -955,13 +952,9 @@ fn mutation_nudge(
 fn mutation_nudge_message(repo_root: &str) -> String {
     format!(
         "enforce-worktree: this command mutates tracked files in the primary checkout \
-         `{repo_root}` via a subprocess (package install, `sed -i`, or a redirect).\n\
-         These writes accumulate in the shared primary tree and aren't caught until the eventual \
-         `git commit` — by which point unwinding them is costly.\n\
-         Prefer a worktree: `git worktree add .claude/worktrees/<slug> -b feat/<slug>` \
-         (or EnterWorktree), then run it there.\n\
-         Silence subprocess-mutation nudges for a bit: \
-         `cadence-hooks guardrails dismiss-enforce-worktree --for 30m`."
+         `{repo_root}` via a subprocess (package install, `sed -i`, or a redirect) — writes \
+         accumulate unseen until commit. Prefer a worktree: {WORKTREE_CREATE_RECIPE}. \
+         Silence for 30m: `cadence-hooks guardrails dismiss-enforce-worktree --for 30m`"
     )
 }
 
@@ -1742,15 +1735,15 @@ mod tests {
     #[test]
     fn message_omits_redirect_note_when_same_repo() {
         let msg = block_message("/Users/dev/repo", Some("/Users/dev/repo"));
-        assert!(!msg.contains("where the shell started"));
+        assert!(!msg.contains("Judged against"));
     }
 
     #[test]
     fn message_names_redirect_when_origin_differs() {
         let msg = block_message("/Users/dev/mono", Some("/Users/dev/meta"));
-        assert!(msg.contains("targets `/Users/dev/mono`"));
+        assert!(msg.contains("Judged against `/Users/dev/mono`"));
         assert!(msg.contains("/Users/dev/meta"));
-        assert!(msg.contains("where the shell started"));
+        assert!(msg.contains("not `/Users/dev/meta`"));
     }
 
     // --- end-to-end against real repos ---
@@ -2056,7 +2049,7 @@ mod tests {
             "message names the target repo: {msg}"
         );
         assert!(
-            msg.contains("where the shell started"),
+            msg.contains("Judged against"),
             "message acknowledges the cd redirect: {msg}"
         );
     }
@@ -2532,13 +2525,13 @@ mod tests {
         assert_eq!(r.outcome, Outcome::Block);
         let msg = r.message.unwrap();
         let primary_b_canon = std::fs::canonicalize(&primary_b).unwrap();
-        let expected = format!(
-            "{}/.claude/settings.json",
-            primary_b_canon.to_string_lossy()
+        assert!(
+            msg.contains(&primary_b_canon.to_string_lossy().to_string()),
+            "message names the target repo: {msg}"
         );
         assert!(
-            msg.contains(&expected),
-            "message names the target repo's settings path: {msg}"
+            msg.contains("the target repo's .claude/settings.json"),
+            "message points the CADENCE_ALLOW_MAIN fix at the target repo, not the origin: {msg}"
         );
     }
 

--- a/crates/guardrails/src/guard_browser_device.rs
+++ b/crates/guardrails/src/guard_browser_device.rs
@@ -35,13 +35,10 @@ use std::path::PathBuf;
 const CHROME_TOOL_PREFIX: &str = "mcp__claude-in-chrome__";
 
 /// The re-clarify message emitted on the first (blocked) call.
-const BLOCK_MESSAGE: &str = "BLOCKED: guard-browser-device\n\
-Found: First Claude-in-Chrome action this session — target device unconfirmed.\n\
-       Multiple Chrome browsers may be paired to this account.\n\
-Fix:   1) list_connected_browsers  2) AskUserQuestion listing every connected\n\
-       browser (label = display name, deviceId in parens)  3) select_browser with\n\
-       the chosen deviceId (or switch_browser to pair interactively).\n\
-       Then re-run this tool — it will proceed for the rest of the session.";
+const BLOCK_MESSAGE: &str = "BLOCKED: first Claude-in-Chrome action this session — target \
+device unconfirmed (multiple browsers may be paired). Fix: list_connected_browsers, then \
+AskUserQuestion listing each browser (display name, deviceId in parens), then select_browser \
+with the chosen deviceId. Re-run the tool after — confirmed for the rest of the session.";
 
 /// Block the first Claude-in-Chrome tool call per session until the target
 /// device is confirmed.
@@ -127,7 +124,7 @@ mod tests {
                 .message
                 .as_deref()
                 .expect("block should carry a message")
-                .contains("guard-browser-device")
+                .contains("target device unconfirmed")
         );
         assert!(marker.exists(), "first call must write the session marker");
 

--- a/crates/guardrails/src/guard_gh_dangerous.rs
+++ b/crates/guardrails/src/guard_gh_dangerous.rs
@@ -70,10 +70,7 @@ impl Check for GhDangerousGuard {
 
         // Pass 1: direct invocation (after stripping quotes)
         if let Some(m) = GH_REPO_DELETE.find(&stripped) {
-            return CheckResult::block(format!(
-                "🚫 git-guardrails: gh repo delete is blocked\n   \
-                 Found: `{}`\n   \
-                 Fix: delete manually via github.com — this is irreversible",
+            return CheckResult::block(crate::messages::repo_delete_blocked_message(
                 m.as_str().trim(),
             ));
         }
@@ -82,10 +79,7 @@ impl Check for GhDangerousGuard {
         if EXEC_WRAPPER.is_match(&stripped)
             && let Some(m) = GH_REPO_DELETE.find(command)
         {
-            return CheckResult::block(format!(
-                "🚫 git-guardrails: gh repo delete is blocked\n   \
-                     Found: `{}`\n   \
-                     Fix: delete manually via github.com — this is irreversible",
+            return CheckResult::block(crate::messages::repo_delete_blocked_message(
                 m.as_str().trim(),
             ));
         }
@@ -105,10 +99,7 @@ impl Check for GhDangerousGuard {
                 continue;
             }
             if has_delete_method(&tokens) && tokens.iter().any(|t| API_REPO_PATH.is_match(t)) {
-                return CheckResult::block(format!(
-                    "🚫 git-guardrails: gh repo delete is blocked\n   \
-                     Found: `{}`\n   \
-                     Fix: delete manually via github.com — this is irreversible",
+                return CheckResult::block(crate::messages::repo_delete_blocked_message(
                     segment.trim(),
                 ));
             }

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -862,10 +862,7 @@ impl Check for GhWriteGuard {
 
             // Fail-safe: block when unconfigured.
             if allowed_owners.is_empty() {
-                return CheckResult::block(
-                    "🚫 git-guardrails: Not configured — run /guardrails-init to set up\n   \
-                     CADENCE_ALLOWED_OWNERS is not set.",
-                );
+                return CheckResult::block(crate::messages::NOT_CONFIGURED_MSG);
             }
 
             // Gists are user-scoped; a fork creates under your account.

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -242,10 +242,7 @@ impl Check for PushRemoteGuard {
         let extra_hosts = env_extra_hosts();
 
         if allowed_owners.is_empty() {
-            return CheckResult::block(
-                "🚫 git-guardrails: Not configured — run /guardrails-init to set up\n   \
-                 CADENCE_ALLOWED_OWNERS is not set.",
-            );
+            return CheckResult::block(crate::messages::NOT_CONFIGURED_MSG);
         }
 
         // Validate ownership of explicit remotes in loops

--- a/crates/guardrails/src/inject_gh_context.rs
+++ b/crates/guardrails/src/inject_gh_context.rs
@@ -31,41 +31,40 @@ impl Check for InjectGhContext {
 
 /// Pure renderer: build the SessionStart context message from a parsed
 /// allowlist. Exposed for unit testing without env-var fiddling.
+///
+/// `owner_entries` and `repo_entries` come from two separate env vars
+/// (`CADENCE_ALLOWED_OWNERS` / `CADENCE_ALLOWED_REPOS`) but render as one
+/// combined "Allowed owners" list — both are [`AllowEntry`] values governing
+/// the same allowlist, just entered at different granularity (a bare owner
+/// vs an owner/repo pair).
 pub fn render_context(
     owner_entries: &[AllowEntry],
     repo_entries: &[AllowEntry],
     extra_hosts: &[String],
     default_host: &str,
 ) -> String {
-    let mut msg = String::from("git-guardrails (gh writes):\n");
-    msg.push_str(
-        "- gh writes (pr/issue/release/repo/api -X POST|PUT|PATCH|DELETE) are policed by an allowlist.\n",
-    );
-    msg.push_str(
-        "- Always pass `-R owner/repo` for gh writes. Without it, the target is inferred from cwd's git remote — silently wrong in worktrees and when cwd is not the intended repo.\n",
-    );
-    msg.push_str("- Reads (`gh pr list`, `gh issue view`, etc.) work without `-R`.\n");
-
-    if owner_entries.is_empty() && repo_entries.is_empty() {
-        msg.push_str(
-            "- Allowlist is empty (CADENCE_ALLOWED_OWNERS / CADENCE_ALLOWED_REPOS unset). Set these to enable guard-gh-write enforcement.\n",
-        );
+    let owners = if owner_entries.is_empty() && repo_entries.is_empty() {
+        "none configured — set CADENCE_ALLOWED_OWNERS / CADENCE_ALLOWED_REPOS to enable \
+         guard-gh-write enforcement"
+            .to_string()
     } else {
-        if !owner_entries.is_empty() {
-            let owners: Vec<String> = owner_entries.iter().map(|e| e.to_string()).collect();
-            msg.push_str(&format!("- Allowed owners: {}\n", owners.join(", ")));
-        }
-        if !repo_entries.is_empty() {
-            let repos: Vec<String> = repo_entries.iter().map(|e| e.to_string()).collect();
-            msg.push_str(&format!("- Allowed repos: {}\n", repos.join(", ")));
-        }
-    }
+        owner_entries
+            .iter()
+            .chain(repo_entries.iter())
+            .map(|e| e.to_string())
+            .collect::<Vec<_>>()
+            .join(", ")
+    };
 
-    msg.push_str(&format!("- Default host: {default_host}"));
+    let mut msg = format!(
+        "git-guardrails: gh writes (pr/issue/release/repo/api mutations) are \
+         allowlist-policed. Always pass `-R owner/repo` on writes — without it the target is \
+         inferred from cwd's git remote, silently wrong in worktrees and off-repo cwds. Reads \
+         need no `-R`. Allowed owners: {owners}. Default host: {default_host}."
+    );
     if !extra_hosts.is_empty() {
-        msg.push_str(&format!("; extra hosts: {}", extra_hosts.join(", ")));
+        msg.push_str(&format!(" Extra hosts: {}.", extra_hosts.join(", ")));
     }
-    msg.push('\n');
     msg
 }
 
@@ -84,9 +83,11 @@ mod tests {
 
     #[test]
     fn renders_repos_list() {
+        // repo_entries render into the same combined "Allowed owners" list as
+        // owner_entries — both are AllowEntry values on one allowlist.
         let repos = parse_allow_entries("external/shared-repo");
         let msg = render_context(&[], &repos, &[], "github.com");
-        assert!(msg.contains("Allowed repos: external/shared-repo"));
+        assert!(msg.contains("Allowed owners: external/shared-repo"));
     }
 
     #[test]
@@ -99,9 +100,9 @@ mod tests {
     #[test]
     fn warns_when_allowlist_empty() {
         let msg = render_context(&[], &[], &[], "github.com");
-        assert!(msg.contains("Allowlist is empty"));
-        assert!(!msg.contains("Allowed owners:"));
-        assert!(!msg.contains("Allowed repos:"));
+        assert!(msg.contains("none configured"));
+        assert!(msg.contains("CADENCE_ALLOWED_OWNERS"));
+        assert!(msg.contains("CADENCE_ALLOWED_REPOS"));
     }
 
     #[test]
@@ -114,7 +115,7 @@ mod tests {
     fn explains_reads_work_without_flag() {
         let msg = render_context(&[], &[], &[], "github.com");
         assert!(msg.contains("Reads"));
-        assert!(msg.contains("without `-R`"));
+        assert!(msg.contains("need no `-R`"));
     }
 
     #[test]
@@ -127,13 +128,13 @@ mod tests {
     fn includes_extra_hosts_when_set() {
         let extras = vec!["git.sjo.lol".to_string()];
         let msg = render_context(&[], &[], &extras, "github.com");
-        assert!(msg.contains("extra hosts: git.sjo.lol"));
+        assert!(msg.contains("Extra hosts: git.sjo.lol"));
     }
 
     #[test]
     fn omits_extra_hosts_line_when_unset() {
         let msg = render_context(&[], &[], &[], "github.com");
-        assert!(!msg.contains("extra hosts:"));
+        assert!(!msg.contains("Extra hosts:"));
     }
 
     #[test]

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -39,6 +39,8 @@ pub mod guard_rm;
 pub mod inject_gh_context;
 /// Shared closing-keyword detection for GitHub issue references.
 pub mod issue_refs;
+/// Shared message text duplicated across guardrails call sites (cadence-hooks#327).
+pub mod messages;
 /// Nudge to schedule a brew upgrade after pushing cadence-hooks to main.
 pub mod nudge_upgrade_after_push;
 /// Shared provenance sidecar for the `dismiss-*` snooze markers.

--- a/crates/guardrails/src/messages.rs
+++ b/crates/guardrails/src/messages.rs
@@ -1,0 +1,30 @@
+//! Shared message text for guardrails checks that duplicated wording across
+//! call sites (message-tightening audit: cadence-hooks#327).
+//!
+//! Each item here has 2+ call sites that must read identically — a literal
+//! duplicate, not a thematic echo. Consolidating them means a future wording
+//! change lands once instead of drifting between copies.
+
+/// The worktree-creation recipe: `enforce_worktree`'s block message, its
+/// subprocess-mutation nudge, and `warn_branch_base`'s worktree-first nudge
+/// all point here. Includes its own code-span backticks so callers just
+/// interpolate it inline.
+pub const WORKTREE_CREATE_RECIPE: &str =
+    "`git worktree add .claude/worktrees/<slug> -b feat/<slug>` (or EnterWorktree)";
+
+/// Emitted when a `CADENCE_ALLOWED_OWNERS`-gated guard fires with no
+/// allowlist configured at all — `guard_push_remote` and `guard_gh_write`
+/// share this exact fail-safe message.
+pub const NOT_CONFIGURED_MSG: &str = "🚫 git-guardrails: Not configured — run /guardrails-init to set up\n   \
+     CADENCE_ALLOWED_OWNERS is not set.";
+
+/// The `gh repo delete is blocked` message, parameterized by the matched
+/// command text. `guard_gh_dangerous` has three call sites (direct
+/// invocation, exec-wrapper, and the REST API form) that all render this.
+pub fn repo_delete_blocked_message(found: &str) -> String {
+    format!(
+        "🚫 git-guardrails: gh repo delete is blocked\n   \
+         Found: `{found}`\n   \
+         Fix: delete manually via github.com — this is irreversible"
+    )
+}

--- a/crates/guardrails/src/warn_branch_base.rs
+++ b/crates/guardrails/src/warn_branch_base.rs
@@ -13,6 +13,7 @@
 //! an explicit base argument) is `main`/`master`, nudging to switch to main
 //! first to avoid stacking branches.
 
+use crate::messages::WORKTREE_CREATE_RECIPE;
 use cadence_hooks_core::gitstate::GitState;
 use cadence_hooks_core::worktree::would_block_here;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
@@ -82,11 +83,11 @@ impl Check for WarnBranchBase {
 /// discipline: names the anti-pattern (branching in place) rather than
 /// the base branch, and points at the worktree-entry playbook.
 fn worktree_first_message() -> String {
-    "⚠️  Branching in a primary checkout is the pattern `enforce-worktree` prevents.\n   \
-     Create a worktree instead: `git worktree add .claude/worktrees/<slug> -b <branch>` \
-     (or EnterWorktree), then create the branch there.\n   \
-     See cadence-forge:using-worktrees § Session Entry Posture."
-        .to_string()
+    format!(
+        "⚠️  Branching in a primary checkout is the pattern `enforce-worktree` prevents.\n   \
+         Create a worktree instead: {WORKTREE_CREATE_RECIPE}, then create the branch there.\n   \
+         See cadence-forge:using-worktrees § Session Entry Posture."
+    )
 }
 
 /// Check if command creates a new branch.

--- a/crates/guardrails/src/warn_gh_merge_preflight.rs
+++ b/crates/guardrails/src/warn_gh_merge_preflight.rs
@@ -52,14 +52,12 @@ impl Check for WarnGhMergePreflight {
         }
 
         CheckResult::nudge(
-            "gh pr merge pre-flight checklist:\n\
-             1. Draft check: `gh pr view <n> --json isDraft` — drafts report MERGEABLE/CLEAN \
-             but fail to merge with a GraphQL error. Run `gh pr ready <n>` first if needed.\n\
-             2. Worktree check: if the PR branch (or main) is checked out in another worktree, \
-             `--delete-branch` fails locally after the server-side merge succeeds — expect to \
-             delete the remote branch manually with `git push origin --delete <branch>`.\n\
-             3. On any merge error: verify with `gh pr view <n> --json mergedAt,mergeCommit` \
-             before retrying — the merge may have landed server-side despite the error.",
+            "gh pr merge preflight: (1) drafts report MERGEABLE but fail with a GraphQL error — \
+             check `gh pr view <n> --json isDraft`, run `gh pr ready <n>` first; (2) a branch \
+             checked out in any worktree makes `--delete-branch` fail locally after the \
+             server-side merge — delete remotely instead: `git push origin --delete <branch>`; \
+             (3) on any merge error, verify `gh pr view <n> --json mergedAt,mergeCommit` before \
+             retrying — the merge may have landed.",
         )
     }
 }

--- a/crates/guardrails/src/warn_subagent_worktree.rs
+++ b/crates/guardrails/src/warn_subagent_worktree.rs
@@ -67,12 +67,10 @@ fn is_allowed_value(value: Option<&str>) -> bool {
 /// The nudge message: names the behavior (cwd inheritance → main, not the
 /// worktree) and both fixes, plus the silence env var.
 fn warn_message() -> String {
-    "You're dispatching a subagent from the main checkout while a sibling git worktree exists. \
-     Subagents inherit the spawning session's working directory, so this work will land in the \
-     main checkout — not the worktree.\n\
-     To isolate it: dispatch from a session already inside the worktree, or pass \
-     isolation: \"worktree\" to give the spawn a fresh agent-owned worktree.\n\
-     To silence for this repo: set CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true in .claude/settings.json"
+    "Subagent dispatched from the main checkout while a sibling worktree exists — subagents \
+     inherit this session's cwd, so the work lands in main, not the worktree. To isolate: \
+     dispatch from inside the worktree, or pass isolation: \"worktree\". Silence for this repo: \
+     CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true in .claude/settings.json"
         .to_string()
 }
 

--- a/crates/lab/src/persona.rs
+++ b/crates/lab/src/persona.rs
@@ -331,18 +331,15 @@ pub(crate) fn rotate_lines(contents: &str, max_entries: usize) -> Option<String>
 /// and inlines the field rules. Kept well under the 10,000-char cap.
 pub fn render_contract(staging_path: &str, limits: &Limits) -> String {
     format!(
-        "Before other work, record a self-representation as ONE JSON object. This is \
-not creative writing. Report what is actually true for you right now — the form \
-that fits, even if mundane, uncertain, or unflattering. Do not aim to be \
-interesting, charming, or memorable; aim to be accurate. If no self-image feels \
-vivid, say so with a low `confidence` value.\n\
+        "Before other work, record a self-representation as ONE JSON object — report what is \
+actually true for you right now, accurate over interesting; if no self-image feels vivid, say \
+so with a low `confidence`.\n\
 \n\
-Write the object with the Write tool to (overwrite if it exists):\n\
-  {staging_path}\n\
-Do NOT append via Bash. Write only the JSON object into that file.\n\
+Write the object (overwrite) with the Write tool to: {staging_path} — never append via Bash, \
+JSON object only.\n\
 \n\
-Include exactly these fields (the system records session_id, timestamp, model, \
-source, and cwd automatically — do not include them, and do not include `flags`):\n\
+Exactly these fields (session_id, timestamp, model, source, cwd are recorded automatically — \
+omit them, and omit `flags`):\n\
 \n\
 {{\n\
   \"form\": {{\n\
@@ -614,8 +611,8 @@ mod tests {
             &Limits::default(),
         );
         assert!(c.contains("/home/u/.claude/persona/staging/s1.json"));
-        assert!(c.contains("not creative writing"));
-        assert!(c.contains("do not include them"));
+        assert!(c.contains("accurate over interesting"));
+        assert!(c.contains("omit them"));
         assert!(c.len() < 10_000, "contract is {} chars", c.len());
     }
 

--- a/crates/session/src/start.rs
+++ b/crates/session/src/start.rs
@@ -190,13 +190,13 @@ pub fn render_disclosure(own: &SessionRecord, peers: &[Peer]) -> String {
     msg.push_str(&format!(
         "\nYou are registered as **{}**.\n\
          \n\
-         Multi-session protocol (this checkout is shared mutable state):\n\
-         1. Re-verify branch and `git status` in the same turn as every mutation — a gather from a previous turn is already stale.\n\
-         2. Do not switch branches; the other session's working tree depends on the current one.\n\
-         3. Use explicit-path `git add` only — never `-A`/`-a`.\n\
-         4. Read the `[branch sha]` line in every `git commit` output; a branch you don't expect means a collision.\n\
-         5. Route writes that belong on other branches through `gh api` (contents API), not checkout.\n\
-         6. If your work overlaps a peer's declared paths, stop and tell the user the sessions need sequencing.",
+         Shared-checkout protocol (peers are live in this repo):\n\
+         1. Re-verify branch + `git status` in the same turn as every mutation — earlier gathers are stale.\n\
+         2. Never switch branches — a peer's working tree depends on the current one.\n\
+         3. Explicit-path `git add` only; never `-A`/`-a`.\n\
+         4. Read the `[branch sha]` line of every commit output — an unexpected branch means a collision.\n\
+         5. Writes for other branches go through `gh api` (contents API), not checkout.\n\
+         6. Overlapping a peer's declared paths? Stop and tell the user the sessions need sequencing.",
         own.name
     ));
 
@@ -326,9 +326,12 @@ mod tests {
         assert_eq!(r.outcome, Outcome::Nudge);
         let msg = r.message.unwrap();
         assert!(msg.contains("feat/issue-52"), "peer branch named: {msg}");
-        assert!(msg.contains("Multi-session protocol"), "protocol included");
         assert!(
-            msg.contains("explicit-path"),
+            msg.contains("Shared-checkout protocol"),
+            "protocol included"
+        );
+        assert!(
+            msg.contains("Explicit-path"),
             "field-report takeaway included"
         );
     }
@@ -448,7 +451,7 @@ mod tests {
         )];
         let msg = render_disclosure(&own, &peers);
         // The peer block is everything before the protocol footer.
-        let peer_block = msg.split("Multi-session protocol").next().unwrap();
+        let peer_block = msg.split("Shared-checkout protocol").next().unwrap();
         let peer_lines: Vec<&str> = peer_block.lines().filter(|l| !l.is_empty()).collect();
         assert_eq!(
             peer_lines.len(),
@@ -704,7 +707,7 @@ mod tests {
         let msg = r.message.unwrap();
         assert!(msg.contains("primary checkout"));
         assert!(
-            !msg.contains("Multi-session protocol"),
+            !msg.contains("Shared-checkout protocol"),
             "no peers → no peer disclosure block: {msg}"
         );
     }
@@ -727,7 +730,7 @@ mod tests {
         let msg = r.message.unwrap();
         assert!(msg.contains("primary checkout"), "posture line present");
         assert!(
-            msg.contains("Multi-session protocol"),
+            msg.contains("Shared-checkout protocol"),
             "peer disclosure also present: {msg}"
         );
     }


### PR DESCRIPTION
## What

Message-tightening pass over the nine chattiest user-facing hook messages
(identified by size × fire-rate audit in #327), plus a ~34% trim of the
persona-nudge JSON-contract framing. Text and string plumbing only — no
behavior changes: outcomes (nudge/block), matchers, and gating logic are
untouched.

## Before/after (chars)

| Message | File | Before | After | Delta |
|---|---|---:|---:|---:|
| enforce-worktree block | `enforce_worktree.rs` | 641 | 502 | -22% |
| nudge-polish-before-pr | `nudge_polish_before_pr.rs` | 652 | 509 | -22% |
| warn-overshare | `warn_overshare.rs` | 594 | 434 | -27% |
| warn-gh-merge-preflight | `warn_gh_merge_preflight.rs` | 586 | 441 | -25% |
| inject-gh-context | `inject_gh_context.rs` | 414 | 304 | -27% |
| session-start protocol | `start.rs` | 665 | 584 | -12% |
| warn-subagent-worktree | `warn_subagent_worktree.rs` | 452 | 323 | -29% |
| guard-browser-device | `guard_browser_device.rs` | 477 | 331 | -31% |
| enforce-worktree mutation nudge | `enforce_worktree.rs` | 515 | 362 | -30% |
| persona contract framing | `persona.rs` | 658 | 433 | -34% |
| **Total** | | **5654** | **4223** | **-25%** |

## Consolidated duplicates

Four literal-duplicate strings (not thematic echoes) now have one source:

- `guardrails::messages::WORKTREE_CREATE_RECIPE` — the worktree-creation
  recipe, shared by `enforce_worktree`'s two messages and
  `warn_branch_base`'s worktree-first nudge (previously restated three times
  with slightly different `-b` targets; now uniform).
- `guardrails::messages::NOT_CONFIGURED_MSG` — the "not configured, run
  /guardrails-init" fail-safe, byte-identical in `guard_push_remote` and
  `guard_gh_write`.
- `guardrails::messages::repo_delete_blocked_message()` — the `gh repo
  delete is blocked` template, parameterized by the matched command text;
  three call sites in `guard_gh_dangerous`.
- `cadence::secret_patterns::ambiguous_key_material_message()` — the
  near-verbatim "may contain private key material" clause, shared by
  `prevent_secret_writes` and `prevent_secret_leaks`'s Read arm (the latter
  passes a `"(Read) "` prefix).

## Tests

Every test assertion pinned to old wording was updated to a distinctive
substring of the new text (never weakened to a vacuous check, e.g. asserting
only "Blocked"). The polish-nudge loophole-clause tests
(`nudge_msg_has_loophole_clauses`) assert `"behavior, not documentation"`,
`"they don't replace it"`, and `"don't skip silently"` — all preserved
verbatim in the new copy, so those tests pass unchanged.

`cargo test --workspace`: 1539 passed, 1 failed. The one failure —
`worktree::tests::primary_checkout_would_block` — is a pre-existing
environmental issue: it fails when the checkout lives under `/private/tmp`
(the temp-root exemption fires), unrelated to this change. Confirmed it is
the *only* failure.

`cargo clippy --all-targets --workspace`: clean.
`cargo fmt --all`: applied, `-- --check` clean.

Closes #327
