### PR TITLE
feat(rules): accept background frontmatter field, enforce strict booleans

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`validate-skill-frontmatter` accepts the `background` field and enforces strict booleans.** Claude Code 2.1.218 made `context: fork` skills background-by-default with `background: false` as the per-skill opt-out; the field allowlist now admits `background` so the opt-out is writable. New value-validation applies one rule to all three boolean fields (`background`, `disable-model-invocation`, `user-invocable`): exactly `true` or `false`. The platform also accepts `yes/no/on/off/1/0` as of 2.1.218 — cadence deliberately does not; one spelling keeps the skill corpus greppable.
+
 ### Fixed
 
 - **`warn-subagent-worktree` no longer nudges on a structurally read-only dispatch (cameronsjo/cadence-hooks#331).** The built-in `Explore`/`Plan` `subagent_type` values have their own tool grant exclude `Edit`/`Write`/`NotebookEdit` — nothing can land in the worktree or the primary checkout either way, so isolation is moot. These two are now exempted. A plugin-provided or custom-instructed read-only dispatch (e.g. `cadence:explorer`, or a `general-purpose` agent told "read-only" in its prompt) is not detectable today — whether the Agent tool's `PreToolUse` payload even carries the dispatch prompt text is an open question (cameronsjo/cadence-hooks#374) — and still nudges; documented as a known false-positive class in the check's doc comment.

--- a/crates/rules/src/validate_skill_frontmatter.rs
+++ b/crates/rules/src/validate_skill_frontmatter.rs
@@ -92,6 +92,19 @@ fn skill_dir_name(path: &str) -> Option<&str> {
     parent.rsplit('/').next()
 }
 
+/// Strip a trailing inline YAML comment from a scalar value. Per YAML, `#`
+/// opens a comment only when preceded by whitespace — `true  # why` yields
+/// `true`, while `true#x` stays intact (it is the value, not a comment).
+fn strip_inline_comment(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    for i in 1..bytes.len() {
+        if bytes[i] == b'#' && bytes[i - 1].is_ascii_whitespace() {
+            return value[..i].trim_end();
+        }
+    }
+    value
+}
+
 /// Validates YAML frontmatter in skill and command markdown files.
 pub struct ValidateSkillFrontmatter;
 
@@ -132,11 +145,14 @@ impl Check for ValidateSkillFrontmatter {
         }
 
         // Boolean fields: exactly `true` or `false` — house strictness, one
-        // rule for all three (the platform accepts yes/no/on/off/1/0).
+        // rule for all three (the platform accepts yes/no/on/off/1/0). A
+        // trailing inline comment is not part of the value; quoted values
+        // (`"true"`) stay blocked — unquoted is the house spelling.
         for (key, value) in &fields {
-            if BOOLEAN_FIELDS.contains(&key.as_str()) && value != "true" && value != "false" {
+            let bare = strip_inline_comment(value);
+            if BOOLEAN_FIELDS.contains(&key.as_str()) && bare != "true" && bare != "false" {
                 errors.push(format!(
-                    "'{key}' must be exactly 'true' or 'false' (got: '{value}') — the platform accepts yes/no/on/off/1/0, cadence house style does not"
+                    "'{key}' must be exactly 'true' or 'false' (got: '{bare}') — the platform accepts yes/no/on/off/1/0, cadence house style does not"
                 ));
             }
         }
@@ -693,6 +709,46 @@ mod tests {
         );
         let result = ValidateSkillFrontmatter.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn run_skill_boolean_with_inline_comment_passes() {
+        // A trailing YAML comment is not part of the value — `true  # why`
+        // is the boolean true, not a malformed spelling.
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\ncontext: fork\nbackground: true  # opt out later\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn run_skill_quoted_boolean_blocks() {
+        // Deliberate: `"true"` is a string spelling, not the house boolean.
+        // Unquoted true/false is the one greppable form.
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\ncontext: fork\nbackground: \"true\"\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("must be exactly 'true' or 'false'")
+        );
+    }
+
+    #[test]
+    fn strip_inline_comment_edges() {
+        assert_eq!(strip_inline_comment("true  # opt out later"), "true");
+        assert_eq!(strip_inline_comment("true"), "true");
+        // `#` without preceding whitespace is part of the value, not a comment.
+        assert_eq!(strip_inline_comment("true#x"), "true#x");
+        assert_eq!(strip_inline_comment("#leading"), "#leading");
+        assert_eq!(strip_inline_comment(""), "");
     }
 
     #[test]

--- a/crates/rules/src/validate_skill_frontmatter.rs
+++ b/crates/rules/src/validate_skill_frontmatter.rs
@@ -19,10 +19,16 @@ const VALID_FIELDS: &[&str] = &[
     "user-invocable",
     "model",
     "context",
+    "background",
     "agent",
     "hooks",
     "paths",
 ];
+
+// House strictness: boolean fields take exactly `true` or `false`. The
+// platform (Claude Code >= 2.1.218) also accepts yes/no/on/off/1/0 —
+// cadence deliberately does not: one spelling keeps the corpus greppable.
+const BOOLEAN_FIELDS: &[&str] = &["background", "disable-model-invocation", "user-invocable"];
 
 // Kebab-case name, optionally prefixed by a kebab `namespace:` (the
 // `plugin:directory` invocation id, e.g. `cadence:attune`). Both sides are
@@ -122,6 +128,16 @@ impl Check for ValidateSkillFrontmatter {
         for (key, _) in &fields {
             if !VALID_FIELDS.contains(&key.as_str()) {
                 errors.push(format!("Unknown frontmatter field: '{key}'"));
+            }
+        }
+
+        // Boolean fields: exactly `true` or `false` — house strictness, one
+        // rule for all three (the platform accepts yes/no/on/off/1/0).
+        for (key, value) in &fields {
+            if BOOLEAN_FIELDS.contains(&key.as_str()) && value != "true" && value != "false" {
+                errors.push(format!(
+                    "'{key}' must be exactly 'true' or 'false' (got: '{value}') — the platform accepts yes/no/on/off/1/0, cadence house style does not"
+                ));
             }
         }
 
@@ -590,6 +606,90 @@ mod tests {
         let input = make_write_input(
             "/plugins/skills/my-skill/SKILL.md",
             "---\nname: my-skill\ndescription: A test skill\npaths: src/**/*.rs\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    // --- Background fork skills (Claude Code 2.1.218) + strict booleans ---
+
+    #[test]
+    fn run_skill_with_background_true_passes() {
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\ncontext: fork\nbackground: true\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn run_skill_with_background_false_passes() {
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\ncontext: fork\nbackground: false\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
+    fn run_skill_background_yes_blocks() {
+        // The platform loosened boolean parsing (yes/no/on/off/1/0) in
+        // 2.1.218; cadence house style stays strict true/false.
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\ncontext: fork\nbackground: yes\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("must be exactly 'true' or 'false'")
+        );
+    }
+
+    #[test]
+    fn run_skill_user_invocable_yes_blocks() {
+        // One rule for all boolean fields — pre-existing booleans get the
+        // same strictness as the new `background` field.
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\nuser-invocable: yes\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("'user-invocable' must be exactly 'true' or 'false'")
+        );
+    }
+
+    #[test]
+    fn run_skill_disable_model_invocation_numeric_blocks() {
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\ndisable-model-invocation: 1\n---\n# Content",
+        );
+        let result = ValidateSkillFrontmatter.run(&input);
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+        assert!(
+            result
+                .message
+                .unwrap()
+                .contains("'disable-model-invocation' must be exactly 'true' or 'false'")
+        );
+    }
+
+    #[test]
+    fn run_skill_boolean_true_false_still_pass() {
+        let input = make_write_input(
+            "/plugins/skills/my-skill/SKILL.md",
+            "---\nname: my-skill\ndescription: A test skill\nuser-invocable: false\ndisable-model-invocation: true\n---\n# Content",
         );
         let result = ValidateSkillFrontmatter.run(&input);
         assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);


### PR DESCRIPTION
## What

Claude Code 2.1.218 made `context: fork` skills background-by-default, with `background: false` as the per-skill opt-out. `validate-skill-frontmatter`'s strict field allowlist rejected `background` as an unknown field, so the opt-out could not be written under the guard.

## Changes

- Add `background` to `VALID_FIELDS`.
- New boolean value-validation, one rule for all three boolean fields (`background`, `disable-model-invocation`, `user-invocable`): exactly `true` or `false`. The platform also accepts `yes/no/on/off/1/0` as of 2.1.218 — this repo's house style deliberately does not; one spelling keeps a skill corpus greppable.
- Strip trailing inline YAML comments before the boolean compare (`background: true  # note` is the boolean `true`; a `#` without preceding whitespace stays part of the value per YAML). Quoted values (`"true"`) remain blocked — unquoted is the one house spelling.
- Regression tests: `true`/`false` accepted (bare and with an inline comment); `yes`, `1`, and quoted spellings rejected with the house-strictness message; unknown fields still rejected; strip-helper boundary cases.

## Verification

- `make ci` green locally (fmt-check + clippy `-D warnings` + full suite), run from a carve-out-free worktree.
- Corpus grep across all local skill sources found zero existing non-`true/false` values on the three boolean fields — no migration needed.
- Sequencing proof: with the installed 0.64.0 binary, writing a skill file carrying `background: true` is blocked ("Unknown frontmatter field"); this change unblocks it while keeping value strictness.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for additional skill frontmatter fields, including `background`, `agent`, `hooks`, and `paths`.
  * Boolean frontmatter values are now validated consistently and must use unquoted `true` or `false`.
  * Inline YAML comments are supported when validating boolean values.

* **Documentation**
  * Updated the changelog with the new frontmatter validation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->