### PR TITLE
fix(cadence): drop retro-path exemption from warn-overshare

### DIFF
--- a/crates/cadence/src/warn_overshare.rs
+++ b/crates/cadence/src/warn_overshare.rs
@@ -9,8 +9,11 @@
 //!   that legitimately hold personal context.
 //! - Write/Edit under `$OBSIDIAN_VAULT` — the vault is the safe destination
 //!   for personal context, not a public repo.
-//! - Write/Edit to retro paths (`docs/blog/*retro*`) — retros are blog
-//!   source material and intentionally personal.
+//!
+//! The prior retro-path exemption (`docs/blog/*retro*`) was removed in
+//! cadence-hooks#329: `cadence:retro` relocated its output out of the repo
+//! (vault primary, gitignored fallback), so retro paths no longer have a
+//! sanctioned repo destination to exempt.
 
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
@@ -25,8 +28,6 @@ const BASH_THREE_TOKEN_TRIGGERS: &[[&str; 3]] = &[
 ];
 
 const FIELD_REPORTS_MARKER: &str = "/docs/field-reports/";
-const BLOG_MARKER: &str = "/docs/blog/";
-const RETRO_TOKEN: &str = "retro";
 
 /// Nudges the model to audit about-to-ship content for overshare before
 /// commits, pushes, PRs/issues, or field-report writes ship.
@@ -108,26 +109,11 @@ fn is_bash_overshare_trigger(command: &str) -> bool {
     })
 }
 
-/// True when `path` is under the Obsidian vault or matches a retro path.
+/// True when `path` is under the Obsidian vault.
 ///
-/// Vault paths are the safe destination for personal context; retros
-/// (docs/blog/*retro*) feed blog articles and are intentionally personal.
+/// Vault paths are the safe destination for personal context.
 fn path_is_exempt(path: &str, vault: Option<&str>) -> bool {
-    if let Some(v) = vault
-        && !v.is_empty()
-        && path.starts_with(v)
-    {
-        return true;
-    }
-    is_retro_path(path)
-}
-
-fn is_retro_path(path: &str) -> bool {
-    if !path.contains(BLOG_MARKER) {
-        return false;
-    }
-    let filename = path.rsplit('/').next().unwrap_or(path);
-    filename.contains(RETRO_TOKEN)
+    matches!(vault, Some(v) if !v.is_empty() && path.starts_with(v))
 }
 
 fn nudge_text() -> String {
@@ -140,7 +126,7 @@ fn nudge_text() -> String {
      to the user before continuing.\n\n\
      If personal context is needed, route it to the Obsidian vault \
      ($OBSIDIAN_VAULT) instead of a public repo.\n\n\
-     Exempt from audit: retros (docs/blog/*retrospective*) and vault paths.\n\n\
+     Exempt from audit: vault paths.\n\n\
      Silence for this session: CADENCE_SKIP_OVERSHARE_AUDIT=1"
         .to_string()
 }
@@ -324,7 +310,10 @@ mod tests {
     }
 
     #[test]
-    fn retrospective_blog_path_skips_audit() {
+    fn retrospective_blog_path_allows_via_default_fallthrough() {
+        // No longer an exemption (cadence-hooks#329) — this allows because
+        // it isn't a field-report path, same as any other non-field-report,
+        // non-vault Write/Edit target.
         let result = run(&make_write(
             "/Users/c/proj/docs/blog/2026-06-02-foo-retrospective.md",
             "blog post",
@@ -333,7 +322,10 @@ mod tests {
     }
 
     #[test]
-    fn retro_blog_path_skips_audit() {
+    fn retro_blog_path_allows_via_default_fallthrough() {
+        // No longer an exemption (cadence-hooks#329) — this allows because
+        // it isn't a field-report path, same as any other non-field-report,
+        // non-vault Write/Edit target.
         let result = run(&make_write(
             "/Users/c/proj/docs/blog/2026-06-05-foo-retro.md",
             "blog post",
@@ -350,6 +342,19 @@ mod tests {
             "blog post",
         ));
         assert_eq!(result.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn retro_named_path_under_field_reports_marker_nudges() {
+        // Highest-signal case: a path that would have matched the (now
+        // removed) retro exemption AND the field-reports marker. With the
+        // exemption gone this must fall through to the field-report check
+        // and nudge, not exempt-allow. (cadence-hooks#329)
+        let result = run(&make_write(
+            "/Users/c/proj/docs/blog/notes/docs/field-reports/foo-retro.md",
+            "report content",
+        ));
+        assert_eq!(result.outcome, Outcome::Nudge);
     }
 
     // --- Edge cases ---
@@ -394,29 +399,5 @@ mod tests {
         // `cd foo && git commit ...` should still trigger.
         let result = run(&make_bash("cd foo && git commit -m bar"));
         assert_eq!(result.outcome, Outcome::Nudge);
-    }
-
-    // --- Helpers ---
-
-    #[test]
-    fn is_retro_path_matches_retrospective() {
-        assert!(is_retro_path(
-            "/a/docs/blog/2026-01-01-foo-retrospective.md"
-        ));
-    }
-
-    #[test]
-    fn is_retro_path_matches_retro() {
-        assert!(is_retro_path("/a/docs/blog/2026-01-01-retro.md"));
-    }
-
-    #[test]
-    fn is_retro_path_requires_blog_dir() {
-        assert!(!is_retro_path("/a/docs/notes/2026-01-01-retro.md"));
-    }
-
-    #[test]
-    fn is_retro_path_requires_token_in_filename() {
-        assert!(!is_retro_path("/a/docs/blog/2026-01-01-announcement.md"));
     }
 }

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -28,7 +28,7 @@ For how hooks communicate with Claude Code (stdin/stdout/exit codes), see
 
 `warn-overshare` does path triage only — it fires on commit/push/PR/issue Bash
 commands and on Write/Edit to `docs/field-reports/`, then leaves the content
-judgment to the model. It exempts retro paths and writes under `$OBSIDIAN_VAULT`
+judgment to the model. It exempts writes under `$OBSIDIAN_VAULT`
 (the safe home for personal context), and is silenced session-wide with
 `CADENCE_SKIP_OVERSHARE_AUDIT=1`.
 


### PR DESCRIPTION
## Summary

Removes the `docs/blog/*retro*` exemption from the `warn-overshare` check. `cadence:retro` is relocating its output out of the repo (vault primary, gitignored fallback — see cameronsjo/cadence#499), so the exemption has no remaining sanctioned repo path to protect. It also keyed on a filename token, so any file keeping "retro" in its name under `docs/blog/` inherited the waiver at ship time — including polished articles forged from raw retro material, not just the raw capture itself.

- Deleted `is_retro_path`, `BLOG_MARKER`, `RETRO_TOKEN` from `crates/cadence/src/warn_overshare.rs`
- `path_is_exempt` now checks only the Obsidian vault path
- Updated the module doc comment and ship-nudge exempt clause to match
- Updated `docs/hooks.md`'s description of the check
- Added a test pinning the highest-signal behavioral change: a path matching both the old retro exemption and the field-reports marker now nudges instead of exempt-allowing

Branched from `origin/main`; note PR #328 rewrites the same nudge string for message tightening — whichever lands second takes a one-string rebase (this PR does not adopt #328's wording).

## Test plan

- [x] TDD: added a failing test (`retro_named_path_under_field_reports_marker_nudges`) confirming the old exemption short-circuited before the field-report check, then removed the exemption and watched it pass
- [x] `cargo test --workspace`: 493 passed, 1 failed (`worktree::tests::primary_checkout_would_block` — known pre-existing environmental failure under `/private/tmp` checkouts, unrelated to this change)
- [x] `cargo clippy --all-targets`: clean
- [x] `cargo fmt --all`: applied

Closes #329

Companion change relocating cadence:retro's output out of the repo: cameronsjo/cadence#499