### PR TITLE
fix(guardrails): name the explicit-worktree false positive in warn-subagent-worktree

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`warn-subagent-worktree`'s message names a known false-positive shape (cameronsjo/cadence-hooks#371).** The check can only see structural signals (`isolation`, cwd, sibling-worktree count) — the dispatch prompt text itself isn't in the hook payload today, so a dispatch whose prompt has the agent create and operate on its own explicit worktree (`git -C <repo> worktree add ...`, then `git -C <path>` throughout — the `orchestrating-issue-slates` pattern) still nudges even though the work lands exactly where intended. The nudge now names this case explicitly so an operator can recognize and disregard it rather than learning to ignore the warning broadly.
+
 ## [0.64.0] - 2026-07-21
 
 ### Fixed

--- a/crates/guardrails/src/warn_subagent_worktree.rs
+++ b/crates/guardrails/src/warn_subagent_worktree.rs
@@ -66,11 +66,23 @@ fn is_allowed_value(value: Option<&str>) -> bool {
 
 /// The nudge message: names the behavior (cwd inheritance → main, not the
 /// worktree) and both fixes, plus the silence env var.
+///
+/// Known false-positive shape (cadence-hooks#371): this check can only see
+/// structural signals (`isolation`, cwd, sibling-worktree count) — the actual
+/// dispatch prompt text isn't in the hook payload, so a dispatch whose prompt
+/// itself instructs the agent to `git -C <path> worktree add ...` and operate
+/// exclusively via that explicit path (the `orchestrating-issue-slates`
+/// pattern) still nudges even though the work lands exactly where intended.
+/// The message names this case explicitly so an operator can recognize and
+/// disregard it, rather than the warning training "ignore this" broadly.
 fn warn_message() -> String {
     "Subagent dispatched from the main checkout while a sibling worktree exists — subagents \
-     inherit this session's cwd, so the work lands in main, not the worktree. To isolate: \
-     dispatch from inside the worktree, or pass isolation: \"worktree\". Silence for this repo: \
-     CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true in .claude/settings.json"
+     inherit this session's cwd, so the work lands in main, not the worktree. Known false \
+     positive: if the dispatch prompt itself has the agent create and operate on its own \
+     explicit worktree (`git -C <repo> worktree add ...`, then `git -C <path>` throughout), \
+     disregard this nudge. To isolate otherwise: dispatch from inside the worktree, or pass \
+     isolation: \"worktree\". Silence for this repo: CADENCE_ALLOW_SUBAGENT_FROM_MAIN=true in \
+     .claude/settings.json"
         .to_string()
 }
 
@@ -182,6 +194,23 @@ mod tests {
         let msg = result.message.expect("nudge has a message");
         assert!(msg.contains("worktree"));
         assert!(msg.contains("CADENCE_ALLOW_SUBAGENT_FROM_MAIN"));
+    }
+
+    #[test]
+    fn warn_message_names_the_explicit_worktree_false_positive() {
+        // #371: the check can't see the dispatch prompt text, so it can't
+        // auto-suppress the "agent creates its own worktree" pattern — the
+        // message must name it explicitly so an operator can recognize and
+        // disregard it instead of learning to ignore the warning wholesale.
+        let msg = warn_message();
+        assert!(
+            msg.contains("false positive"),
+            "message should name the known false-positive shape: {msg}"
+        );
+        assert!(
+            msg.to_lowercase().contains("git -c"),
+            "message should describe the explicit-worktree pattern concretely: {msg}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary

`warn-subagent-worktree` nudges whenever a subagent is dispatched from the primary checkout with a sibling worktree present and no `isolation: "worktree"` set — reasoning that the subagent will inherit the spawning session's cwd (main). But a dispatch whose *prompt* itself instructs the agent to `git -C <repo> worktree add ...` and operate exclusively on that explicit path (the `orchestrating-issue-slates` pattern) still nudges, even though the work lands exactly where intended.

- Names this known false-positive shape explicitly in the nudge message, so an operator can recognize and disregard it rather than the warning training "ignore this" broadly — the fallback fix the issue itself named when full auto-suppression isn't available
- Added a test asserting the message names the false positive and describes the concrete pattern

## Why not auto-suppress?

`HookInput`/`ToolInput` has no field for the Agent tool's dispatch prompt text today — the top-level `prompt` field is UserPromptSubmit-only, and `ToolInput` (used for Agent/Task) captures only `subagent_type` and `isolation`. Whether the platform's live wire payload actually carries the prompt text (just uncaptured by this struct) or genuinely omits it is an open question docs couldn't settle — filed as [cadence-hooks#374](https://github.com/cameronsjo/cadence-hooks/issues/374) rather than guessing at a schema change here.

## Verification

Reviewed via `cadence:code-reviewer`, which caught two real, fixed findings: the message had grown into a dense 96-word run-on sentence with an out-of-convention ALL-CAPS "UNLESS" — tightened to two plain sentences matching this crate's existing message style; and a missing CHANGELOG entry — added. The reviewer's fourth question (whether the "no prompt field" premise is actually platform-confirmed) is exactly what #374 investigates.

`cargo test -p cadence-hooks-guardrails --lib warn_subagent_worktree`: 27/27 pass. `cargo clippy --workspace --all-targets -- -D warnings` and `cargo fmt --all -- --check` clean.

Closes cameronsjo/cadence-hooks#371