### PR TITLE
test(cadence): fail loudly when the sibling script moves; harden NS= parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 ### Added
 
 - **Cross-sibling namespace-parity audit test.** `tests/hook_registration_audit.rs::namespace_list_matches_redact_check_sh` now diffs `redact_external_content::NAMESPACES` (newly `pub`) against the sibling plugin's `redact-check.sh` `NS='...'` alternation as sets, catching drift between the Rust and bash namespace blocklists. Mirrors the existing sibling-resolution and silent-skip posture used by `all_binary_subcommands_are_registered` — no sibling checkout, no failure.
+- **Hardened the namespace-parity audit's sibling resolution and `NS=` parsing.** The skip now keys off the sibling plugin's `skills/redaction` *directory* existing (mirroring `all_binary_subcommands_are_registered`'s directory-keyed skip), not the script file itself — so a present plugin checkout with a moved or renamed `redact-check.sh` fails loudly instead of silently skipping. `parse_redact_check_namespaces` now collects every `NS='...'` line and asserts there's exactly one, rather than trusting the first match. Also extracted a shared `workspace_root()` helper (was duplicated three times) and marked `NAMESPACES` `#[doc(hidden)]` as an in-repo test-linkage exposure, not a supported public API.
 
 ## [0.66.0] - 2026-07-23
 

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -105,7 +105,9 @@ fn ceiling_ord(s: &str) -> u8 {
 /// not as `cadence` + leftover or bare `mcp`.
 /// `pub` (rather than crate-private) so the cross-sibling namespace-parity
 /// audit test (`tests/hook_registration_audit.rs`) can read it directly and
-/// diff it against the plugin-side `redact-check.sh` namespace list.
+/// diff it against the plugin-side `redact-check.sh` namespace list. Exposed
+/// for that in-repo test linkage only — not a supported public API.
+#[doc(hidden)]
 pub const NAMESPACES: &[&str] = &[
     "cadence",
     "cadence-forge",

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -11,6 +11,17 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::path::PathBuf;
 use std::process::Command;
 
+/// The workspace parent directory — one level above this crate's manifest
+/// dir — where sibling plugin checkouts (`cadence/`, `cadence-guardrails/`,
+/// etc.) live alongside this repo. Shared by every audit that cross-checks
+/// a sibling plugin.
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .parent()
+        .expect("cadence-hooks should be inside claude-configurations")
+        .to_path_buf()
+}
+
 /// All valid `<plugin> <subcommand>` pairs the binary accepts.
 /// Discovered by running `cadence-hooks <plugin> --help` for each plugin group.
 fn binary_subcommands() -> BTreeSet<String> {
@@ -144,10 +155,7 @@ const KNOWN_DISTINCT_SETTINGS_SCRIPTS: &[&str] = &[
 
 /// Plugin name -> list of `<plugin> <subcommand>` strings referenced in its hooks.json.
 fn hooks_json_references() -> BTreeMap<String, Vec<HookRef>> {
-    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("cadence-hooks should be inside claude-configurations")
-        .to_path_buf();
+    let workspace_root = workspace_root();
 
     let plugin_dirs = BINARY_PLUGIN_DIRS;
 
@@ -372,10 +380,7 @@ fn all_binary_subcommands_are_registered() {
     // (not hooks.json existence) so a checked-out plugin with missing wiring
     // fails the audit instead of hiding behind the exemption. Remove the
     // PENDING_PLUGIN_GROUPS entry in the plugin's wiring PR.
-    let workspace_parent = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("cadence-hooks should be inside claude-configurations")
-        .to_path_buf();
+    let workspace_parent = workspace_root();
     let pending_groups: BTreeSet<&str> = PENDING_PLUGIN_GROUPS
         .iter()
         .filter(|(group, _)| {
@@ -684,38 +689,59 @@ fn hook_event_types_match_hooks_json() {
 /// sibling plugin's `redact-check.sh`. Matched by the `NS='` prefix, never
 /// by line number, so the script can grow unrelated lines above or below it
 /// without breaking this parse.
+///
+/// Collects every matching line (rather than returning on the first) and
+/// asserts there is exactly one — a future unrelated line shaped like
+/// `NS='...'` (e.g. a comment or a second variable) would otherwise
+/// silently win by first-match instead of failing loudly.
 fn parse_redact_check_namespaces(content: &str) -> Vec<String> {
-    for line in content.lines() {
-        let trimmed = line.trim();
-        if let Some(rest) = trimmed.strip_prefix("NS='")
-            && let Some(list) = rest.strip_suffix('\'')
-        {
-            return list.split('|').map(str::to_string).collect();
-        }
-    }
-    Vec::new()
+    let matches: Vec<&str> = content
+        .lines()
+        .map(str::trim)
+        .filter_map(|line| line.strip_prefix("NS='"))
+        .filter_map(|rest| rest.strip_suffix('\''))
+        .collect();
+
+    assert_eq!(
+        matches.len(),
+        1,
+        "expected exactly one `NS='...'` line in redact-check.sh, found {}: {matches:?}",
+        matches.len()
+    );
+
+    matches[0].split('|').map(str::to_string).collect()
 }
 
 #[test]
 fn namespace_list_matches_redact_check_sh() {
     // Sibling plugin script that carries a bash-side copy of the same
     // namespace list used to build `redact_external_content::NAMESPACES`.
-    // Resolved the same way as the plugin hooks.json siblings above — skip
-    // (not fail) when the sibling checkout isn't present, e.g. bare CI.
-    let workspace_root = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
-        .parent()
-        .expect("cadence-hooks should be inside claude-configurations")
-        .to_path_buf();
-    let script_path =
-        workspace_root.join("cadence/plugins/cadence/skills/redaction/scripts/redact-check.sh");
-
-    if !script_path.exists() {
+    //
+    // The skip is keyed off the sibling's `skills/redaction` DIRECTORY
+    // existing, not the script file — mirroring how
+    // `all_binary_subcommands_are_registered` keys its exemption off plugin
+    // directory existence. That distinguishes two different situations:
+    // the sibling checkout genuinely isn't present alongside this repo
+    // (bare CI, no siblings — benign, silent skip), versus the checkout IS
+    // present but `redact-check.sh` has moved or been renamed underneath
+    // it (a real regression this test should fail loudly on, not swallow).
+    let skill_dir = workspace_root().join("cadence/plugins/cadence/skills/redaction");
+    if !skill_dir.is_dir() {
         eprintln!(
-            "SKIPPED: sibling redact-check.sh not found at {} (plugin dir not alongside workspace)",
-            script_path.display()
+            "SKIPPED: sibling cadence plugin's redaction skill dir not found at {} \
+             (plugin dir not alongside workspace)",
+            skill_dir.display()
         );
         return;
     }
+
+    let script_path = skill_dir.join("scripts/redact-check.sh");
+    assert!(
+        script_path.exists(),
+        "sibling redaction skill dir exists at {} but scripts/redact-check.sh is missing — \
+         has the script moved or been renamed? Update this test's expected path.",
+        skill_dir.display()
+    );
 
     let content = std::fs::read_to_string(&script_path)
         .unwrap_or_else(|e| panic!("failed to read {}: {e}", script_path.display()));
@@ -723,11 +749,6 @@ fn namespace_list_matches_redact_check_sh() {
     let script_namespaces: BTreeSet<String> = parse_redact_check_namespaces(&content)
         .into_iter()
         .collect();
-    assert!(
-        !script_namespaces.is_empty(),
-        "failed to find a `NS='...'` line in {}",
-        script_path.display()
-    );
 
     let rust_namespaces: BTreeSet<String> =
         cadence_hooks_cadence::redact_external_content::NAMESPACES


### PR DESCRIPTION
Post-merge review follow-up to #386 — the reviewer's one Important + three nits, all applied:

- **Important:** the parity audit's silent-skip no longer conflates "sibling checkout absent" (benign, CI posture — still a silent skip) with "sibling present but `redact-check.sh` moved/renamed" — the skip now keys off the skill *directory* existing, and a present directory with a missing script fails loudly naming the regression. Mirrors the directory-keyed exemption `all_binary_subcommands_are_registered` already uses.
- `parse_redact_check_namespaces` collects every `NS='…'`-shaped line and asserts exactly one before using it — a future comment or second variable shaped like one now fails loudly instead of silently winning.
- The thrice-duplicated workspace-root derivation is factored into a shared `workspace_root()` helper (the one deliberate non-conversion: `main_rs_event_types` resolves this crate's own manifest dir, a different pattern).
- `NAMESPACES` gains `#[doc(hidden)]` (stays `pub` — an integration test compiles as an external crate) with a doc-comment clause marking it test-linkage-only, not a supported public API.

## Verification

- Perturb control re-proven post-refactor: dropping `"core"` from the Rust list turns the test red naming the entry; restoring turns it green. Independently re-run by the orchestrating session (exit 0, `1 passed`).
- The moved-script panic path is verified by code inspection (deliberately not live-tested — that would mutate the sibling checkout); the live sibling directory and script both exist, so the branch is dormant.
- `make ci`: fmt + clippy green; the only failure is the documented pre-existing `all_binary_subcommands_are_registered` local-siblings non-blocker (`registry_matches_clap_dispatch` green). GitHub CI is the gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
