### PR TITLE
fix(tests): match the panic location by file name, not by separator

### DIFF
--- a/tests/failopen_telemetry.rs
+++ b/tests/failopen_telemetry.rs
@@ -208,8 +208,12 @@ fn a_panicking_check_fails_open_and_dispatch_survives_it() {
     let error = rows[0]["error"]
         .as_str()
         .expect("the panic row carries the payload");
+    // Match on the file name alone, without a leading separator: `Location::file()`
+    // yields the path as the compiler saw it, so a `src/` prefix is `src\` on
+    // Windows. The property under test is that the location was recorded and
+    // points at the dispatch site, which the bare file name pins on every host.
     assert!(
-        error.contains("CADENCE_TEST_PANIC") && error.contains("at src/dispatch.rs:"),
+        error.contains("CADENCE_TEST_PANIC") && error.contains("dispatch.rs:"),
         "payload and source location are both recorded: {error}"
     );
 


### PR DESCRIPTION
Hotfix: `main` is red.

## What broke

`a_panicking_check_fails_open_and_dispatch_survives_it` asserted that the
recorded panic location contains `at src/dispatch.rs:`. `Location::file()`
yields the path as the compiler saw it, so on Windows that is
`src\dispatch.rs` — the assertion failed on the Windows leg while passing
everywhere else.

The `error` field was recording exactly the right thing. Only the assertion was
platform-specific.

## The fix

Match on the bare file name. That pins the same property — the location was
recorded, and it points at the dispatch site — on every host, without
normalizing one platform's spelling into another's.

Checked against the failing string and its siblings, so the assertion still
discriminates rather than merely passing:

| input | matches |
|---|---|
| Windows, `at src\dispatch.rs:60` | yes |
| Unix, `at src/dispatch.rs:60` | yes |
| no location recorded | no |
| a different file, `at src/main.rs:60` | no |

## Why it reached main

The merge that introduced it went in on a clean local suite and a clean review
while the Windows leg was still running. Local verification on one platform is
not a substitute for the matrix, and the review gate is review-clean **and**
CI-green — this took the first half only.

## Considered and not done

The deeper fix is normalizing the separator at the write site, so the ledger
stores platform-consistent paths for anything that later greps it. That is a
change to shipped behavior and this is a hotfix for a red default branch, which
is the wrong moment to widen scope. Worth doing separately.

## Verification

`cargo test --test failopen_telemetry` → 5 passed, 0 failed.
`cargo clippy --workspace --all-targets` → 0 warnings.
`cargo fmt --check` → clean.

No shipped code is touched; the diff is confined to the test.
