### PR TITLE
ci(release): cut workflow-artifact retention to 1 day

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -102,6 +102,7 @@ jobs:
         with:
           name: ${{ matrix.name }}
           path: ${{ env.ARCHIVE }}
+          retention-days: 1
 
   release:
     name: Create Release


### PR DESCRIPTION
## What

Sets `retention-days: 1` on the release workflow's artifact upload step. The five platform archives only bridge the `build` → `release` job handoff within a single run; the durable copies are the GitHub Release assets themselves.

## Why

Without an explicit value they inherit the 90-day default, keeping ~5 binaries per release on workflow-artifact storage long after they're dead weight. One day is GitHub's minimum and still leaves a full day's window to pull the archives when debugging a failed release run.

No other workflow in the repo uploads artifacts, and nothing downloads these outside the same run (the Homebrew dispatch parses `checksums.txt` inline, not the artifacts).

Closes #301
