### PR TITLE
feat(session): warn-commit-provenance — nudge toward producer-tuple trailers

### DIFF
--- a/crates/core/src/transcript.rs
+++ b/crates/core/src/transcript.rs
@@ -53,6 +53,42 @@ pub fn last_assistant_model(transcript: &str) -> Option<String> {
     })
 }
 
+/// Minimal transcript-line shape for harness-version resolution: the
+/// top-level `version` field (the harness build string, e.g. `"2.1.214"`)
+/// alongside the nested `message.role` needed to scope the scan to assistant
+/// lines. Deliberately separate from [`ModelLine`] — `version` lives at the
+/// line's top level while `model` lives nested under `message`, so one
+/// shared struct would carry a dead field on every deserialize.
+#[derive(Deserialize)]
+struct HarnessVersionLine {
+    version: Option<String>,
+    message: Option<AssistantRole>,
+}
+
+#[derive(Deserialize)]
+struct AssistantRole {
+    role: Option<String>,
+}
+
+/// The harness build version (e.g. `"2.1.214"`) stamped on the top-level
+/// `version` field of the *last* assistant message in a session transcript,
+/// or `None` when no assistant line carries a non-empty `version`.
+///
+/// Mirrors [`last_assistant_model`]'s tail-scan discipline exactly, reading
+/// the sibling top-level field instead of the nested `message.model` one —
+/// see that function's docs for the scan/skip semantics. Pure — operates on
+/// the transcript text, no I/O.
+pub fn last_assistant_harness_version(transcript: &str) -> Option<String> {
+    transcript.lines().rev().find_map(|line| {
+        let parsed = serde_json::from_str::<HarnessVersionLine>(line).ok()?;
+        let message = parsed.message?;
+        if message.role.as_deref() != Some("assistant") {
+            return None;
+        }
+        parsed.version.filter(|v| !v.is_empty())
+    })
+}
+
 /// True when the session transcript contains a `cadence-forge:polish` Skill
 /// invocation. Pure — operates on the transcript text, no I/O.
 ///
@@ -382,5 +418,66 @@ mod tests {
     #[test]
     fn last_assistant_model_empty_transcript_is_none() {
         assert_eq!(last_assistant_model(""), None);
+    }
+
+    // --- last_assistant_harness_version ---
+
+    fn harness_line(role: &str, version: &str) -> String {
+        format!(r#"{{"version":"{version}","message":{{"role":"{role}"}}}}"#)
+    }
+
+    #[test]
+    fn last_assistant_harness_version_returns_newest() {
+        let transcript = [
+            harness_line("assistant", "2.1.200"),
+            harness_line("assistant", "2.1.214"),
+        ]
+        .join("\n");
+        assert_eq!(
+            last_assistant_harness_version(&transcript).as_deref(),
+            Some("2.1.214"),
+            "the last assistant harness version must win over earlier ones"
+        );
+    }
+
+    #[test]
+    fn last_assistant_harness_version_skips_trailing_user_and_corrupt_lines() {
+        let transcript = [
+            harness_line("assistant", "2.1.214"),
+            r#"{"version":"2.1.215","message":{"role":"user"}}"#.to_string(),
+            "not json {{".to_string(),
+        ]
+        .join("\n");
+        assert_eq!(
+            last_assistant_harness_version(&transcript).as_deref(),
+            Some("2.1.214")
+        );
+    }
+
+    #[test]
+    fn last_assistant_harness_version_none_without_assistant() {
+        let transcript = [
+            r#"{"version":"2.1.214","message":{"role":"user"}}"#,
+            r#"{"version":"2.1.215","message":{"role":"user"}}"#,
+        ]
+        .join("\n");
+        assert_eq!(last_assistant_harness_version(&transcript), None);
+    }
+
+    #[test]
+    fn last_assistant_harness_version_none_when_assistant_has_no_version() {
+        let transcript = r#"{"message":{"role":"assistant"}}"#;
+        assert_eq!(last_assistant_harness_version(transcript), None);
+    }
+
+    #[test]
+    fn last_assistant_harness_version_ignores_empty_version_string() {
+        let transcript = harness_line("assistant", "");
+        assert_eq!(last_assistant_harness_version(&transcript), None);
+    }
+
+    #[test]
+    fn last_assistant_harness_version_empty_transcript_is_none() {
+        assert_eq!(last_assistant_harness_version(""), None);
     }
 }

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -24,11 +24,13 @@
 //! | `guard`             | PreToolUse   | [`guard`]       |
 //! | `warn-branch-drift` | PreToolUse   | [`branch_drift`]|
 //! | `warn-branch-intent`| PreToolUse   | [`branch_intent`]|
+//! | `warn-commit-provenance` | PreToolUse | [`warn_commit_provenance`] |
 //! | `declare`           | CLI action   | [`cli`]         |
 //! | `status`            | CLI action   | [`cli`]         |
 //! | `end`               | SessionEnd   | [`end`]         |
 //! | `backstop-record`   | SessionEnd   | [`backstop`]    |
 //! | `backstop-warn`     | SessionStart | [`backstop`]    |
+//! | `persist-plan`      | UserPromptSubmit | [`persist_plan`] |
 
 /// Outro "no loose ends" backstop: SessionEnd records loose ends, SessionStart warns (#123).
 pub mod backstop;
@@ -56,3 +58,6 @@ pub mod provenance;
 pub mod registry;
 /// SessionStart hook: register self, sweep stale, disclose live peers.
 pub mod start;
+/// PreToolUse commit-time provenance nudge: warn when a Claude-composed
+/// commit message lacks a `Session-Id:` trailer (cadence#473).
+pub mod warn_commit_provenance;

--- a/crates/session/src/provenance.rs
+++ b/crates/session/src/provenance.rs
@@ -2,8 +2,8 @@
 //!
 //! A raw hostname is machine-identifying but not something that belongs in a
 //! git-committed artifact — it leaks environment topology to anyone who reads
-//! the repo's history. Every COMMITTED provenance block (persisted plans
-//! today; a future commit-message check per the same convention) uses
+//! the repo's history. Every COMMITTED provenance block (persisted plans,
+//! and the `warn-commit-provenance` nudge's computed trailer) uses
 //! [`machine_digest`] instead. Local-only telemetry (e.g. `plan-links.jsonl`)
 //! is unaffected and keeps the bare hostname — this module exists only for
 //! the committed-artifact path.

--- a/crates/session/src/warn_commit_provenance.rs
+++ b/crates/session/src/warn_commit_provenance.rs
@@ -1,0 +1,716 @@
+//! `session warn-commit-provenance` — PreToolUse commit-time provenance nudge
+//! (cadence#473, commit half; the persist-plan half lives in
+//! [`crate::persist_plan`] and shares [`crate::provenance::machine_digest`]).
+//!
+//! A Claude-composed commit is easier to trace back to its producing session
+//! when its message carries a `Session-Id:` trailer. Rather than asking every
+//! session to remember the format, this check watches `git commit` at
+//! PreToolUse time and, when the message lacks that marker, nudges with the
+//! trailer block ALREADY COMPUTED and ready to copy — the friction of
+//! recalling the format is the reason compliance is inconsistent, not
+//! unwillingness.
+//!
+//! **Warn tier only, never blocks (ADR-0001).** Every uncertainty — no
+//! message derivable, an unreadable `-F` file, a missing transcript, an
+//! unresolvable model/harness/session field — degrades to either a silent
+//! allow (no message at all) or a nudge with whatever tuple fields resolved.
+//! A hook bug must never stop a commit.
+//!
+//! Detection reuses [`crate::branch_drift::is_git_commit`] (the sibling
+//! PreToolUse-Bash-commit check) and `cadence_hooks_core::shell`'s existing
+//! parsers (`tokenize`, `strip_quotes`) rather than a third hand-rolled
+//! git-commit parser.
+
+use crate::identity;
+use crate::provenance;
+use cadence_hooks_core::shell::{strip_quotes, tokenize};
+use cadence_hooks_core::transcript;
+use cadence_hooks_core::{Check, CheckResult, HookInput};
+use std::path::{Path, PathBuf};
+
+/// The trailer marker whose presence in a commit message satisfies this
+/// check — any commit that already carries it is left alone.
+const SESSION_ID_MARKER: &str = "Session-Id:";
+
+/// Cap on a `-F`/`--file` commit-message file's size before it's treated as
+/// unreadable. Real commit messages run well under this; the cap exists so a
+/// crafted huge file can't turn a PreToolUse hook into a self-inflicted
+/// slowdown (same defensive posture as `persist_plan`'s
+/// `PARENT_SCAN_MAX_FILE_BYTES`, scaled down for a single small text file).
+const MAX_MESSAGE_FILE_BYTES: u64 = 64 * 1024;
+
+/// Nudge toward carrying the producer-tuple trailer on Claude-composed commits.
+pub struct WarnCommitProvenance;
+
+impl Check for WarnCommitProvenance {
+    fn name(&self) -> &str {
+        "warn-commit-provenance"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let host = gethostname::gethostname().to_string_lossy().into_owned();
+        // Narrow defense-in-depth: this check fires on every `git commit`
+        // Bash invocation, and the `Check` dispatch path (unlike `Logger`'s)
+        // has no panic guard today (a separate, broader gap tracked
+        // elsewhere). A bug here must not stop a commit, so a panic
+        // degrades to a silent allow rather than propagating — same guard
+        // `PersistPlan::run` uses.
+        std::panic::catch_unwind(|| run_warn_commit_provenance(input, &host))
+            .unwrap_or_else(|_| CheckResult::allow())
+    }
+}
+
+/// Testable core: `host` is injected so tests exercise the real
+/// [`provenance::machine_digest`] derivation without depending on the
+/// process's actual hostname.
+pub fn run_warn_commit_provenance(input: &HookInput, host: &str) -> CheckResult {
+    if input.tool_name() != Some("Bash") {
+        return CheckResult::allow();
+    }
+    let Some(command) = input.command() else {
+        return CheckResult::allow();
+    };
+    if !crate::branch_drift::is_git_commit(&strip_quotes(command)) {
+        return CheckResult::allow();
+    }
+
+    let Some(message) = extract_commit_message(command, input.cwd.as_deref()) else {
+        return CheckResult::allow();
+    };
+    if message.contains(SESSION_ID_MARKER) {
+        return CheckResult::allow();
+    }
+
+    CheckResult::nudge(build_nudge(input, host))
+}
+
+// ---------------------------------------------------------------------------
+// Message extraction: inline -m/--message, heredoc-in-command-string, -F/--file
+// ---------------------------------------------------------------------------
+
+/// Extract the commit message from a `git commit` Bash command, across the
+/// three shapes Claude actually emits. Returns `None` when no message can be
+/// derived — an editor-based commit, a bare `--amend`, or an unreadable/
+/// oversized `-F` file — which the caller treats as a silent allow.
+///
+/// `-F`/`--file` takes priority over `-m`/`--message` when both are present
+/// (an unusual shape git itself rejects; if it somehow appears, the file is
+/// the more literal source of the actual committed text). Multiple `-m`
+/// flags are concatenated with a blank line between, matching git's own
+/// paragraph semantics for repeated `-m`.
+fn extract_commit_message(command: &str, cwd: Option<&str>) -> Option<String> {
+    let tokens = tokenize(command);
+    let mut messages: Vec<String> = Vec::new();
+    let mut file_arg: Option<String> = None;
+
+    let mut i = 0;
+    while i < tokens.len() {
+        let tok = tokens[i].as_str();
+        match tok {
+            "-m" | "--message" => {
+                if let Some(v) = tokens.get(i + 1) {
+                    messages.push(resolve_message_value(v));
+                }
+                i += 2;
+                continue;
+            }
+            "-F" | "--file" => {
+                if let Some(v) = tokens.get(i + 1) {
+                    file_arg = Some(v.clone());
+                }
+                i += 2;
+                continue;
+            }
+            _ => {}
+        }
+        if let Some(v) = tok.strip_prefix("--message=") {
+            messages.push(resolve_message_value(v));
+        } else if let Some(v) = tok.strip_prefix("--file=") {
+            file_arg = Some(v.to_string());
+        }
+        i += 1;
+    }
+
+    if let Some(path) = file_arg {
+        return read_message_file(&path, cwd);
+    }
+    if messages.is_empty() {
+        return None;
+    }
+    Some(messages.join("\n\n"))
+}
+
+/// Resolve one captured `-m`/`--message` token value: if it embeds a
+/// `$(cat <<'WORD' … WORD)`-style heredoc — the estate's common shape for a
+/// multi-line commit message, which [`tokenize`]'s single-quote-state parser
+/// captures verbatim inside the outer double quotes — extract the body
+/// between the delimiter lines. A plain literal value passes through as-is.
+fn resolve_message_value(value: &str) -> String {
+    extract_heredoc_body(value).unwrap_or_else(|| value.to_string())
+}
+
+/// Extract the body of a heredoc embedded within `value`: find the first
+/// line introducing a `<<WORD`/`<<-WORD`/`<<'WORD'`/`<<"WORD"` delimiter,
+/// then the body is every line up to (not including) the first following
+/// terminator line — matched per real bash semantics: `<<-WORD` tolerates a
+/// leading-tab-indented terminator, plain `<<WORD` requires an exact match.
+///
+/// Only the FIRST delimiter/terminator pair is ever resolved — a `value`
+/// that somehow concatenates two heredoc substitutions (`$(cat <<'A' …
+/// A)$(cat <<'B' … B)`) yields only the first body; anything from the first
+/// terminator onward, including a second heredoc, is silently dropped
+/// rather than guessed at or merged (pinned by
+/// `extract_heredoc_two_heredocs_in_one_value_only_first_extracted`).
+///
+/// `None` when `value` carries no heredoc delimiter (a plain literal
+/// message), or when a delimiter is found but its terminator never appears —
+/// mirroring `core::shell::strip_heredoc_bodies`'s terminator-not-found
+/// discipline: never guess at a boundary that wasn't confidently located.
+fn extract_heredoc_body(value: &str) -> Option<String> {
+    let lines: Vec<&str> = value.lines().collect();
+    let (idx, word, strip_leading_tabs) = lines
+        .iter()
+        .enumerate()
+        .find_map(|(idx, line)| heredoc_delimiter(line).map(|(w, s)| (idx, w, s)))?;
+    let end = lines[idx + 1..]
+        .iter()
+        .position(|line| terminator_matches(line, word, strip_leading_tabs))
+        .map(|offset| idx + 1 + offset)?;
+    Some(lines[idx + 1..end].join("\n"))
+}
+
+/// True when `line` is the terminator for a heredoc introduced with
+/// delimiter `word`. The strip-leading-tabs form (`<<-WORD`) strips only
+/// leading TABS before comparing (bash's own rule — not arbitrary
+/// whitespace); the plain form (`<<WORD`) requires an exact match.
+fn terminator_matches(line: &str, word: &str, strip_leading_tabs: bool) -> bool {
+    if strip_leading_tabs {
+        line.trim_start_matches('\t') == word
+    } else {
+        line == word
+    }
+}
+
+/// The delimiter word introduced by a `<<`/`<<-` on `line`, if any, paired
+/// with whether it's the strip-leading-tabs form (`<<-WORD`). An optional
+/// surrounding quote around the word suppresses expansion in real bash but
+/// doesn't affect body extraction here — only the word matters.
+fn heredoc_delimiter(line: &str) -> Option<(&str, bool)> {
+    let idx = line.find("<<")?;
+    let after = &line[idx + 2..];
+    let strip_leading_tabs = after.starts_with('-');
+    let rest = after.strip_prefix('-').unwrap_or(after);
+    let rest = rest.trim_start();
+    let word = if let Some(stripped) = rest.strip_prefix('\'') {
+        stripped.split('\'').next()?
+    } else if let Some(stripped) = rest.strip_prefix('"') {
+        stripped.split('"').next()?
+    } else {
+        rest.split(|c: char| c.is_whitespace() || c == ')').next()?
+    };
+    (!word.is_empty()).then_some((word, strip_leading_tabs))
+}
+
+/// Read a `-F`/`--file` commit-message file: untrusted, attacker-influenceable
+/// text — opened and read only, never written, created, or canonicalized.
+/// Resolves a relative `path` against `cwd`; a missing `cwd` for a relative
+/// path, a missing/non-file/oversized target, or a read failure all collapse
+/// to `None` (silent allow) — never an error, never a guess.
+fn read_message_file(path: &str, cwd: Option<&str>) -> Option<String> {
+    let resolved = resolve_message_path(path, cwd)?;
+    let meta = std::fs::metadata(&resolved).ok()?;
+    if !meta.is_file() || meta.len() > MAX_MESSAGE_FILE_BYTES {
+        return None;
+    }
+    std::fs::read_to_string(&resolved).ok()
+}
+
+/// Resolve a `-F` path argument: absolute paths pass through; a relative
+/// path joins onto `cwd` (from the PreToolUse payload — the directory Claude
+/// wrote the file from). `None` when relative and `cwd` is absent.
+fn resolve_message_path(path: &str, cwd: Option<&str>) -> Option<PathBuf> {
+    let p = Path::new(path);
+    if p.is_absolute() {
+        Some(p.to_path_buf())
+    } else {
+        cwd.map(|c| Path::new(c).join(p))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Nudge: the computed producer-tuple trailer block
+// ---------------------------------------------------------------------------
+
+/// Render the nudge: an instruction line plus the trailer block, with each
+/// tuple field's line present only when resolvable — an unresolvable field
+/// is omitted, never rendered blank or guessed (the nudge's job is making
+/// compliance easy, not being complete).
+///
+/// The transcript is read AT MOST ONCE per run (not once for `Model:` and
+/// again for `Harness:`) — its content is threaded to both resolvers.
+/// `Model:`/`Harness:` are transcript- or env-sourced text, not the
+/// hardened Session-Id/Name/Machine fields, so each is passed through
+/// `identity::sanitize_field` before interpolation: a crafted transcript
+/// `model`/`version` value, or an `AI_AGENT` env value, could otherwise
+/// smuggle newlines (serde decodes `\n` escapes to real control bytes) or
+/// oversized text into the nudge Claude reads as context.
+fn build_nudge(input: &HookInput, host: &str) -> String {
+    let mut lines = Vec::new();
+    if let Some((name, session_id)) = resolve_session_name_and_id(input) {
+        lines.push(format!("Session-Name: {name}"));
+        lines.push(format!("Session-Id: {session_id}"));
+    }
+    let transcript_content = input
+        .transcript_path()
+        .and_then(|path| std::fs::read_to_string(path).ok());
+    if let Some(model) = resolve_model(transcript_content.as_deref()) {
+        lines.push(format!(
+            "Model: {}",
+            identity::sanitize_field(&model, identity::MAX_FIELD_DISPLAY)
+        ));
+    }
+    if let Some(harness) = resolve_harness(transcript_content.as_deref()) {
+        lines.push(format!(
+            "Harness: claude-code {}",
+            identity::sanitize_field(&harness, identity::MAX_FIELD_DISPLAY)
+        ));
+    }
+    lines.push(format!("Machine: {}", provenance::machine_digest(host)));
+
+    format!(
+        "This commit message doesn't carry a `{SESSION_ID_MARKER}` trailer. For traceable \
+         provenance, consider appending this computed block to the commit message:\n\n{}",
+        lines.join("\n")
+    )
+}
+
+/// The session's display name and id, when the payload's `session_id` is
+/// present and safe to render. A missing or unsafe id omits both the
+/// `Session-Name:` and `Session-Id:` lines rather than rendering an untrusted
+/// value into the nudge Claude reads as context — same discipline as
+/// `persist_plan`'s and `branch_drift`'s session-id handling.
+fn resolve_session_name_and_id(input: &HookInput) -> Option<(String, String)> {
+    let session_id = input
+        .session_id()
+        .filter(|s| identity::is_safe_session_id(s))?;
+    Some((identity::generate_name(session_id), session_id.to_string()))
+}
+
+/// The current session model, resolved from the transcript tail — same call
+/// pattern as `guardrails::guard_read_model::GuardReadModel::run`. Takes the
+/// already-read transcript content rather than re-reading the file, so a
+/// single run resolves both `Model:` and `Harness:` off one read.
+fn resolve_model(transcript_content: Option<&str>) -> Option<String> {
+    transcript::last_assistant_model(transcript_content?)
+}
+
+/// The harness version: prefer the transcript's top-level `version` field on
+/// the last assistant line; fall back to parsing the `AI_AGENT` env var
+/// (`claude-code_2-1-215_agent` → `2.1.215`) when the transcript doesn't
+/// resolve it. `None` when neither source yields a version — the `Harness:`
+/// line is then omitted entirely rather than rendered from a guess.
+fn resolve_harness(transcript_content: Option<&str>) -> Option<String> {
+    if let Some(content) = transcript_content
+        && let Some(version) = transcript::last_assistant_harness_version(content)
+    {
+        return Some(version);
+    }
+    std::env::var("AI_AGENT")
+        .ok()
+        .and_then(|v| parse_ai_agent_version(&v))
+}
+
+/// Parse the `AI_AGENT` env var's `claude-code_<X-Y-Z>_agent` shape into a
+/// dotted version string (`2-1-215` → `2.1.215`). `None` for any value that
+/// doesn't carry both the exact prefix and suffix, or whose version segment
+/// is empty — never a partial/mangled guess.
+fn parse_ai_agent_version(value: &str) -> Option<String> {
+    let version_part = value.strip_prefix("claude-code_")?.strip_suffix("_agent")?;
+    (!version_part.is_empty()).then(|| version_part.replace('-', "."))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use cadence_hooks_core::{Outcome, ToolInput};
+
+    fn bash_input(
+        cmd: &str,
+        session_id: Option<&str>,
+        cwd: Option<&str>,
+        transcript_path: Option<&str>,
+    ) -> HookInput {
+        HookInput {
+            tool_name: Some("Bash".into()),
+            tool_input: Some(ToolInput {
+                command: Some(cmd.into()),
+                ..Default::default()
+            }),
+            session_id: session_id.map(String::from),
+            cwd: cwd.map(String::from),
+            transcript_path: transcript_path.map(String::from),
+            ..Default::default()
+        }
+    }
+
+    // --- Check::run guard clauses ---
+
+    #[test]
+    fn non_bash_tool_allows() {
+        let input = HookInput {
+            tool_name: Some("Read".into()),
+            ..Default::default()
+        };
+        assert_eq!(WarnCommitProvenance.run(&input).outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn non_commit_git_allows() {
+        let input = bash_input("git status", Some("sid"), None, None);
+        assert_eq!(
+            run_warn_commit_provenance(&input, "host").outcome,
+            Outcome::Allow
+        );
+    }
+
+    // --- extraction: inline -m ---
+
+    #[test]
+    fn extract_single_inline_dash_m() {
+        assert_eq!(
+            extract_commit_message("git commit -m 'fix: thing'", None),
+            Some("fix: thing".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_multiple_dash_m_concatenated_with_blank_line() {
+        assert_eq!(
+            extract_commit_message("git commit -m 'subject' -m 'body line'", None),
+            Some("subject\n\nbody line".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_long_message_flag() {
+        assert_eq!(
+            extract_commit_message("git commit --message 'fix: thing'", None),
+            Some("fix: thing".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_message_equals_form() {
+        assert_eq!(
+            extract_commit_message("git commit --message='fix: thing'", None),
+            Some("fix: thing".to_string())
+        );
+    }
+
+    // --- extraction: heredoc-in-command-string ---
+
+    #[test]
+    fn extract_heredoc_body_from_command_string() {
+        let command = "git commit -m \"$(cat <<'EOF'\nfix: something\n\nbody paragraph\nEOF\n)\"";
+        assert_eq!(
+            extract_commit_message(command, None),
+            Some("fix: something\n\nbody paragraph".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_heredoc_with_session_id_trailer_is_visible_to_the_marker_check() {
+        let command =
+            "git commit -m \"$(cat <<'EOF'\nfix: something\n\nSession-Id: abc123\nEOF\n)\"";
+        let message = extract_commit_message(command, None).unwrap();
+        assert!(message.contains("Session-Id: abc123"));
+    }
+
+    // --- extraction: -F/--file ---
+
+    #[test]
+    fn extract_dash_f_relative_path_resolves_against_cwd() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        std::fs::write(tmp.path().join("msg.txt"), "fix: from file").unwrap();
+        let command = "git commit -F msg.txt";
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        assert_eq!(
+            extract_commit_message(command, Some(&cwd)),
+            Some("fix: from file".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dash_f_absolute_path() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("msg.txt");
+        std::fs::write(&path, "fix: from file").unwrap();
+        let command = format!("git commit -F {}", path.display());
+        assert_eq!(
+            extract_commit_message(&command, None),
+            Some("fix: from file".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_file_equals_form() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("msg.txt");
+        std::fs::write(&path, "fix: from file").unwrap();
+        let command = format!("git commit --file={}", path.display());
+        assert_eq!(
+            extract_commit_message(&command, None),
+            Some("fix: from file".to_string())
+        );
+    }
+
+    #[test]
+    fn extract_dash_f_unreadable_is_none() {
+        assert_eq!(
+            extract_commit_message("git commit -F /no/such/file.txt", None),
+            None
+        );
+    }
+
+    #[test]
+    fn extract_dash_f_oversized_is_none() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("huge.txt");
+        std::fs::write(&path, "x".repeat((MAX_MESSAGE_FILE_BYTES as usize) + 1)).unwrap();
+        let command = format!("git commit -F {}", path.display());
+        assert_eq!(extract_commit_message(&command, None), None);
+    }
+
+    // --- extraction: no message derivable ---
+
+    #[test]
+    fn extract_no_message_flag_is_none() {
+        assert_eq!(extract_commit_message("git commit --amend", None), None);
+        assert_eq!(extract_commit_message("git commit", None), None);
+    }
+
+    // --- run_warn_commit_provenance: end-to-end gating ---
+
+    #[test]
+    fn message_already_carrying_session_id_allows() {
+        let input = bash_input(
+            "git commit -m 'fix: thing\n\nSession-Id: existing'",
+            Some("sid"),
+            None,
+            None,
+        );
+        assert_eq!(
+            run_warn_commit_provenance(&input, "host").outcome,
+            Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn no_message_derivable_allows() {
+        let input = bash_input("git commit --amend", Some("sid"), None, None);
+        assert_eq!(
+            run_warn_commit_provenance(&input, "host").outcome,
+            Outcome::Allow
+        );
+    }
+
+    #[test]
+    fn missing_session_id_marker_nudges() {
+        let input = bash_input("git commit -m 'fix: thing'", Some("sid12345"), None, None);
+        let result = run_warn_commit_provenance(&input, "host");
+        assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.unwrap();
+        assert!(msg.contains("Session-Id:"));
+        assert!(msg.contains("Machine:"));
+    }
+
+    #[test]
+    fn oversized_dash_f_file_allows_end_to_end() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let path = tmp.path().join("huge.txt");
+        std::fs::write(&path, "x".repeat((MAX_MESSAGE_FILE_BYTES as usize) + 1)).unwrap();
+        let command = format!("git commit -F {}", path.display());
+        let input = bash_input(&command, Some("sid"), None, None);
+        assert_eq!(
+            run_warn_commit_provenance(&input, "host").outcome,
+            Outcome::Allow
+        );
+    }
+
+    // --- nudge content: full tuple resolution end-to-end ---
+
+    #[test]
+    fn nudge_carries_full_computed_tuple() {
+        let tmp = tempfile::TempDir::new().unwrap();
+        let transcript_path = tmp.path().join("sess.jsonl");
+        std::fs::write(
+            &transcript_path,
+            r#"{"version":"2.1.214","message":{"role":"assistant","model":"claude-fable-5"}}"#,
+        )
+        .unwrap();
+
+        let input = bash_input(
+            "git commit -m 'fix: thing'",
+            Some("cedar-session-id"),
+            None,
+            Some(&transcript_path.to_string_lossy()),
+        );
+        let result = run_warn_commit_provenance(&input, "sjomba.local");
+        assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.unwrap();
+
+        assert!(
+            msg.contains(&format!(
+                "Session-Name: {}",
+                identity::generate_name("cedar-session-id")
+            )),
+            "computed session name present: {msg}"
+        );
+        assert!(msg.contains("Session-Id: cedar-session-id"), "{msg}");
+        assert!(msg.contains("Model: claude-fable-5"), "{msg}");
+        assert!(msg.contains("Harness: claude-code 2.1.214"), "{msg}");
+        assert!(
+            msg.contains(&format!(
+                "Machine: {}",
+                provenance::machine_digest("sjomba.local")
+            )),
+            "computed machine digest present: {msg}"
+        );
+    }
+
+    #[test]
+    fn nudge_omits_unresolvable_fields_but_still_fires() {
+        // No session_id, no transcript, no AI_AGENT — only Machine: resolves.
+        // The instructional sentence still mentions the backtick-wrapped
+        // `Session-Id:` marker name, so the negative assertions check for the
+        // rendered FIELD LINE shape (colon-space-value), not the bare word.
+        // AI_AGENT is explicitly cleared — this session's own real Claude
+        // Code process sets it, which would otherwise let Harness: resolve
+        // and falsify the "nothing but Machine resolves" premise.
+        with_ai_agent_env(None, || {
+            let input = bash_input("git commit -m 'fix: thing'", None, None, None);
+            let result = run_warn_commit_provenance(&input, "host");
+            assert_eq!(result.outcome, Outcome::Nudge);
+            let msg = result.message.unwrap();
+            assert!(!msg.contains("Session-Name: "), "{msg}");
+            assert!(!msg.contains("Session-Id: "), "{msg}");
+            assert!(!msg.contains("Model: "), "{msg}");
+            assert!(!msg.contains("Harness: "), "{msg}");
+            assert!(msg.contains("Machine: "), "{msg}");
+        });
+    }
+
+    // --- AI_AGENT env fallback (process-global — serialized + restored) ---
+
+    /// Serializes tests that mutate the `AI_AGENT` env var, mirroring
+    /// `guardrails::guard_read_model`'s `ENV_LOCK`/`with_env` pattern.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_ai_agent_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let prior = std::env::var("AI_AGENT").ok();
+        // SAFETY: serialized via ENV_LOCK; restored below.
+        unsafe {
+            match value {
+                Some(v) => std::env::set_var("AI_AGENT", v),
+                None => std::env::remove_var("AI_AGENT"),
+            }
+        }
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+        // SAFETY: same lock still held; restoring prior state.
+        unsafe {
+            match prior {
+                Some(v) => std::env::set_var("AI_AGENT", v),
+                None => std::env::remove_var("AI_AGENT"),
+            }
+        }
+        result.unwrap_or_else(|e| std::panic::resume_unwind(e))
+    }
+
+    #[test]
+    fn resolve_harness_falls_back_to_ai_agent_env_when_transcript_absent() {
+        with_ai_agent_env(Some("claude-code_2-1-215_agent"), || {
+            assert_eq!(resolve_harness(None), Some("2.1.215".to_string()));
+        });
+    }
+
+    #[test]
+    fn resolve_harness_prefers_transcript_over_ai_agent_env() {
+        with_ai_agent_env(Some("claude-code_9-9-999_agent"), || {
+            let content = r#"{"version":"2.1.214","message":{"role":"assistant"}}"#;
+            assert_eq!(resolve_harness(Some(content)), Some("2.1.214".to_string()));
+        });
+    }
+
+    // --- AI_AGENT fallback parsing ---
+
+    #[test]
+    fn parse_ai_agent_version_valid() {
+        assert_eq!(
+            parse_ai_agent_version("claude-code_2-1-215_agent"),
+            Some("2.1.215".to_string())
+        );
+    }
+
+    #[test]
+    fn parse_ai_agent_version_wrong_shape_is_none() {
+        assert_eq!(parse_ai_agent_version("something-else"), None);
+        assert_eq!(parse_ai_agent_version("claude-code_agent"), None);
+        // Prefix and suffix both match, but the version segment between them
+        // is empty — never render a blank/guessed harness version.
+        assert_eq!(parse_ai_agent_version("claude-code__agent"), None);
+    }
+
+    // --- heredoc delimiter parsing ---
+
+    #[test]
+    fn heredoc_delimiter_quoted_and_unquoted() {
+        assert_eq!(heredoc_delimiter("$(cat <<'EOF'"), Some(("EOF", false)));
+        assert_eq!(heredoc_delimiter("$(cat <<\"EOF\""), Some(("EOF", false)));
+        assert_eq!(heredoc_delimiter("$(cat <<EOF"), Some(("EOF", false)));
+        assert_eq!(heredoc_delimiter("$(cat <<-EOF"), Some(("EOF", true)));
+        assert_eq!(heredoc_delimiter("no heredoc here"), None);
+    }
+
+    #[test]
+    fn extract_heredoc_body_terminator_not_found_is_none() {
+        // Single-line value: no terminator line can ever appear after it.
+        assert_eq!(extract_heredoc_body("plain message, no heredoc"), None);
+    }
+
+    // --- heredoc terminator: real bash semantics (dash strips tabs, plain is exact) ---
+
+    #[test]
+    fn heredoc_dash_form_tolerates_leading_tab_indented_terminator() {
+        let value = "$(cat <<-'EOF'\nbody\n\tEOF\n)";
+        assert_eq!(extract_heredoc_body(value), Some("body".to_string()));
+    }
+
+    #[test]
+    fn heredoc_plain_form_rejects_indented_terminator() {
+        // Real bash requires an EXACT match for the plain `<<WORD` form — a
+        // tab-indented terminator line does not close it, so the "terminator
+        // never appears" fallback applies (never a guessed boundary).
+        let value = "$(cat <<'EOF'\nbody\n\tEOF\n)";
+        assert_eq!(extract_heredoc_body(value), None);
+    }
+
+    // --- documented single-heredoc-per-value limitation ---
+
+    #[test]
+    fn extract_heredoc_two_heredocs_in_one_value_only_first_extracted() {
+        // A single -m value that somehow concatenates two heredoc
+        // substitutions only yields the first body — everything from the
+        // first terminator onward (including the second heredoc) is
+        // silently dropped, never guessed at or merged. Two SEPARATE `-m`
+        // flags, each with its own heredoc, are unaffected by this: each is
+        // tokenized into its own value and resolved independently (see
+        // `extract_multiple_dash_m_concatenated_with_blank_line`).
+        let command =
+            "git commit -m \"$(cat <<'A'\nfirst body\nA\n)$(cat <<'B'\nsecond body\nB\n)\"";
+        assert_eq!(
+            extract_commit_message(command, None),
+            Some("first body".to_string())
+        );
+    }
+}

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -143,6 +143,7 @@ give sessions *identity* within a repo via a registry at `<repo>/.claude/session
 | `heartbeat` | PostToolUse | Touch this session's registry file; refresh the recorded branch so peers see branch drift |
 | `guard` | PreToolUse (Bash, Edit, Write) | Warn — never block — on branch switches, blanket staging (`git add -A`, `git commit -a`), and writes inside a peer's declared paths |
 | `warn-branch-drift` | PreToolUse (Bash, `git commit`) | Warn when HEAD drifted from the session's recorded branch at commit time |
+| `warn-commit-provenance` | PreToolUse (Bash, `git commit`) | Nudge with a computed `Session-Id:` trailer block when a Claude-composed commit message lacks one |
 
 Liveness is mtime-based: a session that crashes or closes simply stops heartbeating
 and is presumed dead after 10 minutes (`CADENCE_SESSION_STALE_MINUTES`). No

--- a/src/main.rs
+++ b/src/main.rs
@@ -326,6 +326,8 @@ enum SessionCommands {
     WarnBranchDrift,
     /// Nudge when new work starts on a stale, unrelated feature branch (PreToolUse)
     WarnBranchIntent,
+    /// Nudge toward a `Session-Id:` trailer on a Claude-composed commit message (PreToolUse)
+    WarnCommitProvenance,
     /// Deregister this session's registry file when it ends (SessionEnd logger)
     End,
     /// Record loose ends when the session ends, for the next start to surface (SessionEnd logger)
@@ -438,6 +440,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             SessionCommands::Guard => "guard",
             SessionCommands::WarnBranchDrift => "warn-branch-drift",
             SessionCommands::WarnBranchIntent => "warn-branch-intent",
+            SessionCommands::WarnCommitProvenance => "warn-commit-provenance",
             SessionCommands::End => "end",
             SessionCommands::BackstopRecord => "backstop-record",
             SessionCommands::BackstopWarn => "backstop-warn",
@@ -1081,6 +1084,11 @@ fn main() {
             ),
             SessionCommands::WarnBranchIntent => dispatch::run_logged_check(
                 &cadence_hooks_session::branch_intent::WarnBranchIntent,
+                pre,
+                canonical_hook,
+            ),
+            SessionCommands::WarnCommitProvenance => dispatch::run_logged_check(
+                &cadence_hooks_session::warn_commit_provenance::WarnCommitProvenance,
                 pre,
                 canonical_hook,
             ),

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -395,6 +395,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::PreToolUse),
     },
     HookEntry {
+        name: "warn-commit-provenance",
+        description: "Nudge toward a Session-Id: trailer on a Claude-composed commit message",
+        plugin: "session",
+        event: Some(HookEvent::PreToolUse),
+    },
+    HookEntry {
         name: "end",
         description: "Deregister this session's registry file when it ends (SessionEnd)",
         plugin: "session",
@@ -501,6 +507,12 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         // and fail-opens cleanly (cwd not a registered session).
         ("session", "warn-branch-intent") => Some(
             r#"{"session_id":"test","tool_name":"Edit","cwd":"/tmp","tool_input":{"file_path":"/tmp/x.rs"}}"#,
+        ),
+        // warn-commit-provenance early-exits unless the command is a git
+        // commit carrying an extractable message — the generic PreToolUse
+        // sample (`git status`) would never reach the Session-Id: check.
+        ("session", "warn-commit-provenance") => Some(
+            r#"{"session_id":"test","tool_name":"Bash","tool_input":{"command":"git commit -m test"}}"#,
         ),
         // end gates on hook_event_name == "SessionEnd"; the generic logger
         // sample carries a different event and would no-op before the gate.


### PR DESCRIPTION
The commit half of cameronsjo/cadence#473 (the subagent-identity half stays open there): a warn-tier PreToolUse Bash check that nudges Claude-composed git commits toward carrying the producer-tuple trailer block.

Stacked on #359 (reuses its `provenance::machine_digest`); both ride one v0.62.0 bump.

## Behavior

When a git-commit command's message lacks `Session-Id:`, warn with a fully-computed, copy-ready trailer block — Session-Name (canon `identity::generate_name`), Session-Id (payload), Model (`transcript::last_assistant_model`), Harness (transcript top-level `version`, AI_AGENT env fallback), Machine (salted digest). Any unresolvable field is omitted, never guessed; no message derivable, message already compliant, or any error → silent allow. Never blocks.

Message extraction covers the three shapes Claude actually emits: inline `-m`/`--message` (multiple `-m` concatenated with git's paragraph semantics), heredoc-in-command-string (bash-faithful `<<`/`<<-` terminator semantics), and `-F`/`--file` (cwd-relative, 64 KiB metadata-checked cap, scan-only — file content is never echoed into any output).

## Review

Two independent seats beyond CI:
- **Adversarial security review** (guard-feeding parser lens): contract-critical points confirmed clean (never-echo, fail-open, read-only, linear parsing); its one Important finding — unsanitized transcript/env-derived `Model`/`Harness` interpolation into the nudge — is fixed via `identity::sanitize_field`. Known-minor accepted as follow-up: a Linux-only `/proc` st_size-lie could bypass the -F cap (macOS unaffected; content never echoed; specials blocked by `is_file`).
- **Code review**: its Important finding — missing `catch_unwind` self-guard mirroring the stacked sibling — fixed; heredoc `<<-` tab-stripping semantics and a pinned single-value-two-heredocs limitation test added.

## Verification

`make ci` green (fmt, clippy -D warnings, full workspace, 29 check-specific tests) — independently re-run from a carve-out-free checkout with captured exit code 0. Extraction/nudge tests use fixture transcripts that actually carry `message.model`/`version`.

Plugin wiring (`if: Bash(*git commit*)` beside warn-branch-drift in cadence-canon) follows separately, gated on the v0.62.0 release being live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)