### PR TITLE
fix(guardrails): recognize cross-repo closing keywords in warn-pr-issue-link (#270)

### DIFF
--- a/crates/guardrails/src/issue_refs.rs
+++ b/crates/guardrails/src/issue_refs.rs
@@ -11,11 +11,13 @@ use std::sync::LazyLock;
 /// Regex for issue-closing keywords followed by a `#<number>` ref.
 ///
 /// Matches: closes, closed, close, fixes, fixed, fix, resolves, resolved, resolve.
-/// Case-insensitive; captures the digit string after `#`.
+/// Case-insensitive. Captures the digit string after `#` as `num`, and an
+/// optional cross-repo `owner/repo` prefix as `repo`. Cross-repo
+/// `owner/repo#N` is recognized (URL form and `GH-N` remain out of scope).
 static CLOSING_KW_RE: LazyLock<Regex> = LazyLock::new(|| {
     // Word boundaries keep substring hits ("discloses", "prefixes") from
     // counting as closing keywords.
-    Regex::new(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s+#([0-9]+)\b")
+    Regex::new(r"(?i)\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s+(?P<repo>[A-Za-z0-9._-]+/[A-Za-z0-9._-]+)?#(?P<num>[0-9]+)\b")
         .expect("pattern should compile")
 });
 
@@ -31,7 +33,10 @@ pub fn has_closing_keyword(text: &str) -> bool {
 pub fn extract_refs(text: &str) -> Vec<u64> {
     let mut nums: Vec<u64> = CLOSING_KW_RE
         .captures_iter(text)
-        .filter_map(|cap| cap.get(1)?.as_str().parse::<u64>().ok())
+        // Same-repo only: a cross-repo `owner/repo#N` number would be closed
+        // against the PR's own repo, closing the wrong repo's issue.
+        .filter(|cap| cap.name("repo").is_none())
+        .filter_map(|cap| cap.name("num")?.as_str().parse::<u64>().ok())
         .collect();
     nums.sort_unstable();
     nums.dedup();
@@ -72,6 +77,19 @@ mod tests {
         assert!(!has_closing_keyword("this discloses #2 publicly"));
         assert!(!has_closing_keyword("prefixes #3 with a dash"));
         assert!(extract_refs("discloses #2 and prefixes #3").is_empty());
+    }
+
+    #[test]
+    fn has_closing_keyword_matches_cross_repo() {
+        assert!(has_closing_keyword("Closes cameronsjo/cadence#308"));
+        assert!(has_closing_keyword("Fixes owner/repo#5"));
+        assert!(has_closing_keyword("resolves a-b/c.d_e#7"));
+    }
+
+    #[test]
+    fn extract_refs_skips_cross_repo() {
+        assert!(extract_refs("Closes owner/repo#5").is_empty());
+        assert_eq!(extract_refs("Closes #3 and closes owner/repo#5"), vec![3]);
     }
 
     #[test]

--- a/crates/guardrails/src/warn_pr_issue_link.rs
+++ b/crates/guardrails/src/warn_pr_issue_link.rs
@@ -184,6 +184,32 @@ mod tests {
         assert!(judge_pr_create("gh pr create -t x -F body.md", &contents).is_none());
     }
 
+    // Regression for #270: a cross-repo `Closes owner/repo#N` in a body file
+    // must be recognized as a closing keyword — allow (no nudge).
+    #[test]
+    fn body_file_cross_repo_closes_allowed() {
+        let contents = BodyFile::Contents("Closes cameronsjo/cadence#308".into());
+        assert!(
+            judge_pr_create(
+                "gh pr create -R cameronsjo/cadence --draft --title x --body-file /tmp/pr-body-entry.md",
+                &contents
+            )
+            .is_none()
+        );
+    }
+
+    // Cross-repo `Closes owner/repo#N` in an inline body — allow (no nudge).
+    #[test]
+    fn inline_body_cross_repo_closes_allowed() {
+        assert!(
+            judge_pr_create(
+                r#"gh pr create --body "Closes owner/repo#5""#,
+                &BodyFile::Absent
+            )
+            .is_none()
+        );
+    }
+
     // Test case 6b: --body-file flag present but file unreadable — stay silent (ADR-0001).
     // An unreadable file is the check's own verification failure (write/hook race,
     // permissions, path resolution) — never bother the user about it.


### PR DESCRIPTION
## What

The closing-keyword detector required `#` immediately after the keyword, so a cross-repo reference like `Closes owner/repo#308` was invisible — the guard nudged PR authors who *had* linked an issue. This landed in both the inline `--body` and `--body-file` paths (the body-file contents are read; they just hit the same regex).

## How

- The shared regex in `issue_refs.rs` now admits an optional `owner/repo` prefix before `#N`, so `has_closing_keyword` recognizes cross-repo closing references.
- `extract_refs` filters to **same-repo refs only** (`repo` capture absent). This is deliberate: the auto-close verifier resolves extracted numbers against the PR's own repository, and a naively extracted cross-repo number would close the wrong repo's issue. Net behavior change for the auto-close path: zero.

## Tests

- `has_closing_keyword_matches_cross_repo` — `Closes cameronsjo/cadence#308`, `Fixes owner/repo#5`, `resolves a-b/c.d_e#7`.
- `extract_refs_skips_cross_repo` — cross-repo numbers never leak into extraction; mixed bodies keep only same-repo numbers.
- `body_file_cross_repo_closes_allowed` / `inline_body_cross_repo_closes_allowed` — regression tests for the exact reported shape.

Closes #270


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition of cross-repository issue references in closing keywords.
  * Prevented cross-repository references from being incorrectly treated as same-repository issue links.
  * Correctly handles these references in both inline text and body-file content without unnecessary warnings.
* **Tests**
  * Added coverage for cross-repository references and mixed same- and cross-repository issue links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->