### PR TITLE
fix(try): sandbox metrics logger writes to a scratch dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`try` no longer writes real metrics rows into the production metrics dir (cameronsjo/cadence-hooks#269).** `cadence-hooks try metrics <logger>` self-execs the compiled binary against a generated sample payload, but metrics loggers write unconditionally and silently — a `try` run had appended a real row to the live `skills.jsonl` stream. `try_hook.rs` now sandboxes the self-exec'd child to a scratch tempdir via `CADENCE_METRICS_DIR` (best-effort: if the scratch dir can't be created, a stderr warning names the risk instead of silently falling back to the real dir). `tempfile` promoted from a dev-dependency to a real one in the root crate.
+
 ## [0.64.0] - 2026-07-21
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,7 +44,6 @@ path = "src/main.rs"
 
 [dev-dependencies]
 serde_json.workspace = true
-tempfile = "3"
 
 [dependencies]
 clap.workspace = true
@@ -58,3 +57,4 @@ cadence-hooks-obsidian.workspace = true
 cadence-hooks-metrics.workspace = true
 cadence-hooks-lab.workspace = true
 cadence-hooks-session.workspace = true
+tempfile = "3"

--- a/src/try_hook.rs
+++ b/src/try_hook.rs
@@ -81,13 +81,33 @@ pub fn run(
     );
     println!();
 
-    let mut child = match Command::new(&exe)
+    // A metrics logger writes unconditionally and silently (no stdout on
+    // success), so without this override `try` appends a real row to the
+    // live production metrics stream every time it exercises one (#269).
+    // Scratch dir is best-effort: if it can't be created, the child falls
+    // back to the real metrics dir rather than failing the `try` run — the
+    // pre-existing (buggy) behavior, not a new failure mode — but this must
+    // never be a *silent* fallback, or the exact bug being fixed recurs
+    // invisibly.
+    let metrics_scratch = tempfile::tempdir().ok();
+    if metrics_scratch.is_none() {
+        eprintln!(
+            "cadence-hooks: could not create a scratch metrics dir — this run \
+             may write a real row into the production metrics directory."
+        );
+    }
+
+    let mut command = Command::new(&exe);
+    command
         .args([namespace, subcommand])
         .stdin(Stdio::piped())
         .stdout(Stdio::piped())
-        .stderr(Stdio::piped())
-        .spawn()
-    {
+        .stderr(Stdio::piped());
+    if let Some(scratch) = &metrics_scratch {
+        command.env("CADENCE_METRICS_DIR", scratch.path());
+    }
+
+    let mut child = match command.spawn() {
         Ok(c) => c,
         Err(e) => {
             eprintln!("cadence-hooks: failed to spawn {}: {e}", exe.display());

--- a/tests/try_hook.rs
+++ b/tests/try_hook.rs
@@ -115,10 +115,9 @@ fn try_nudge_renders_context_as_readable_text() {
 
 #[test]
 fn try_runs_a_logger() {
+    // No CADENCE_METRICS_DIR override needed — try_hook.rs sandboxes every
+    // logger invocation to its own scratch dir internally (#269).
     let mut cmd = cadence_hooks();
-    // Point metrics at a temp dir so the logger's side effect lands nowhere real.
-    let tmp = std::env::temp_dir().join("cadence-hooks-try-test");
-    cmd.env("CADENCE_METRICS_DIR", &tmp);
     cmd.args(["try", "metrics", "snapshot"]);
 
     let output = cmd.output().expect("failed to execute binary");
@@ -291,9 +290,10 @@ fn session_cli_actions_remain_bypass_exempt() {
 
 #[test]
 fn try_log_subagent_uses_subagent_event_sample() {
+    // No CADENCE_METRICS_DIR override needed here anymore — try_hook.rs now
+    // sandboxes every logger invocation to a scratch dir internally (#269),
+    // so this test no longer needs (or leaks into) a fixed-path tempdir.
     let mut cmd = cadence_hooks();
-    let tmp = std::env::temp_dir().join("cadence-hooks-try-test");
-    cmd.env("CADENCE_METRICS_DIR", &tmp);
     cmd.args(["try", "metrics", "log-subagent"]);
 
     let output = cmd.output().expect("failed to execute binary");
@@ -305,6 +305,33 @@ fn try_log_subagent_uses_subagent_event_sample() {
     assert!(
         stdout.contains("SubagentStop"),
         "log-subagent sample must use a Subagent event: {stdout}"
+    );
+}
+
+#[test]
+fn try_metrics_logger_never_writes_into_the_configured_metrics_dir() {
+    // #269: `try metrics log-skill` (the issue's exact repro) appended a real
+    // row to production `skills.jsonl`. Stand in for "the configured metrics
+    // dir" with an isolated tempdir — this test must never observe (or
+    // pollute) the real per-user directory on the machine running it — and
+    // confirm no override is supplied by the caller, matching the real-world
+    // repro where the driver agent set none either.
+    let fake_config_dir = tempfile::tempdir().unwrap();
+
+    let mut cmd = cadence_hooks();
+    cmd.env("CLAUDE_CONFIG_DIR", fake_config_dir.path());
+    cmd.env_remove("CADENCE_METRICS_DIR");
+    cmd.args(["try", "metrics", "log-skill"]);
+
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.status.code(), Some(0), "stdout: {stdout}");
+
+    let would_be_metrics_dir = fake_config_dir.path().join("metrics");
+    assert!(
+        !would_be_metrics_dir.join("skills.jsonl").exists(),
+        "log-skill must not write into the configured metrics dir under try: {}",
+        would_be_metrics_dir.display()
     );
 }
 
@@ -328,9 +355,13 @@ fn piped_stdin_does_not_trigger_interactive_guard() {
 
 #[test]
 fn piped_stdin_logger_does_not_trigger_interactive_guard() {
+    // This calls the logger directly (no `try` wrapper, so try_hook.rs's
+    // internal scratch-dir override doesn't apply here) — point metrics at
+    // an isolated per-test tempdir so the logger's side effect lands nowhere
+    // real and never accumulates residue across runs (#269).
+    let scratch = tempfile::tempdir().unwrap();
     let mut cmd = cadence_hooks();
-    let tmp = std::env::temp_dir().join("cadence-hooks-try-test");
-    cmd.env("CADENCE_METRICS_DIR", &tmp);
+    cmd.env("CADENCE_METRICS_DIR", scratch.path());
     cmd.args(["metrics", "snapshot"]);
 
     let output = run_with_stdin(cmd, "{}");


### PR DESCRIPTION
## Summary

`cadence-hooks try metrics <logger>` self-execs the binary against a generated sample payload, but metrics loggers write unconditionally and silently (no stdout on success) via `common::metrics_dir()`, which already honors a `CADENCE_METRICS_DIR` override. A `try metrics log-skill` run had appended a real row into the live production `skills.jsonl` stream during a verification session.

- `try_hook.rs` now creates a scratch tempdir and sets `CADENCE_METRICS_DIR` on the self-exec'd child only (`Command::env()` — never touches the parent `try` process's own environment)
- Best-effort: if the scratch dir can't be created, a stderr warning names the risk instead of silently falling back into the exact bug being fixed
- `tempfile` promoted from a dev-dependency to a real one in the root crate, since this is now production code
- Cleaned up two existing tests that pointed `CADENCE_METRICS_DIR` at a fixed, non-random path (`$TMPDIR/cadence-hooks-try-test`) — confirmed this had accumulated real residue (a growing `subagents.jsonl`, a `state/` dir) across every prior test run. One test's override is now redundant (it goes through `try`, which sandboxes internally); the other calls the logger directly and now uses a fresh per-test tempdir instead of the shared fixed path
- Adds a regression test confirming no file lands in a `CLAUDE_CONFIG_DIR`-configured metrics dir after `try metrics log-skill`
- CHANGELOG `[Unreleased]` entry added

## Verification

- Built the pre-fix binary from `origin/main` and confirmed it reproduces the bug (a real row lands in a fake `CLAUDE_CONFIG_DIR`-pointed metrics dir); built the fixed binary and confirmed the same repro writes nothing
- Full test suite green except two pre-existing, unrelated failures: `doctor.rs` (confirmed present on unmodified `origin/main` too) and 5 `worktree::tests::*` carve-out false-failures (this checkout sits under `/tmp`, a documented CLAUDE.md gotcha; `worktree.rs` isn't touched by this diff)
- `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean
- Reviewed via `cadence:code-reviewer`: caught two real Important findings (silent fallback with no warning on tempdir-creation failure; missing CHANGELOG entry) — both fixed in this PR. A third finding (a sibling test still using the fixed residue-accumulating path) was based on a stale read — that test was already fixed in an earlier pass of this same PR, confirmed by re-grepping the current file

Closes cameronsjo/cadence-hooks#269