### PR TITLE
fix(markers): stop cargo test from writing into the production marker dir

### DIFF
--- a/crates/cadence/src/lib.rs
+++ b/crates/cadence/src/lib.rs
@@ -33,3 +33,7 @@ pub mod validate_line_endings;
 pub mod warn_docs_update;
 /// Nudge to audit about-to-ship content for personal-context overshare.
 pub mod warn_overshare;
+
+/// Shared test-only helpers for tests that write real marker files (#302).
+#[cfg(test)]
+pub(crate) mod test_support;

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -106,6 +106,7 @@ fn nudge_message() -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_marker_dir;
     use cadence_hooks_core::gitstate::GitState;
     use cadence_hooks_core::markers::{polish_marker, write_marker};
     use cadence_hooks_core::test_builders::{make_bash, make_bash_with_cwd};
@@ -237,10 +238,13 @@ mod tests {
         // #146 RED (integration): repo is on branch B, but the only marker is for
         // branch A → the different-branch marker must NOT satisfy → Nudge.
         let (tmp, root) = init_repo_on_branch("branch-b");
-        write_marker(&polish_marker(&root, "branch-a"), "{}").unwrap();
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(&polish_marker(&root, "branch-a"), "{}").unwrap();
 
-        let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
-        assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Nudge);
+            let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
+            assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Nudge);
+        });
     }
 
     #[test]
@@ -249,15 +253,18 @@ mod tests {
         // Allow, silent. Also the #154 regression end-to-end: no transcript at
         // all is involved, purely the marker.
         let (tmp, root) = init_repo_on_branch("feat/thing");
-        write_marker(&polish_marker(&root, "feat/thing"), "{}").unwrap();
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(&polish_marker(&root, "feat/thing"), "{}").unwrap();
 
-        let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
-        let result = NudgePolishBeforePr.run(&input);
-        assert_eq!(result.outcome, Outcome::Allow);
-        assert!(
-            result.message.is_none(),
-            "a recorded polish allows silently"
-        );
+            let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
+            let result = NudgePolishBeforePr.run(&input);
+            assert_eq!(result.outcome, Outcome::Allow);
+            assert!(
+                result.message.is_none(),
+                "a recorded polish allows silently"
+            );
+        });
     }
 
     #[test]
@@ -274,15 +281,18 @@ mod tests {
         // The ship anchor end-to-end: `gh pr ready` on a branch whose marker
         // exists → silent allow, resolved the same way a create would be.
         let (tmp, root) = init_repo_on_branch("feat/ready");
-        write_marker(&polish_marker(&root, "feat/ready"), "{}").unwrap();
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(&polish_marker(&root, "feat/ready"), "{}").unwrap();
 
-        let input = make_bash_with_cwd("gh pr ready 12", tmp.path().to_str().unwrap());
-        let result = NudgePolishBeforePr.run(&input);
-        assert_eq!(result.outcome, Outcome::Allow);
-        assert!(
-            result.message.is_none(),
-            "a recorded polish allows silently"
-        );
+            let input = make_bash_with_cwd("gh pr ready 12", tmp.path().to_str().unwrap());
+            let result = NudgePolishBeforePr.run(&input);
+            assert_eq!(result.outcome, Outcome::Allow);
+            assert!(
+                result.message.is_none(),
+                "a recorded polish allows silently"
+            );
+        });
     }
 
     #[test]
@@ -369,25 +379,28 @@ mod tests {
         );
 
         let wt_state = GitState::resolve(&wt).expect("worktree resolves");
-        write_marker(
-            &polish_marker(&wt_state.git_common_dir.to_string_lossy(), "feat/thing"),
-            "{}",
-        )
-        .unwrap();
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(
+                &polish_marker(&wt_state.git_common_dir.to_string_lossy(), "feat/thing"),
+                "{}",
+            )
+            .unwrap();
 
-        git_in(
-            &primary,
-            &["worktree", "remove", "--force", wt.to_str().unwrap()],
-        );
-        git_in(&primary, &["checkout", "-q", "feat/thing"]);
+            git_in(
+                &primary,
+                &["worktree", "remove", "--force", wt.to_str().unwrap()],
+            );
+            git_in(&primary, &["checkout", "-q", "feat/thing"]);
 
-        let input = make_bash_with_cwd("gh pr create --title x", primary.to_str().unwrap());
-        let result = NudgePolishBeforePr.run(&input);
-        assert_eq!(
-            result.outcome,
-            Outcome::Allow,
-            "a worktree-recorded marker must satisfy the primary checkout on the same branch"
-        );
+            let input = make_bash_with_cwd("gh pr create --title x", primary.to_str().unwrap());
+            let result = NudgePolishBeforePr.run(&input);
+            assert_eq!(
+                result.outcome,
+                Outcome::Allow,
+                "a worktree-recorded marker must satisfy the primary checkout on the same branch"
+            );
+        });
     }
 
     #[test]
@@ -400,27 +413,30 @@ mod tests {
         git_in(&primary, &["checkout", "-q", "-b", "feat/y"]);
 
         let primary_state = GitState::resolve(&primary).expect("primary resolves");
-        write_marker(
-            &polish_marker(&primary_state.git_common_dir.to_string_lossy(), "feat/y"),
-            "{}",
-        )
-        .unwrap();
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(
+                &polish_marker(&primary_state.git_common_dir.to_string_lossy(), "feat/y"),
+                "{}",
+            )
+            .unwrap();
 
-        // Free `feat/y` from the primary so a worktree can check it out.
-        git_in(&primary, &["checkout", "-q", "main"]);
-        let wt = tmp.path().join("wt");
-        git_in(
-            &primary,
-            &["worktree", "add", "-q", wt.to_str().unwrap(), "feat/y"],
-        );
+            // Free `feat/y` from the primary so a worktree can check it out.
+            git_in(&primary, &["checkout", "-q", "main"]);
+            let wt = tmp.path().join("wt");
+            git_in(
+                &primary,
+                &["worktree", "add", "-q", wt.to_str().unwrap(), "feat/y"],
+            );
 
-        let input = make_bash_with_cwd("gh pr create --title x", wt.to_str().unwrap());
-        let result = NudgePolishBeforePr.run(&input);
-        assert_eq!(
-            result.outcome,
-            Outcome::Allow,
-            "a primary-recorded marker must satisfy a linked worktree on the same branch"
-        );
+            let input = make_bash_with_cwd("gh pr create --title x", wt.to_str().unwrap());
+            let result = NudgePolishBeforePr.run(&input);
+            assert_eq!(
+                result.outcome,
+                Outcome::Allow,
+                "a primary-recorded marker must satisfy a linked worktree on the same branch"
+            );
+        });
     }
 
     #[test]
@@ -445,20 +461,23 @@ mod tests {
         );
 
         let wt_state = GitState::resolve(&wt).expect("worktree resolves");
-        write_marker(
-            &polish_marker(&wt_state.git_common_dir.to_string_lossy(), "feat/a"),
-            "{}",
-        )
-        .unwrap();
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(
+                &polish_marker(&wt_state.git_common_dir.to_string_lossy(), "feat/a"),
+                "{}",
+            )
+            .unwrap();
 
-        // Primary stays on `main` — a different branch from the marker.
-        let input = make_bash_with_cwd("gh pr create --title x", primary.to_str().unwrap());
-        let result = NudgePolishBeforePr.run(&input);
-        assert_eq!(
-            result.outcome,
-            Outcome::Nudge,
-            "a marker for a different branch must not satisfy the ship command"
-        );
+            // Primary stays on `main` — a different branch from the marker.
+            let input = make_bash_with_cwd("gh pr create --title x", primary.to_str().unwrap());
+            let result = NudgePolishBeforePr.run(&input);
+            assert_eq!(
+                result.outcome,
+                Outcome::Nudge,
+                "a marker for a different branch must not satisfy the ship command"
+            );
+        });
     }
 
     // --- preserved matcher tests (is_polish_ship_anchor) ---

--- a/crates/cadence/src/nudge_polish_before_pr.rs
+++ b/crates/cadence/src/nudge_polish_before_pr.rs
@@ -270,10 +270,16 @@ mod tests {
     #[test]
     fn run_no_marker_in_real_repo_nudges() {
         // Fail-open: a resolvable repo/branch but no marker → Nudge, never Block.
+        // run() reads marker_dir() (env) via polish_marker_present, so hold
+        // ENV_LOCK against concurrent with_marker_dir writers (#369), off the
+        // real per-user dir (#302).
         let (tmp, _root) = init_repo_on_branch("feat/unmarked");
-        let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
-        let result = NudgePolishBeforePr.run(&input);
-        assert_eq!(result.outcome, Outcome::Nudge);
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let input = make_bash_with_cwd("gh pr create --title x", tmp.path().to_str().unwrap());
+            let result = NudgePolishBeforePr.run(&input);
+            assert_eq!(result.outcome, Outcome::Nudge);
+        });
     }
 
     #[test]
@@ -298,9 +304,13 @@ mod tests {
     #[test]
     fn run_pr_ready_no_marker_nudges() {
         // `gh pr ready` with no marker for the branch → fail-open nudge.
+        // Under ENV_LOCK (#369/#302), same as the create-side sibling above.
         let (tmp, _root) = init_repo_on_branch("feat/ready-unmarked");
-        let input = make_bash_with_cwd("gh pr ready 12", tmp.path().to_str().unwrap());
-        assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Nudge);
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let input = make_bash_with_cwd("gh pr ready 12", tmp.path().to_str().unwrap());
+            assert_eq!(NudgePolishBeforePr.run(&input).outcome, Outcome::Nudge);
+        });
     }
 
     #[test]

--- a/crates/cadence/src/record_polish.rs
+++ b/crates/cadence/src/record_polish.rs
@@ -108,6 +108,7 @@ pub fn run_record(repo_root: Option<String>, branch: Option<String>, scope: Opti
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::test_support::with_marker_dir;
     use cadence_hooks_core::markers::polish_marker;
 
     #[test]
@@ -147,33 +148,36 @@ mod tests {
 
     #[test]
     fn run_record_writes_marker_at_expected_path_with_parseable_content() {
-        // With explicit overrides the write path is `polish_marker(repo, branch)`
-        // — the same value this test recomputes, since both calls resolve
-        // `marker_dir()` from the same environment. No env mutation needed: the
-        // marker lands in the real private dir at a hashed, unique name; we read
-        // it back and clean up. A repo/branch unlikely to collide with any peer.
-        let repo = "/tmp/record-polish-test-repo";
-        let branch = "feat/record-polish-y";
-        let path = polish_marker(repo, branch);
-        let _ = std::fs::remove_file(&path); // ensure a clean slate
+        // Both `polish_marker` calls below resolve `marker_dir()` from the same
+        // (overridden) environment, so the recomputed path matches what
+        // `run_record` actually wrote — isolated to a tempdir so this never
+        // lands in the real per-user marker directory (#302).
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/record-polish-test-repo";
+            let branch = "feat/record-polish-y";
+            let path = polish_marker(repo, branch);
 
-        run_record(Some(repo.into()), Some(branch.into()), Some("code".into()));
+            run_record(Some(repo.into()), Some(branch.into()), Some("code".into()));
 
-        assert!(path.is_file(), "marker should exist at {path:?}");
-        let content = std::fs::read_to_string(&path).unwrap();
-        let v: serde_json::Value = serde_json::from_str(&content).unwrap();
-        assert_eq!(v["branch"], branch);
-        assert_eq!(v["scope"], "code");
-
-        let _ = std::fs::remove_file(&path);
+            assert!(path.is_file(), "marker should exist at {path:?}");
+            let content = std::fs::read_to_string(&path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert_eq!(v["branch"], branch);
+            assert_eq!(v["scope"], "code");
+        });
     }
 
     #[test]
     fn run_record_degrades_to_noop_when_repo_unresolved() {
-        // No overrides + a non-repo cwd → resolve returns None → no panic, no
-        // marker. Asserts the call simply returns (fail-open) without unwinding;
-        // a bad marker dir would likewise exit via the write_marker arm.
-        run_record(None, None, Some("full".into()));
+        // No overrides, and `cargo test`'s cwd IS this real git checkout, so
+        // `resolve` actually succeeds here (unlike the name implies) and
+        // `run_record` really does write a marker — isolate it (#302), same as
+        // every other write-path test in this module.
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            run_record(None, None, Some("full".into()));
+        });
     }
 
     // --- worktree-stable keying (cadence-hooks#324) ---
@@ -233,26 +237,29 @@ mod tests {
             "feat/thing",
         ]);
 
-        // Record from the WORKTREE path — the record side's own resolution.
-        let wt_str = wt.to_str().unwrap().to_string();
-        let (repo_root, branch, head_sha) =
-            resolve(&wt_str, None, None).expect("worktree resolves repo/branch");
-        assert_eq!(branch, "feat/thing");
-        let content = marker_content(&branch, &head_sha, "full");
-        write_marker(&polish_marker(&repo_root, &branch), &content).unwrap();
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            // Record from the WORKTREE path — the record side's own resolution.
+            let wt_str = wt.to_str().unwrap().to_string();
+            let (repo_root, branch, head_sha) =
+                resolve(&wt_str, None, None).expect("worktree resolves repo/branch");
+            assert_eq!(branch, "feat/thing");
+            let content = marker_content(&branch, &head_sha, "full");
+            write_marker(&polish_marker(&repo_root, &branch), &content).unwrap();
 
-        // Free the branch from the worktree and check it out on the primary —
-        // the realistic sequel to "finished the worktree, shipping from primary".
-        git(&["worktree", "remove", "--force", wt.to_str().unwrap()]);
-        git(&["checkout", "-q", "feat/thing"]);
+            // Free the branch from the worktree and check it out on the primary —
+            // the realistic sequel to "finished the worktree, shipping from primary".
+            git(&["worktree", "remove", "--force", wt.to_str().unwrap()]);
+            git(&["checkout", "-q", "feat/thing"]);
 
-        assert!(
-            cadence_hooks_core::markers::polish_marker_present(
-                "gh pr create --title x",
-                Some(primary.to_str().unwrap()),
-            ),
-            "a polish marker recorded from a linked worktree must satisfy a ship \
-             command run from the primary checkout on the same branch"
-        );
+            assert!(
+                cadence_hooks_core::markers::polish_marker_present(
+                    "gh pr create --title x",
+                    Some(primary.to_str().unwrap()),
+                ),
+                "a polish marker recorded from a linked worktree must satisfy a ship \
+                 command run from the primary checkout on the same branch"
+            );
+        });
     }
 }

--- a/crates/cadence/src/test_support.rs
+++ b/crates/cadence/src/test_support.rs
@@ -1,0 +1,34 @@
+//! Shared test-only helpers for this crate's marker-writing tests (#302).
+//!
+//! `nudge_polish_before_pr` and `record_polish` both write real `polish_marker`
+//! files in their tests. Without an override they land in the real per-user
+//! [`cadence_hooks_core::markers::marker_dir`] and never get cleaned up.
+
+use std::path::Path;
+use std::sync::Mutex;
+
+/// Crate-wide serialization lock for tests that mutate `CADENCE_MARKER_DIR`.
+///
+/// The var is process-global, so every test in this crate that sets it must
+/// hold this one lock — a per-module lock only serializes within its own
+/// module and lets `nudge_polish_before_pr`'s tests race `record_polish`'s.
+/// Mirrors the metrics crate's `common::ENV_LOCK`
+/// (`crates/metrics/src/common.rs`).
+pub(crate) static ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// Run `f` with `CADENCE_MARKER_DIR` set to `dir`, serialized against every
+/// other marker-dir-mutating test in this crate via [`ENV_LOCK`].
+pub(crate) fn with_marker_dir<F: FnOnce()>(dir: &Path, f: F) {
+    let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    // SAFETY: serialized against every other marker-dir-mutating test in this
+    // crate via ENV_LOCK.
+    unsafe {
+        std::env::set_var("CADENCE_MARKER_DIR", dir);
+    }
+    f();
+    // SAFETY: serialized against every other marker-dir-mutating test in this
+    // crate via ENV_LOCK.
+    unsafe {
+        std::env::remove_var("CADENCE_MARKER_DIR");
+    }
+}

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -336,9 +336,15 @@ mod tests {
 
     #[test]
     fn session_marker_stable_for_same_inputs() {
-        let a = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo"));
-        let b = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo"));
-        assert_eq!(a, b, "same inputs must produce the same marker");
+        // Holds ENV_LOCK across both reads so a concurrent `with_marker_dir`
+        // test can't flip CADENCE_MARKER_DIR between them (#369): the stability
+        // property is "same inputs + same env → same marker".
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let a = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo"));
+            let b = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo"));
+            assert_eq!(a, b, "same inputs must produce the same marker");
+        });
     }
 
     #[test]
@@ -354,18 +360,23 @@ mod tests {
     fn session_marker_never_embeds_raw_session_id() {
         // A path-traversal session id must be hashed to a plain filename — the
         // result is always a direct child of marker_dir(), never an escape.
-        let input = input_with_session("../../evil");
-        let p = session_marker(&input, "test-kind", None);
-        assert_eq!(
-            p.parent(),
-            Some(marker_dir().as_path()),
-            "marker must be a direct child of the private dir: {p:?}"
-        );
-        let name = p.file_name().unwrap().to_string_lossy();
-        assert!(
-            !name.contains('/') && !name.contains(".."),
-            "filename must carry no traversal: {name}"
-        );
+        // Under ENV_LOCK so the `session_marker` read and the `marker_dir()`
+        // read in the assert resolve the same base (#369).
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let input = input_with_session("../../evil");
+            let p = session_marker(&input, "test-kind", None);
+            assert_eq!(
+                p.parent(),
+                Some(marker_dir().as_path()),
+                "marker must be a direct child of the private dir: {p:?}"
+            );
+            let name = p.file_name().unwrap().to_string_lossy();
+            assert!(
+                !name.contains('/') && !name.contains(".."),
+                "filename must carry no traversal: {name}"
+            );
+        });
     }
 
     #[test]
@@ -384,41 +395,56 @@ mod tests {
 
     #[test]
     fn polish_marker_stable_for_same_inputs() {
-        let a = polish_marker("/tmp/repo", "main");
-        let b = polish_marker("/tmp/repo", "main");
-        assert_eq!(a, b, "same inputs must produce the same marker");
+        // Under ENV_LOCK so a concurrent `with_marker_dir` test can't flip the
+        // base between the two reads (#369).
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let a = polish_marker("/tmp/repo", "main");
+            let b = polish_marker("/tmp/repo", "main");
+            assert_eq!(a, b, "same inputs must produce the same marker");
+        });
     }
 
     #[test]
     fn polish_marker_never_embeds_raw_branch_or_repo() {
         // A path-traversal branch/repo must be hashed to a plain filename — the
         // result is always a direct child of marker_dir(), never an escape.
-        let p = polish_marker("../../evil-repo", "../../evil-branch");
-        assert_eq!(
-            p.parent(),
-            Some(marker_dir().as_path()),
-            "marker must be a direct child of the private dir: {p:?}"
-        );
-        let name = p.file_name().unwrap().to_string_lossy();
-        assert!(
-            !name.contains('/') && !name.contains(".."),
-            "filename must carry no traversal: {name}"
-        );
+        // Under ENV_LOCK so both reads resolve the same base (#369).
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let p = polish_marker("../../evil-repo", "../../evil-branch");
+            assert_eq!(
+                p.parent(),
+                Some(marker_dir().as_path()),
+                "marker must be a direct child of the private dir: {p:?}"
+            );
+            let name = p.file_name().unwrap().to_string_lossy();
+            assert!(
+                !name.contains('/') && !name.contains(".."),
+                "filename must carry no traversal: {name}"
+            );
+        });
     }
 
     #[cfg(unix)]
     #[test]
     fn marker_dir_is_owner_only() {
         use std::os::unix::fs::PermissionsExt;
-        let dir = marker_dir();
-        // marker_dir() only returns the private path when it secured it; if it
-        // fell back to the shared temp root, that's the fail-open path and 0700
-        // is not asserted. In the normal test environment the private dir is
-        // created and locked down.
-        if dir != paths::marker_temp_dir() {
-            let mode = std::fs::metadata(&dir).unwrap().permissions().mode();
-            assert_eq!(mode & 0o777, 0o700, "marker dir must be owner-only");
-        }
+        // Under ENV_LOCK + an override base so this never creates/hardens the
+        // real per-user marker dir (#302/#369); the override is still hardened,
+        // so the 0700 property holds on it just the same.
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let dir = marker_dir();
+            // marker_dir() only returns the private path when it secured it; if it
+            // fell back to the shared temp root, that's the fail-open path and 0700
+            // is not asserted. In the normal test environment the private dir is
+            // created and locked down.
+            if dir != paths::marker_temp_dir() {
+                let mode = std::fs::metadata(&dir).unwrap().permissions().mode();
+                assert_eq!(mode & 0o777, 0o700, "marker dir must be owner-only");
+            }
+        });
     }
 
     #[cfg(unix)]

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -36,8 +36,36 @@ use std::path::{Path, PathBuf};
 /// **Fails open** to the shared [`paths::marker_temp_dir`] when the private dir
 /// can't be created or secured (or a symlink squats its path): markers are
 /// advisory, so a re-fired nudge is the acceptable degraded mode, never a block.
+///
+/// Honors `CADENCE_MARKER_DIR` as a base-directory override, read
+/// unconditionally like `CADENCE_METRICS_DIR` (`crates/metrics/src/common.rs`)
+/// — not `#[cfg(test)]`-gated, since the integration suite (`tests/session_markers.rs`)
+/// exercises the real compiled binary, which must honor it too. When set and
+/// non-empty, the per-user hashed subdir is created under it instead of the
+/// shared [`paths::marker_temp_dir`]; [`harden_marker_dir`] still runs on the
+/// result, so an override can never skip the `0700` lockdown — it can only
+/// fail open to an *unhardened override base* the same way the default path
+/// fails open to an unhardened [`paths::marker_temp_dir`]. Intended for tests
+/// today (#302); a real caller setting it changes only which advisory nudge
+/// state that caller's own process sees.
 pub fn marker_dir() -> PathBuf {
-    let base = paths::marker_temp_dir();
+    marker_dir_from(std::env::var("CADENCE_MARKER_DIR").ok())
+}
+
+/// Pure resolver behind [`marker_dir`]: takes the `CADENCE_MARKER_DIR` value
+/// explicitly (rather than reading process-global env) so the override is
+/// unit-testable without env mutation, mirroring `metrics_dir_from`
+/// (`crates/metrics/src/common.rs`). `None` or an empty string falls through to
+/// the shared [`paths::marker_temp_dir`].
+///
+/// The override replaces only the *base* the per-user hashed subdir is created
+/// under — [`harden_marker_dir`] still runs on the derived path, so an override
+/// never bypasses the `0700` lockdown.
+fn marker_dir_from(override_dir: Option<String>) -> PathBuf {
+    let base = match override_dir {
+        Some(dir) if !dir.is_empty() => PathBuf::from(dir),
+        _ => paths::marker_temp_dir(),
+    };
     let mut hasher = DefaultHasher::new();
     paths::user_home_lossy_or_default().hash(&mut hasher);
     let dir = base.join(format!("cadence-hooks-{:x}", hasher.finish()));
@@ -217,6 +245,73 @@ pub fn write_marker(path: &Path, contents: &str) -> io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // --- marker_dir_from (pure resolver behind CADENCE_MARKER_DIR) ---
+
+    #[test]
+    fn marker_dir_from_override_is_used_as_base() {
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = marker_dir_from(Some(tmp.path().to_string_lossy().into_owned()));
+        assert!(
+            dir.starts_with(tmp.path()),
+            "override must become the base the hashed subdir is created under: {dir:?}"
+        );
+    }
+
+    #[test]
+    fn marker_dir_from_empty_override_falls_through() {
+        // An empty CADENCE_MARKER_DIR must not shadow the default (guards the
+        // `!dir.is_empty()` branch), mirroring metrics_dir_from's same guard.
+        let dir = marker_dir_from(Some(String::new()));
+        assert!(
+            dir.starts_with(paths::marker_temp_dir()),
+            "empty override must fall through to marker_temp_dir: {dir:?}"
+        );
+    }
+
+    #[test]
+    fn marker_dir_from_none_falls_through() {
+        let dir = marker_dir_from(None);
+        assert!(dir.starts_with(paths::marker_temp_dir()));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn marker_dir_from_override_is_still_hardened() {
+        use std::os::unix::fs::PermissionsExt;
+        let tmp = tempfile::tempdir().unwrap();
+        let dir = marker_dir_from(Some(tmp.path().to_string_lossy().into_owned()));
+        let mode = std::fs::metadata(&dir).unwrap().permissions().mode();
+        assert_eq!(
+            mode & 0o777,
+            0o700,
+            "an overridden base must still get the 0700-hardened derived dir"
+        );
+    }
+
+    // --- crate-local env-mutating test serialization (mirrors the metrics
+    // crate's `common::ENV_LOCK` / per-module `with_metrics_dir`, #302) ---
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Run `f` with `CADENCE_MARKER_DIR` set to `dir`, serialized against every
+    /// other marker-dir-mutating test in this module via [`ENV_LOCK`] — keeps
+    /// `polish_marker_present_*` tests below from ever writing into the real
+    /// per-user production marker directory.
+    fn with_marker_dir<F: FnOnce()>(dir: &Path, f: F) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other env-mutating test in this
+        // module via ENV_LOCK.
+        unsafe {
+            std::env::set_var("CADENCE_MARKER_DIR", dir);
+        }
+        f();
+        // SAFETY: serialized against every other env-mutating test in this
+        // module via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("CADENCE_MARKER_DIR");
+        }
+    }
 
     fn input_with_session(sid: &str) -> HookInput {
         HookInput {
@@ -406,22 +501,28 @@ mod tests {
     #[test]
     fn polish_marker_present_true_for_current_branch_with_marker() {
         let (tmp, root) = init_repo_on_branch("feat/thing");
-        write_marker(&polish_marker(&root, "feat/thing"), "{}").unwrap();
-        assert!(polish_marker_present(
-            "gh pr create --title x",
-            Some(tmp.path().to_str().unwrap())
-        ));
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(&polish_marker(&root, "feat/thing"), "{}").unwrap();
+            assert!(polish_marker_present(
+                "gh pr create --title x",
+                Some(tmp.path().to_str().unwrap())
+            ));
+        });
     }
 
     #[test]
     fn polish_marker_present_false_for_different_branch_marker() {
         // A marker for branch A must NOT satisfy a repo checked out on branch B.
         let (tmp, root) = init_repo_on_branch("branch-b");
-        write_marker(&polish_marker(&root, "branch-a"), "{}").unwrap();
-        assert!(!polish_marker_present(
-            "gh pr create --title x",
-            Some(tmp.path().to_str().unwrap())
-        ));
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            write_marker(&polish_marker(&root, "branch-a"), "{}").unwrap();
+            assert!(!polish_marker_present(
+                "gh pr create --title x",
+                Some(tmp.path().to_str().unwrap())
+            ));
+        });
     }
 
     #[test]

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -553,11 +553,19 @@ mod tests {
 
     #[test]
     fn polish_marker_present_false_when_no_marker() {
+        // polish_marker_present reads marker_dir() (env), so hold ENV_LOCK
+        // against concurrent with_marker_dir writers (#369) and keep the lookup
+        // off the real per-user dir (#302). Unlike the two-read stability tests
+        // this can't flip its assertion, but an unguarded env read still races
+        // a writer's set_var (unsound in edition 2024).
         let (tmp, _root) = init_repo_on_branch("feat/unmarked");
-        assert!(!polish_marker_present(
-            "gh pr create --title x",
-            Some(tmp.path().to_str().unwrap())
-        ));
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            assert!(!polish_marker_present(
+                "gh pr create --title x",
+                Some(tmp.path().to_str().unwrap())
+            ));
+        });
     }
 
     #[test]

--- a/tests/session_markers.rs
+++ b/tests/session_markers.rs
@@ -9,7 +9,11 @@
 use std::io::Write;
 use std::process::Command;
 
-fn cadence_hooks() -> Command {
+/// Build the child command, sandboxed to `marker_dir` via `CADENCE_MARKER_DIR`
+/// so the marker this binary writes never lands in the real per-user marker
+/// directory (#302) — `.env()` only affects the *child's* environment, so this
+/// needs no serialization against other tests in this file.
+fn cadence_hooks(marker_dir: &std::path::Path) -> Command {
     let mut cmd = Command::new(env!("CARGO_BIN_EXE_cadence-hooks"));
     // Don't inherit enforcement toggles from the test runner's session.
     cmd.env_remove("CADENCE_BYPASS");
@@ -19,6 +23,7 @@ fn cadence_hooks() -> Command {
     // exercised deterministically. CADENCE_ALLOW_MAIN would silence the nudge.
     cmd.env_remove("PPID");
     cmd.env_remove("CADENCE_ALLOW_MAIN");
+    cmd.env("CADENCE_MARKER_DIR", marker_dir);
     cmd
 }
 
@@ -52,8 +57,10 @@ fn init_main_repo() -> tempfile::TempDir {
     dir
 }
 
-/// A payload unique per run so markers from prior test runs (which persist in
-/// the temp marker dir) never mask the assertion.
+/// A payload unique per run. Each test's marker dir is now a fresh, isolated
+/// tempdir (#302), so a leftover marker from a prior run can no longer mask
+/// the assertion — the session_id is still generated per-run as a defensive
+/// habit against any future shared-dir regression.
 ///
 /// Built with a JSON serializer, NOT `format!`: on Windows the repo/file paths
 /// carry backslashes (`C:\Users\...`), and a raw `\U`/`\r` in a JSON string is an
@@ -83,9 +90,12 @@ fn warn_main_branch_nudges_once_per_session() {
             .as_nanos()
     );
     let payload = edit_payload(repo.path(), &session_id);
+    // Both invocations must share one marker dir — invocation 2 needs to see
+    // invocation 1's marker — but isolated to this test alone (#302).
+    let marker_dir = tempfile::tempdir().expect("marker tempdir");
 
     // Invocation 1: same session, first edit on main → nudge.
-    let mut cmd1 = cadence_hooks();
+    let mut cmd1 = cadence_hooks(marker_dir.path());
     cmd1.args(["guardrails", "warn-main-branch"]);
     let out1 = run_with_stdin(cmd1, &payload);
     let stdout1 = String::from_utf8_lossy(&out1.stdout);
@@ -97,7 +107,7 @@ fn warn_main_branch_nudges_once_per_session() {
 
     // Invocation 2: same session id, distinct process (distinct pid) → the
     // marker written by invocation 1 must suppress this one.
-    let mut cmd2 = cadence_hooks();
+    let mut cmd2 = cadence_hooks(marker_dir.path());
     cmd2.args(["guardrails", "warn-main-branch"]);
     let out2 = run_with_stdin(cmd2, &payload);
     let stdout2 = String::from_utf8_lossy(&out2.stdout);


### PR DESCRIPTION
## Summary

`cargo test` wrote real polish/session marker files into the real per-user marker directory (`marker_dir()` in `crates/core/src/markers.rs`). Verified live: ~729 residue files had accumulated in `$TMPDIR/cadence-hooks-<hash>` before this fix, and a targeted repro (`record_polish::tests::run_record_degrades_to_noop_when_repo_unresolved`, run in isolation) confirmed a fresh write landing there with this checkout's real repo/branch in the payload.

- `markers.rs`: `marker_dir()` now honors `CADENCE_MARKER_DIR` as a base-directory override, extracted into a pure `marker_dir_from(override: Option<String>)` mirroring `metrics_dir_from`'s shape (`crates/metrics/src/common.rs`). `harden_marker_dir` still runs on the derived path unconditionally, so the override can never skip the `0700` lockdown — it can only fail open to an unhardened override base the same way the default path already fails open to an unhardened `marker_temp_dir()`. The env read is **not** `#[cfg(test)]`-gated (documented in the doc comment) — the integration suite exercises the real compiled binary, which needs to honor it too, same pattern as the already-accepted `CADENCE_METRICS_DIR`.
- Every marker-writing test in `markers.rs`, `nudge_polish_before_pr.rs`, and `record_polish.rs` now runs inside a `with_marker_dir(tempdir, ...)` wrapper (9 call sites total across the three files). `nudge_polish_before_pr.rs` and `record_polish.rs` share one crate-wide `ENV_LOCK` (new `crates/cadence/src/test_support.rs`) since they compile into the same test binary — a per-module lock would let the two files' tests race each other on the process-global env var. `markers.rs` gets its own local lock (separate crate, separate test-binary process, so no sharing needed).
- `tests/session_markers.rs` (spawns the real compiled binary as a child process) passes `CADENCE_MARKER_DIR` via `Command::env()` to the child only — no lock needed, since that never mutates the test binary's own process environment.

## Verification

- `cargo test -p cadence-hooks-core -p cadence-hooks-cadence --lib`: green except 5 pre-existing `worktree::tests::*` failures — confirmed unrelated (that module isn't touched by this diff; they're the documented carve-out-path false-failure from running under `/tmp`, this repo's own CLAUDE.md gotcha).
- `cargo test --test session_markers`: green.
- Live before/after SHA-256 hash of the real production marker directory's file listing across a full test run: byte-identical (no residue written).
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check`: clean.
- Reviewed via `cadence-forge:security-reviewer` (no Critical/Important survive — the override cannot bypass 0700 hardening, doesn't widen cross-user exposure, and the one accuracy nit it found — a doc claiming "tests only" when the read isn't actually `#[cfg(test)]`-gated — is fixed in this PR's doc comment) and `cadence:code-reviewer` (first pass caught a real Critical: a third production-touching test, `run_record_degrades_to_noop_when_repo_unresolved`, whose stale comment claimed a "non-repo cwd" that isn't actually true under `cargo test` — fixed and re-verified isolated).

## Known follow-ups (out of scope here)

- The existing ~1.7k residue files already on disk are separate cleanup (a one-line `rm` or temp-eviction), not part of this fix — this fix stops future accumulation only.
- `with_marker_dir`'s `set_var`/`remove_var` isn't panic-safe (a failing assertion inside the wrapped closure skips the `remove_var`) — this mirrors the pre-existing, already-accepted pattern across the metrics crate's `with_metrics_dir` copies (`log_sweep.rs`, `log_failopen.rs`, `log_bypass.rs`, `log_timing.rs`, `log_denial.rs`, `log_askuserquestion.rs`, `log_session_start.rs`), so this PR extends an established convention rather than introducing a new risk. Worth a `Drop`-guard refactor across all of them at some point, but not scoped to #302.
- A separate, pre-existing edge (#147-era): `marker_dir()` fails open to an *unhardened* base when `harden_marker_dir` fails — this PR doesn't change that behavior or introduce a new exposure class, since the failure path is unchanged for the production default (only reachable today via an already-privileged env-capable context).

Closes cameronsjo/cadence-hooks#302

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved marker-file handling to provide isolated, consistent storage across worktrees and branches.
  * Prevented marker-related test interference and flaky behavior.
  * Ensured session markers are correctly shared between repeated hook invocations within a run.
* **Tests**
  * Expanded coverage for custom marker directories, branch-specific behavior, and worktree scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->