### PR TITLE
fix(guardrails): conditional config lines + non-default-host routing in inject-gh-context

### DIFF
--- a/crates/guardrails/src/inject_gh_context.rs
+++ b/crates/guardrails/src/inject_gh_context.rs
@@ -86,8 +86,9 @@ pub fn render_context(
     if !non_default_hosts.is_empty() {
         let hosts = non_default_hosts.into_iter().collect::<Vec<_>>().join(", ");
         msg.push_str(&format!(
-            " gh only reaches {default_host}; for {hosts} use that forge's own CLI/API \
-             tooling instead."
+            " Hosts other than {default_host} ({hosts}): gh reaches them only if they run \
+             GitHub — pass `-R host/owner/repo`; otherwise use that forge's own CLI/API \
+             tooling."
         ));
     }
 
@@ -173,30 +174,30 @@ mod tests {
     fn routes_away_from_gh_for_host_qualified_owner_entry() {
         let owners = parse_allow_entries("git.sjo.lol/cameron");
         let msg = render_context(&owners, &[], &[], "github.com");
-        assert!(msg.contains("gh only reaches github.com"));
-        assert!(msg.contains("git.sjo.lol"));
+        assert!(msg.contains("Hosts other than github.com (git.sjo.lol)"));
+        assert!(msg.contains("`-R host/owner/repo`"));
     }
 
     #[test]
     fn routes_away_from_gh_for_extra_host() {
         let extras = vec!["git.sjo.lol".to_string()];
         let msg = render_context(&[], &[], &extras, "github.com");
-        assert!(msg.contains("gh only reaches github.com"));
-        assert!(msg.contains("git.sjo.lol"));
+        assert!(msg.contains("Hosts other than github.com (git.sjo.lol)"));
+        assert!(msg.contains("forge's own CLI/API tooling"));
     }
 
     #[test]
     fn omits_routing_sentence_when_no_non_default_hosts() {
         let owners = parse_allow_entries("cameronsjo cameron");
         let msg = render_context(&owners, &[], &[], "github.com");
-        assert!(!msg.contains("gh only reaches"));
+        assert!(!msg.contains("Hosts other than"));
     }
 
     #[test]
     fn omits_routing_sentence_when_host_qualified_entry_matches_default() {
         let owners = parse_allow_entries("github.com/cameron");
         let msg = render_context(&owners, &[], &[], "github.com");
-        assert!(!msg.contains("gh only reaches"));
+        assert!(!msg.contains("Hosts other than"));
     }
 
     #[test]
@@ -205,7 +206,9 @@ mod tests {
         let msg = render_context(&[], &[], &extras, "github.com");
         assert!(msg.contains("Extra hosts: git.sjo.lol."));
         assert!(msg.contains(
-            "gh only reaches github.com; for git.sjo.lol use that forge's own CLI/API tooling instead."
+            "Hosts other than github.com (git.sjo.lol): gh reaches them only if they run \
+             GitHub — pass `-R host/owner/repo`; otherwise use that forge's own CLI/API \
+             tooling."
         ));
     }
 

--- a/crates/guardrails/src/inject_gh_context.rs
+++ b/crates/guardrails/src/inject_gh_context.rs
@@ -9,6 +9,8 @@
 //!
 //! Wired by `cadence-canon`'s `hooks.json` on `matcher: startup|resume|compact`.
 
+use std::collections::BTreeSet;
+
 use cadence_hooks_core::config::{AllowEntry, default_host, env_allow_entries, env_extra_hosts};
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
@@ -56,15 +58,39 @@ pub fn render_context(
             .join(", ")
     };
 
+    let default_host_lower = default_host.to_lowercase();
+
     let mut msg = format!(
         "git-guardrails: gh writes (pr/issue/release/repo/api mutations) are \
          allowlist-policed. Always pass `-R owner/repo` on writes — without it the target is \
          inferred from cwd's git remote, silently wrong in worktrees and off-repo cwds. Reads \
-         need no `-R`. Allowed owners: {owners}. Default host: {default_host}."
+         need no `-R`. Allowed owners: {owners}."
     );
+    if default_host_lower != "github.com" {
+        msg.push_str(&format!(" Default host: {default_host}."));
+    }
     if !extra_hosts.is_empty() {
         msg.push_str(&format!(" Extra hosts: {}.", extra_hosts.join(", ")));
     }
+
+    // `gh` only ever talks to hosts under the default GH_HOST — an allowlist
+    // entry or extra host naming any other forge needs routing away from it.
+    let non_default_hosts: BTreeSet<String> = owner_entries
+        .iter()
+        .chain(repo_entries.iter())
+        .filter_map(|e| e.host.as_deref())
+        .chain(extra_hosts.iter().map(String::as_str))
+        .map(str::to_lowercase)
+        .filter(|h| *h != default_host_lower)
+        .collect();
+    if !non_default_hosts.is_empty() {
+        let hosts = non_default_hosts.into_iter().collect::<Vec<_>>().join(", ");
+        msg.push_str(&format!(
+            " gh only reaches {default_host}; for {hosts} use that forge's own CLI/API \
+             tooling instead."
+        ));
+    }
+
     msg
 }
 
@@ -119,9 +145,15 @@ mod tests {
     }
 
     #[test]
-    fn includes_default_host() {
+    fn omits_default_host_line_when_default() {
         let msg = render_context(&[], &[], &[], "github.com");
-        assert!(msg.contains("Default host: github.com"));
+        assert!(!msg.contains("Default host:"));
+    }
+
+    #[test]
+    fn includes_default_host_when_deviating() {
+        let msg = render_context(&[], &[], &[], "github.example.com");
+        assert!(msg.contains("Default host: github.example.com."));
     }
 
     #[test]
@@ -135,6 +167,46 @@ mod tests {
     fn omits_extra_hosts_line_when_unset() {
         let msg = render_context(&[], &[], &[], "github.com");
         assert!(!msg.contains("Extra hosts:"));
+    }
+
+    #[test]
+    fn routes_away_from_gh_for_host_qualified_owner_entry() {
+        let owners = parse_allow_entries("git.sjo.lol/cameron");
+        let msg = render_context(&owners, &[], &[], "github.com");
+        assert!(msg.contains("gh only reaches github.com"));
+        assert!(msg.contains("git.sjo.lol"));
+    }
+
+    #[test]
+    fn routes_away_from_gh_for_extra_host() {
+        let extras = vec!["git.sjo.lol".to_string()];
+        let msg = render_context(&[], &[], &extras, "github.com");
+        assert!(msg.contains("gh only reaches github.com"));
+        assert!(msg.contains("git.sjo.lol"));
+    }
+
+    #[test]
+    fn omits_routing_sentence_when_no_non_default_hosts() {
+        let owners = parse_allow_entries("cameronsjo cameron");
+        let msg = render_context(&owners, &[], &[], "github.com");
+        assert!(!msg.contains("gh only reaches"));
+    }
+
+    #[test]
+    fn omits_routing_sentence_when_host_qualified_entry_matches_default() {
+        let owners = parse_allow_entries("github.com/cameron");
+        let msg = render_context(&owners, &[], &[], "github.com");
+        assert!(!msg.contains("gh only reaches"));
+    }
+
+    #[test]
+    fn routing_sentence_distinct_from_extra_hosts_line() {
+        let extras = vec!["git.sjo.lol".to_string()];
+        let msg = render_context(&[], &[], &extras, "github.com");
+        assert!(msg.contains("Extra hosts: git.sjo.lol."));
+        assert!(msg.contains(
+            "gh only reaches github.com; for git.sjo.lol use that forge's own CLI/API tooling instead."
+        ));
     }
 
     #[test]


### PR DESCRIPTION
## What

Two injected-context semantics fixes in `inject-gh-context` (SessionStart nudge), test-first:

1. **`Default host:` line is now conditional** — emitted only when the configured host deviates from the `github.com` fallback. A line restating the default spends context with zero information; the conditional shape copies the existing `Extra hosts:` handling. The pinning test `includes_default_host` is rewritten into `omits_default_host_line_when_default` + `includes_default_host_when_deviating`.
2. **Non-default hosts get a routing sentence** — derived from host-qualified allowlist entries plus `CADENCE_EXTRA_HOSTS`, minus the default host (BTreeSet, lowercased, deduped). When non-empty: `gh only reaches {default}; for {hosts} use that forge's own CLI/API tooling instead.` Forge-generic by design — the sentence derives entirely from configuration and names no specific forge product.

## Why

These are the two remaining live instances from an injected-context semantics audit: config lines should render only on deviation from defaults, and guidance coverage should follow what the configuration actually contains — an allowlist naming a host `gh` cannot reach was silent exactly where routing was most needed.

## Enforcement separation (verified)

This hook is advisory priming only (`CheckResult::nudge`). The load-bearing enforcement is `guard_gh_write` (PreToolUse), which parses the actual `gh` command and never reads the injected text — untouched by this diff. Independent security review of the diff: APPROVE (message-rendering only, no new untrusted-input exposure, host-set derivation verified).

## Known limitation (disclosed)

The routing sentence steers writes toward non-`gh` forge tooling, which no guard currently polices. This blind spot is pre-existing (non-`gh` writes were never guarded); the sentence increases the odds it is exercised. Follow-up issue filed for guard coverage of non-`gh` forge CLIs.

## Tests

- Baseline (origin/main) in the dev environment: 888 passed / 60 failed (the 60 are environment-dependent, failing identically before and after — verified on a pristine origin/main worktree).
- With this change: 894 passed / same 60 env failures — +6 net new tests, all `inject_gh_context` tests green 17/17.
- Red-first: the rewritten default-host tests fail against the old renderer by construction (they assert the inverse of the removed pinning test).

Rendered-output pair (owners scrubbed): before — `… Allowed owners: <owner-a>, <owner-b>, git.sjo.lol/<owner-b>. Default host: github.com.` → after — `… Allowed owners: <owner-a>, <owner-b>, git.sjo.lol/<owner-b>. gh only reaches github.com; for git.sjo.lol use that forge's own CLI/API tooling instead.`

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved GitHub write guardrail guidance for non-default forge hosts.
  * Clarified that the GitHub CLI only connects to the default host and that other forges require their own CLI or API tools.
  * Context messages now omit unnecessary default-host details and include extra-host information only when relevant.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->