### PR TITLE
fix(doctor): liveness-aware --prune and actor-addressed --quiet warning

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -109,6 +109,7 @@ kept unprefixed because it's a cross-tool convention.
 | `CADENCE_METRICS_DEBUG` | `log-subagent` | Set to `1` to append a `_keys` array of the raw payload's top-level keys to subagent records — surfaces schema additions across Claude Code releases |
 | `CADENCE_METRICS_STALE_DAYS` | `warn-stale` | Days of metrics-write silence before the SessionStart alarm fires and `doctor` reports staleness (default 4); zero or unparseable falls back to the default |
 | `CADENCE_SESSION_STALE_MINUTES` | `session` hooks | Minutes of heartbeat silence before a session is presumed dead (default 10) |
+| `CADENCE_DOCTOR_PRUNE_FORCE` | `doctor --prune` | Set to `1` or `true` to bypass the live-session gate and let `doctor --prune --apply` delete orphaned plugin-cache version dirs even while peer sessions are running. The gate's refusal message names this override; otherwise run `/reload-plugins` in the live session first to release the retired dirs |
 | `GH_AUTOCLOSE_WAIT_SECONDS` | `verify-pr-autoclose` | Seconds to wait after `gh pr merge` before checking for straggler issues (default 10) |
 | `OBSIDIAN_VAULT` | `trash-guard`, `warn-overshare` | Absolute path to Obsidian vault — the trash guard scopes `rm` blocking to it, and the overshare audit treats it as the safe destination for personal context |
 

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -17,6 +17,9 @@ use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 
 use crate::registry;
+// The session crate's `registry` (peer-session liveness) — aliased because the
+// bare name is already taken by the binary's hook-catalog `registry` above.
+use cadence_hooks_session::registry as session_registry;
 
 /// Severity of a finding: errors block (shell bugs), warnings advise (version skew).
 #[derive(Debug, PartialEq)]
@@ -911,6 +914,42 @@ fn prune_orphans(dirs: &[PathBuf], apply: bool, cache_root: &Path) -> (usize, u6
     (removed, freed)
 }
 
+/// Whether `doctor --prune --apply` may proceed, or is blocked because live peer
+/// sessions are still running and may be pinned to plugin-cache version dirs
+/// that pruning would pull out from under them.
+enum PruneGate {
+    Proceed,
+    Blocked(Vec<String>),
+}
+
+/// Decide whether `--prune --apply` may run. Pure over its inputs so it is
+/// testable without a live registry.
+///
+/// `force` overrides everything (the `CADENCE_DOCTOR_PRUNE_FORCE` escape hatch).
+/// A `None` sessions dir means there is nothing to protect (not inside a repo),
+/// so it proceeds. Otherwise it blocks when any non-stale peer is registered,
+/// naming them. `own_session_id` is `""` so the invoking session itself counts
+/// as a live peer — a prune must not delete dirs the caller is pinned to —
+/// matching how `run_status` enumerates peers.
+///
+/// Limitation: the session registry is repo-scoped (`<repo>/.claude/sessions`),
+/// so sessions running in other checkouts against the same global plugin cache
+/// are invisible here — the gate is under-protective across repos, never
+/// over-destructive.
+fn prune_liveness_gate(sessions_dir: Option<&Path>, stale_secs: u64, force: bool) -> PruneGate {
+    if force {
+        return PruneGate::Proceed;
+    }
+    let Some(dir) = sessions_dir else {
+        return PruneGate::Proceed;
+    };
+    let live = session_registry::live_peers(dir, "", stale_secs);
+    if live.is_empty() {
+        return PruneGate::Proceed;
+    }
+    PruneGate::Blocked(live.into_iter().map(|p| p.record.name).collect())
+}
+
 /// `doctor --prune` entry point: list (or, with `apply`, remove) orphaned
 /// plugin-cache version dirs. Dry-run by default (decision D4) — `apply`
 /// must be paired with `prune` at the call site (`run` enforces this before
@@ -986,6 +1025,33 @@ fn run_prune(root_override: Option<&Path>, quiet: bool, apply: bool) -> u8 {
         }
     }
 
+    // Refuse to delete while live peer sessions may be pinned to these dirs.
+    // Only under default mode (not `--root`), mirroring the legacy-config gating
+    // below — `--root` fixtures must stay hermetic and never read live sessions.
+    // Dry-run deletes nothing, so the gate only guards the destructive `apply`.
+    if root_override.is_none() && apply {
+        let stale_secs = session_registry::stale_minutes() * 60;
+        let force = matches!(
+            std::env::var("CADENCE_DOCTOR_PRUNE_FORCE").as_deref(),
+            Ok("1") | Ok("true")
+        );
+        let sessions_dir = std::env::current_dir()
+            .ok()
+            .and_then(|cwd| session_registry::sessions_dir(&cwd.to_string_lossy()));
+        if let PruneGate::Blocked(names) =
+            prune_liveness_gate(sessions_dir.as_deref(), stale_secs, force)
+        {
+            eprintln!(
+                "cadence-hooks doctor --prune --apply: refusing to prune — {} live session(s) may be pinned to these version dirs: {}. \
+                 Run /reload-plugins in any live session first to release the retired dirs, then re-run. \
+                 Or re-run with CADENCE_DOCTOR_PRUNE_FORCE=1 to prune anyway.",
+                names.len(),
+                names.join(", ")
+            );
+            return 0;
+        }
+    }
+
     let (removed, freed_bytes) = prune_orphans(&dirs, apply, &cache_root);
     let freed_mib = freed_bytes as f64 / (1024.0 * 1024.0);
 
@@ -993,6 +1059,9 @@ fn run_prune(root_override: Option<&Path>, quiet: bool, apply: bool) -> u8 {
         if apply {
             println!(
                 "cadence-hooks doctor --prune --apply: removed {removed} orphaned version dir(s), freed ~{freed_mib:.1} MiB"
+            );
+            println!(
+                "  If any Claude Code session is currently running, run /reload-plugins in it now."
             );
         } else {
             println!(
@@ -2396,6 +2465,79 @@ mod tests {
         assert_eq!(freed, 0);
         assert!(outside.exists(), "outside dir must survive");
         assert!(outside.join("keepme").exists());
+    }
+
+    // ── prune_liveness_gate (#305) ──────────────────────────────────────────
+
+    /// Write a fresh peer record and return its sessions dir.
+    fn seed_session(name: &str, session_id: &str) -> tempfile::TempDir {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = tmp.path().join(".claude").join("sessions");
+        let rec = cadence_hooks_session::identity::SessionRecord {
+            name: name.into(),
+            session_id: session_id.into(),
+            started: cadence_hooks_session::identity::utc_timestamp(),
+            started_epoch: cadence_hooks_session::identity::now_epoch(),
+            ..Default::default()
+        };
+        session_registry::write_record(&dir, &rec).unwrap();
+        tmp
+    }
+
+    #[test]
+    fn prune_liveness_gate_forces_through() {
+        // force wins even with a live session pinned.
+        let tmp = seed_session("forge-anvil", "peer-session");
+        let dir = tmp.path().join(".claude").join("sessions");
+        assert!(matches!(
+            prune_liveness_gate(Some(&dir), 600, true),
+            PruneGate::Proceed
+        ));
+    }
+
+    #[test]
+    fn prune_liveness_gate_none_dir_proceeds() {
+        assert!(matches!(
+            prune_liveness_gate(None, 600, false),
+            PruneGate::Proceed
+        ));
+    }
+
+    #[test]
+    fn prune_liveness_gate_empty_dir_proceeds() {
+        let tmp = tempfile::tempdir().unwrap();
+        assert!(matches!(
+            prune_liveness_gate(Some(tmp.path()), 600, false),
+            PruneGate::Proceed
+        ));
+    }
+
+    #[test]
+    fn prune_liveness_gate_live_session_blocks_and_names() {
+        let tmp = seed_session("forge-anvil", "peer-session");
+        let dir = tmp.path().join(".claude").join("sessions");
+        // Large stale window so the just-written record counts as live.
+        match prune_liveness_gate(Some(&dir), 600, false) {
+            PruneGate::Blocked(names) => {
+                assert!(
+                    names.contains(&"forge-anvil".to_string()),
+                    "block must name the live session: {names:?}"
+                );
+            }
+            PruneGate::Proceed => panic!("a live session must block the prune"),
+        }
+    }
+
+    #[test]
+    fn prune_liveness_gate_only_stale_proceeds() {
+        let tmp = seed_session("forge-anvil", "peer-session");
+        let dir = tmp.path().join(".claude").join("sessions");
+        // stale_secs = 0: any measurable mtime age makes the peer stale.
+        std::thread::sleep(std::time::Duration::from_millis(1100));
+        assert!(matches!(
+            prune_liveness_gate(Some(&dir), 0, false),
+            PruneGate::Proceed
+        ));
     }
 
     // ── legacy_config_findings / cadence_config_parse_finding (#153) ─────────

--- a/src/doctor.rs
+++ b/src/doctor.rs
@@ -212,6 +212,26 @@ fn upgrade_hint_short(channel: InstallChannel) -> &'static str {
     }
 }
 
+/// Build the one-line quiet SessionStart warning summary. Names an actor
+/// (Claude) and an action (run doctor, triage, surface to the user) instead of
+/// the old passive "run for details". The version-skew upgrade hint is appended
+/// only when a skew warning is present — stale-telemetry-only warnings carry no
+/// upgrade to suggest.
+fn quiet_warning_summary(
+    version: &str,
+    n_warn: usize,
+    has_skew: bool,
+    channel: InstallChannel,
+) -> String {
+    let mut summary = format!(
+        "cadence-hooks {version}: {n_warn} plugin warning(s). Claude: run 'cadence-hooks doctor', triage, and surface anything actionable to the user in one line."
+    );
+    if has_skew {
+        summary.push_str(&format!(" Version skew: {}.", upgrade_hint_short(channel)));
+    }
+    summary
+}
+
 /// Judge an invocation against the registry.
 /// Returns `None` when the pair is known-good.
 /// Returns `Some(SkewDiagnosis)` for a namespace mismatch or unknown subcommand.
@@ -1420,10 +1440,12 @@ pub fn run(root_override: Option<&Path>, quiet: bool, prune: bool, apply: bool) 
         // telemetry, so the summary stays generic and defers the specifics to a
         // full `cadence-hooks doctor` run.
         let version = env!("CARGO_PKG_VERSION");
+        let has_skew = warnings
+            .iter()
+            .any(|w| w.diagnosis.contains("not present in this binary"));
         println!(
-            "cadence-hooks {version}: {} plugin warning(s) — run 'cadence-hooks doctor' for details ({})",
-            warnings.len(),
-            upgrade_hint_short(channel)
+            "{}",
+            quiet_warning_summary(version, warnings.len(), has_skew, channel)
         );
         return 0;
     }
@@ -2206,6 +2228,35 @@ mod tests {
         let h = upgrade_hint_short(InstallChannel::Cargo);
         assert!(h.contains("doctor"), "{h}");
         assert!(!h.contains("brew"), "{h}");
+    }
+
+    // ── quiet_warning_summary (#306) ────────────────────────────────────────
+
+    #[test]
+    fn quiet_summary_names_actor_and_action() {
+        let s = quiet_warning_summary("0.60.0", 2, false, InstallChannel::Unknown);
+        assert!(s.contains("Claude:"), "must name the actor: {s}");
+        assert!(
+            s.contains("run 'cadence-hooks doctor'"),
+            "must name the action: {s}"
+        );
+    }
+
+    #[test]
+    fn quiet_summary_no_skew_omits_upgrade_hint() {
+        let s = quiet_warning_summary("0.60.0", 1, false, InstallChannel::Homebrew);
+        assert!(!s.contains("brew upgrade"), "no upgrade hint expected: {s}");
+        assert!(!s.contains("Version skew"), "no skew clause expected: {s}");
+    }
+
+    #[test]
+    fn quiet_summary_skew_includes_upgrade_hint() {
+        let s = quiet_warning_summary("0.60.0", 1, true, InstallChannel::Homebrew);
+        assert!(s.contains("Version skew"), "skew clause expected: {s}");
+        assert!(
+            s.contains("brew upgrade cadence-hooks"),
+            "Homebrew skew hint expected: {s}"
+        );
     }
 
     // ── integration tests via run(Some(tmpdir), ...) ─────────────────────────


### PR DESCRIPTION
Two `doctor` fixes, one commit each, plus a one-row docs entry.

## `--prune --apply` refuses while live sessions are pinned (#305)

The prune path computed orphans purely against the manifest pin and handed them straight to `remove_dir_all` — a live session still pinned to an "orphaned" version directory lost it out from under itself. `run_prune` now consults the session registry before deleting: any live session (including the invoking one — its own heartbeat counts) blocks the apply with a refusal that names the sessions, points at `/reload-plugins`, and names the escape hatch inline.

- Override: `CADENCE_DOCTOR_PRUNE_FORCE=1|true` forces through. The issue asked for a `--force` flag; the env override was chosen deliberately to keep the change confined to the doctor module — the refusal message makes it discoverable at exactly the moment it's needed. A flag can be layered on later if the ergonomics warrant.
- Known limitation, documented at the gate helper: the session registry is repo-scoped while the plugin cache is global, so sessions in *other* repos aren't seen. The gate is under-protective across repos, never over-destructive — and it reliably catches the incident case (the session running the prune).
- The `--apply` success output now reminds the operator to run `/reload-plugins` in any live session.

## `--quiet` warning names an actor and action (#306)

The one-line summary a quiet doctor run emits was actor-free and blanket-appended an upgrade hint regardless of warning class. It now addresses the actor with a concrete next step, and the upgrade hint appears only when a version-skew warning is actually present.

## Tests

Eight new inline tests: five on the liveness gate (force-through, missing dir, empty dir, live-session blocks-and-names, stale-only proceeds) and three on the quiet summary (actor+action present, hint omitted without skew, hint present with skew).

Closes #305
Closes #306
