### PR TITLE
feat(session): persist-plan fires on same-session plan approval

### DIFF
--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -281,6 +281,26 @@ pub struct ToolResponse {
     /// (multiSelect = comma-joined) or null when unanswered. Present only on the
     /// PostToolUse payload for AskUserQuestion.
     pub answers: Option<HashMap<String, serde_json::Value>>,
+    /// ExitPlanMode tool: the approved plan's full markdown body. Present on
+    /// same-session plan approval (`PostToolUse:ExitPlanMode`) — live-verified
+    /// 2026-07-25 (cadence-hooks#396) that on this path `tool_input.plan` is
+    /// EMPTY and this is the only field carrying the plan text.
+    pub plan: Option<String>,
+    /// ExitPlanMode tool: the app's own plans-store copy path, when the client
+    /// wrote one. Carried for parity with the documented payload shape; not
+    /// consulted by any check today.
+    #[serde(rename = "filePath")]
+    pub file_path: Option<String>,
+    /// ExitPlanMode tool: true when the approving turn ran inside a subagent
+    /// rather than the top-level session. `persist-plan-approval` skips these —
+    /// only a top-level session's own approval persists a plan doc.
+    #[serde(rename = "isAgent")]
+    pub is_agent: Option<bool>,
+    /// ExitPlanMode tool: true when the approving turn's tool set included the
+    /// Agent/Task tool. Carried for parity with the documented payload shape;
+    /// not consulted by any check today.
+    #[serde(rename = "hasTaskTool")]
+    pub has_task_tool: Option<bool>,
 }
 
 /// Deserialize an optional typed field leniently: a present value whose JSON
@@ -497,6 +517,15 @@ impl HookInput {
         self.tool_response
             .as_ref()
             .and_then(|tr| tr.stdout.as_deref())
+    }
+
+    /// The `ExitPlanMode` plan text from a `PostToolUse` `tool_response.plan`
+    /// payload — present on same-session plan approval, where `tool_input.plan`
+    /// is empty (cadence-hooks#396).
+    pub fn tool_response_plan(&self) -> Option<&str> {
+        self.tool_response
+            .as_ref()
+            .and_then(|tr| tr.plan.as_deref())
     }
 
     /// The AskUserQuestion questions carried by this tool call, if any.

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -31,6 +31,7 @@
 //! | `backstop-record`   | SessionEnd   | [`backstop`]    |
 //! | `backstop-warn`     | SessionStart | [`backstop`]    |
 //! | `persist-plan`      | UserPromptSubmit | [`persist_plan`] |
+//! | `persist-plan-approval` | PostToolUse | [`persist_plan`] |
 
 /// Outro "no loose ends" backstop: SessionEnd records loose ends, SessionStart warns (#123).
 pub mod backstop;
@@ -48,8 +49,9 @@ pub mod guard;
 pub mod heartbeat;
 /// Pure domain logic: deterministic naming, record schema, relative ages.
 pub mod identity;
-/// UserPromptSubmit hook: persist an approved plan whose post-approval turn
-/// was wiped (approve-and-clear), so it survives on disk (cadence#505).
+/// UserPromptSubmit + PostToolUse hooks: persist an approved plan whose
+/// approving turn leaves no durable trace — the approve-and-clear wipe
+/// (cadence#505) and same-session approval (cadence-hooks#396) respectively.
 pub mod persist_plan;
 /// Salted machine digest for committed provenance blocks (cadence#248) —
 /// shared with a future commit-message provenance check.

--- a/crates/session/src/persist_plan.rs
+++ b/crates/session/src/persist_plan.rs
@@ -22,8 +22,11 @@
 //! Both triggers normalize to the same body-hash-idempotent write through
 //! [`persist_and_nudge`]: `claim_target`'s `O_EXCL` collision ladder, a shared
 //! frontmatter render ([`render_document`]), and one `plan-links.jsonl` row
-//! format. `PersistPlan` alone keeps the PLAN_PREFIX/suffix-strip extraction —
-//! that pipeline is specific to the harness's re-injected prompt shape.
+//! format. Both also run the plan text through
+//! [`strip_trailing_suffix_lines_and_trim`] before hashing (Design 18's
+//! cross-trigger normalization) — only [`PLAN_PREFIX`] stripping is
+//! UserPromptSubmit-exclusive, since `PersistPlanApproval` never sees an
+//! injected prompt to strip a prefix from in the first place.
 //!
 //! Never blocks (ADR-0001): every failure path — no prompt/no plan text, no
 //! match, no `cwd`, not a git repo, unsafe session id, exhausted suffix ladder,
@@ -119,10 +122,22 @@ const PARENT_SCAN_MAX_FILES: usize = 20;
 /// (this scan is a plain `Check`, not a git-spawning probe).
 const PARENT_SCAN_MAX_FILE_BYTES: u64 = 32 * 1024 * 1024;
 
+/// Cap on the EXECUTING session's own transcript before resolving its
+/// model/harness from it — same defensive posture and size as
+/// [`PARENT_SCAN_MAX_FILE_BYTES`]'s sibling-scan cap. Real transcripts run
+/// single-digit MB; this is generous headroom against a pathological file.
+const TRANSCRIPT_READ_MAX_BYTES: u64 = 32 * 1024 * 1024;
+
 /// Schema version stamped on every `plan-links.jsonl` row. A new stream
 /// (cadence#238 convention) — does not share `cadence_hooks_metrics::common`'s
-/// existing version constants; this one lives with its own writer.
-const PLAN_LINKS_SCHEMA_VERSION: u32 = 1;
+/// existing version constants; this one lives with its own writer. Bumped to
+/// 2 (cameronsjo/cadence-hooks#396 review): `host` now carries the salted
+/// [`crate::provenance::machine_digest`] instead of the raw hostname (matching
+/// the committed frontmatter's own field two functions up), and `repo` is
+/// dropped — `plan_path` is already repo-relative, so `repo` was a second,
+/// separately-drifting way to say the same thing; confirmed no consumer
+/// (`reconstruct-journey.py`) reads either field before dropping it.
+const PLAN_LINKS_SCHEMA_VERSION: u32 = 2;
 
 /// Persist an approved plan whose post-approval turn was wiped
 /// (approve-and-clear, cross-session).
@@ -210,28 +225,37 @@ pub fn run_persist_plan(
 
     let body_hash = sha256_hex(body.as_bytes());
     let slug = slugify(&body);
-    let plans_dir = repo_root.join("docs").join("plans");
-    if fs::create_dir_all(&plans_dir).is_err() {
+    let Some((repo_root, plans_dir)) = canonical_plans_dir(&repo_root) else {
         return CheckResult::allow();
-    }
+    };
     let stem = format!("{local_date}-{slug}");
 
-    let parent_session_id = input
+    let parent = input
         .transcript_path()
         .and_then(|tp| find_parent(Path::new(tp), &body_hash, SystemTime::now()));
-    let parent_name = parent_session_id.as_deref().map(identity::generate_name);
+    let parent_session_id = parent.as_ref().map(|p| p.session_id.as_str());
+    let parent_name = parent_session_id.map(identity::generate_name);
     let own_name = identity::generate_name(session_id);
     let machine_digest = crate::provenance::machine_digest(host);
 
+    // The EXECUTING session's own transcript is structurally empty at this
+    // point on a cross-session approve-and-clear wipe: the wipe IS a new
+    // session, so its transcript has no assistant turn yet — `resolve_model`/
+    // `resolve_harness` against it return `None`. Fall back to the APPROVING
+    // parent's already-resolved model/harness (from the same scan that
+    // resolved `approved_in`) rather than leaving the frontmatter fields
+    // permanently unresolved on this trigger's most common path
+    // (cameronsjo/cadence-hooks#396 review).
     let transcript_content = input
         .transcript_path()
-        .and_then(|tp| fs::read_to_string(tp).ok());
-    let model = crate::warn_commit_provenance::resolve_model(transcript_content.as_deref());
-    let harness = crate::warn_commit_provenance::resolve_harness(transcript_content.as_deref());
+        .and_then(|tp| read_capped(Path::new(tp), TRANSCRIPT_READ_MAX_BYTES));
+    let model = crate::warn_commit_provenance::resolve_model(transcript_content.as_deref())
+        .or_else(|| parent.as_ref().and_then(|p| p.model.clone()));
+    let harness = crate::warn_commit_provenance::resolve_harness(transcript_content.as_deref())
+        .or_else(|| parent.as_ref().and_then(|p| p.harness_version.clone()));
     let branch = current_branch(cwd);
 
     let approved_in = parent_session_id
-        .as_deref()
         .zip(parent_name.as_deref())
         .map(|(sid, name)| (name, sid));
 
@@ -256,9 +280,9 @@ pub fn run_persist_plan(
         &body_hash,
         &document,
         utc_now,
-        parent_session_id.as_deref(),
+        parent_session_id,
         session_id,
-        host,
+        &machine_digest,
         &repo_root,
         approved_label,
     )
@@ -276,14 +300,18 @@ pub fn run_persist_plan_approval(
         return CheckResult::allow();
     }
     // A subagent's own plan approval doesn't persist — only a top-level
-    // session's approval does (the plan doc's Task 1 step 2). `is_agent`
-    // rides `tool_response`, alongside `plan`.
-    if input
-        .tool_response
-        .as_ref()
-        .and_then(|tr| tr.is_agent)
-        .unwrap_or(false)
-    {
+    // session's approval does (the plan doc's Task 1 step 2). Deliberately
+    // fail-CLOSED here, the opposite of this hook's usual fail-open posture:
+    // persist only when `is_agent` is the EXPLICIT `Some(false)` AND
+    // `agent_id` is absent. An absent/unrecognized `is_agent` (a future
+    // payload-shape drift, or a stripped-down fixture) must not persist —
+    // treating it as "not a subagent" would forge `approved_in` attribution
+    // for a plan the top-level session never actually saw approved
+    // (cameronsjo/cadence-hooks#396 review).
+    let is_top_level_approval = input.tool_response.as_ref().and_then(|tr| tr.is_agent)
+        == Some(false)
+        && input.agent_id().is_none();
+    if !is_top_level_approval {
         return CheckResult::allow();
     }
     let Some(raw_plan) = input.tool_response_plan() else {
@@ -311,17 +339,20 @@ pub fn run_persist_plan_approval(
 
     let body_hash = sha256_hex(body.as_bytes());
     let slug = slugify(&body);
-    let plans_dir = repo_root.join("docs").join("plans");
-    if fs::create_dir_all(&plans_dir).is_err() {
+    let Some((repo_root, plans_dir)) = canonical_plans_dir(&repo_root) else {
         return CheckResult::allow();
-    }
+    };
     let stem = format!("{local_date}-{slug}");
 
     let own_name = identity::generate_name(session_id);
     let machine_digest = crate::provenance::machine_digest(host);
+    // Same-session approval: unlike `run_persist_plan`'s cross-session wipe,
+    // the executing transcript here HAS just recorded the approving turn (no
+    // wipe occurred), so it's a reliable model/harness source with no
+    // sibling-transcript fallback needed.
     let transcript_content = input
         .transcript_path()
-        .and_then(|tp| fs::read_to_string(tp).ok());
+        .and_then(|tp| read_capped(Path::new(tp), TRANSCRIPT_READ_MAX_BYTES));
     let model = crate::warn_commit_provenance::resolve_model(transcript_content.as_deref());
     let harness = crate::warn_commit_provenance::resolve_harness(transcript_content.as_deref());
     let branch = current_branch(cwd);
@@ -350,7 +381,7 @@ pub fn run_persist_plan_approval(
         utc_now,
         Some(session_id),
         session_id,
-        host,
+        &machine_digest,
         &repo_root,
         &own_name,
     )
@@ -362,6 +393,38 @@ pub fn run_persist_plan_approval(
 /// subprocess spawn on this every-turn/every-approval hot path.
 fn current_branch(cwd: &str) -> Option<String> {
     cadence_hooks_core::gitstate::GitState::resolve(Path::new(cwd)).and_then(|gs| gs.branch)
+}
+
+/// Resolve `<repo_root>/docs/plans`, creating it if needed, and return its
+/// canonical path alongside the canonical `repo_root` — but only when the
+/// canonical plans dir actually nests under the canonical repo root. `None`
+/// on any I/O failure, or when it DOESN'T nest: a `docs/plans` (or an
+/// ancestor, e.g. a symlinked `docs/`) pointing outside the checkout would
+/// otherwise let a plan write escape the repo entirely (cameronsjo/cadence-hooks#396
+/// review) — the same "never trust a path without checking where it actually
+/// resolves" discipline `GitState::resolve` applies to `.git`. Both returned
+/// paths are canonical, so a caller using them for the write target and the
+/// `plan_path` prefix-strip stays internally consistent.
+fn canonical_plans_dir(repo_root: &Path) -> Option<(PathBuf, PathBuf)> {
+    let plans_dir = repo_root.join("docs").join("plans");
+    fs::create_dir_all(&plans_dir).ok()?;
+    let canonical_repo_root = repo_root.canonicalize().ok()?;
+    let canonical_plans_dir = plans_dir.canonicalize().ok()?;
+    canonical_plans_dir
+        .starts_with(&canonical_repo_root)
+        .then_some((canonical_repo_root, canonical_plans_dir))
+}
+
+/// Read `path` capped at `max_bytes`: `None` when it can't be opened/read, or
+/// when its content exceeds the cap — the same take-then-check discipline
+/// [`file_matches_body`] uses, so a pathological transcript can't turn this
+/// hook's model/harness resolution into an unbounded read.
+fn read_capped(path: &Path, max_bytes: u64) -> Option<String> {
+    use std::io::Read as _;
+    let file = fs::File::open(path).ok()?;
+    let mut content = String::new();
+    file.take(max_bytes + 1).read_to_string(&mut content).ok()?;
+    (content.len() as u64 <= max_bytes).then_some(content)
 }
 
 // ---------------------------------------------------------------------------
@@ -593,7 +656,7 @@ fn file_matches_body(path: &Path, body_hash: &str) -> bool {
         fm.lines()
             .find_map(|l| l.strip_prefix(FRONTMATTER_HASH_KEY))
     }) {
-        return recorded.trim() == body_hash;
+        return yaml_unquote(recorded.trim()) == body_hash;
     }
 
     if let Some(recorded) = content
@@ -651,14 +714,32 @@ fn claim_target(
 // Provenance: parent resolution (Approach step 4)
 // ---------------------------------------------------------------------------
 
-/// The `ExitPlanMode` plan text on one transcript line, if `line` is an
-/// assistant message carrying that tool call. Mirrors
-/// `cadence_hooks_core::transcript::line_is_polish_skill_use`'s traversal.
-fn exit_plan_mode_match(line: &str) -> Option<String> {
+/// The `ExitPlanMode` plan text on one transcript line, plus the approving
+/// turn's model (`message.model`) and harness version (top-level `version`),
+/// if `line` is an assistant message carrying that tool call. `model`/
+/// `harness_version` are `None` when the matched line doesn't carry them.
+/// Mirrors `cadence_hooks_core::transcript::line_is_polish_skill_use`'s
+/// traversal.
+///
+/// Restored (cameronsjo/cadence-hooks#396 review): the executing session's
+/// own transcript is structurally empty at the moment `run_persist_plan`
+/// runs on a cross-session approve-and-clear wipe (the wipe IS a new,
+/// just-started session — its transcript has no assistant turn yet), so
+/// `crate::warn_commit_provenance::resolve_model`/`resolve_harness` against
+/// it always return `None` there. The APPROVING parent's transcript — the one
+/// this scan already walks to resolve `approved_in` — is the only source that
+/// reliably carries a populated `model`/`version` for that path.
+struct ExitPlanModeMatch {
+    plan_text: String,
+    model: Option<String>,
+    harness_version: Option<String>,
+}
+
+fn exit_plan_mode_match(line: &str) -> Option<ExitPlanModeMatch> {
     let value: Value = serde_json::from_str(line).ok()?;
     let message = value.get("message")?;
     let content = message.get("content")?.as_array()?;
-    content.iter().find_map(|block| {
+    let plan_text = content.iter().find_map(|block| {
         if block.get("type").and_then(Value::as_str) != Some("tool_use") {
             return None;
         }
@@ -670,7 +751,32 @@ fn exit_plan_mode_match(line: &str) -> Option<String> {
             .get("plan")?
             .as_str()
             .map(str::to_string)
+    })?;
+    let model = message
+        .get("model")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    let harness_version = value
+        .get("version")
+        .and_then(Value::as_str)
+        .map(str::to_string);
+    Some(ExitPlanModeMatch {
+        plan_text,
+        model,
+        harness_version,
     })
+}
+
+/// The approving sibling transcript [`find_parent`] resolves: its session id,
+/// plus the approving turn's model/harness version — the fallback source for
+/// [`FrontmatterFields::model`]/`harness` on a cross-session wipe (see
+/// [`ExitPlanModeMatch`]'s doc for why the executing transcript can't supply
+/// them there).
+#[derive(Debug, PartialEq, Eq)]
+struct ParentMatch {
+    session_id: String,
+    model: Option<String>,
+    harness_version: Option<String>,
 }
 
 /// Scan `transcript_path`'s sibling directory for the transcript whose
@@ -686,7 +792,7 @@ fn exit_plan_mode_match(line: &str) -> Option<String> {
 /// [`identity::is_safe_session_id`]; a match against a hostile-named sibling
 /// is treated as no-match (`unknown`), since the returned id flows raw into
 /// the provenance text and the linkage row.
-fn find_parent(transcript_path: &Path, target_hash: &str, now: SystemTime) -> Option<String> {
+fn find_parent(transcript_path: &Path, target_hash: &str, now: SystemTime) -> Option<ParentMatch> {
     let dir = transcript_path.parent()?;
     let mut candidates: Vec<(SystemTime, PathBuf)> = fs::read_dir(dir)
         .ok()?
@@ -725,15 +831,20 @@ fn find_parent(transcript_path: &Path, target_hash: &str, now: SystemTime) -> Op
             if !line.contains("ExitPlanMode") {
                 continue;
             }
-            let Some(plan_text) = exit_plan_mode_match(&line) else {
+            let Some(exit_plan) = exit_plan_mode_match(&line) else {
                 continue;
             };
-            let normalized = strip_trailing_suffix_lines_and_trim(&plan_text);
+            let normalized = strip_trailing_suffix_lines_and_trim(&exit_plan.plan_text);
             if sha256_hex(normalized.as_bytes()) == target_hash {
-                return path
+                let session_id = path
                     .file_stem()
                     .map(|s| s.to_string_lossy().into_owned())
-                    .filter(|s| identity::is_safe_session_id(s));
+                    .filter(|s| identity::is_safe_session_id(s))?;
+                return Some(ParentMatch {
+                    session_id,
+                    model: exit_plan.model,
+                    harness_version: exit_plan.harness_version,
+                });
             }
         }
     }
@@ -774,10 +885,52 @@ struct FrontmatterFields<'a> {
     approved_in: Option<(&'a str, &'a str)>,
 }
 
+/// Render `s` as a double-quoted YAML scalar: `\` escaped first, then `"` —
+/// order matters, so quote-escaping never re-escapes a backslash the first
+/// pass just introduced. Every frontmatter value goes through this
+/// (cameronsjo/cadence-hooks#396 review): uniform quoting means a reader never
+/// needs per-field heuristics for which lines are quoted, and it defuses any
+/// transcript-sourced free-text value (model, harness, branch) that happens
+/// to embed a literal `"` or `\` from breaking the block's YAML shape.
+fn yaml_quote(s: &str) -> String {
+    let escaped = s.replace('\\', "\\\\").replace('"', "\\\"");
+    format!("\"{escaped}\"")
+}
+
+/// Reverse of [`yaml_quote`]: strip a well-formed double-quoted YAML scalar's
+/// surrounding quotes and unescape `\"`/`\\`. A value that ISN'T
+/// double-quoted (a hand-edited frontmatter line, or a doc from before this
+/// fold started quoting) passes through unchanged — this hook always emits
+/// quoted values now, but the idempotency reader must not choke on an older
+/// or hand-edited file.
+fn yaml_unquote(s: &str) -> String {
+    let Some(inner) = s.strip_prefix('"').and_then(|s| s.strip_suffix('"')) else {
+        return s.to_string();
+    };
+    let mut out = String::with_capacity(inner.len());
+    let mut chars = inner.chars();
+    while let Some(c) = chars.next() {
+        if c == '\\' {
+            match chars.next() {
+                Some('"') => out.push('"'),
+                Some('\\') => out.push('\\'),
+                Some(other) => {
+                    out.push('\\');
+                    out.push(other);
+                }
+                None => out.push('\\'),
+            }
+        } else {
+            out.push(c);
+        }
+    }
+    out
+}
+
 /// Render the frontmatter block for a newly persisted plan.
 ///
-/// `status: in-flight` is a fixed constant: this hook only ever fires at the
-/// moment a plan is approved, so a freshly persisted document is never
+/// `status: "in-flight"` is a fixed constant: this hook only ever fires at
+/// the moment a plan is approved, so a freshly persisted document is never
 /// anything else. Reserved keys the living-plan lifecycle owns for a later
 /// consumer — `next`, `pr`, `card`, `blocked` — are never emitted here (Task 1
 /// step 3 of the plan-as-living-document lifecycle plan); a session or the
@@ -787,38 +940,45 @@ struct FrontmatterFields<'a> {
 /// filesystem (`branch`) are passed through [`identity::sanitize_field`] —
 /// the same discipline `warn_commit_provenance`'s nudge applies to the same
 /// two fields — before interpolation, since none of the three come from a
-/// value this crate itself generated or validated.
+/// value this crate itself generated or validated. Every value, sanitized or
+/// not, is then [`yaml_quote`]d.
 fn render_frontmatter(f: &FrontmatterFields) -> String {
     let mut lines = vec![
         "---".to_string(),
-        "status: in-flight".to_string(),
-        format!("updated: {}", f.updated),
+        format!("status: {}", yaml_quote("in-flight")),
+        format!("updated: {}", yaml_quote(f.updated)),
     ];
     if let Some(b) = f.branch {
         lines.push(format!(
             "branch: {}",
-            identity::sanitize_field(b, identity::MAX_FIELD_DISPLAY)
+            yaml_quote(&identity::sanitize_field(b, identity::MAX_FIELD_DISPLAY))
         ));
     }
-    lines.push(format!("{FRONTMATTER_HASH_KEY} {}", f.body_hash));
-    lines.push(format!("session: {}", f.own_name));
-    lines.push(format!("session_id: {}", f.own_session_id));
+    lines.push(format!(
+        "{FRONTMATTER_HASH_KEY} {}",
+        yaml_quote(f.body_hash)
+    ));
+    lines.push(format!("session: {}", yaml_quote(f.own_name)));
+    lines.push(format!("session_id: {}", yaml_quote(f.own_session_id)));
     if let Some(m) = f.model {
         lines.push(format!(
             "model: {}",
-            identity::sanitize_field(m, identity::MAX_FIELD_DISPLAY)
+            yaml_quote(&identity::sanitize_field(m, identity::MAX_FIELD_DISPLAY))
         ));
     }
     if let Some(h) = f.harness {
         lines.push(format!(
-            "harness: claude-code {}",
-            identity::sanitize_field(h, identity::MAX_FIELD_DISPLAY)
+            "harness: {}",
+            yaml_quote(&format!(
+                "claude-code {}",
+                identity::sanitize_field(h, identity::MAX_FIELD_DISPLAY)
+            ))
         ));
     }
-    lines.push(format!("machine: {}", f.machine_digest));
+    lines.push(format!("machine: {}", yaml_quote(f.machine_digest)));
     if let Some((name, sid)) = f.approved_in {
-        lines.push(format!("approved_in: {name}"));
-        lines.push(format!("approved_session_id: {sid}"));
+        lines.push(format!("approved_in: {}", yaml_quote(name)));
+        lines.push(format!("approved_session_id: {}", yaml_quote(sid)));
     }
     lines.push("---".to_string());
     lines.join("\n")
@@ -843,7 +1003,7 @@ fn persist_and_nudge(
     utc_now: &str,
     parent_session_id: Option<&str>,
     child_session_id: &str,
-    host: &str,
+    machine_digest: &str,
     repo_root: &Path,
     approved_label: &str,
 ) -> CheckResult {
@@ -867,8 +1027,7 @@ fn persist_and_nudge(
         utc_now,
         parent_session_id,
         child_session_id,
-        host,
-        &repo_root.to_string_lossy(),
+        machine_digest,
         &plan_path_rel,
         body_hash,
     ));
@@ -884,12 +1043,21 @@ fn persist_and_nudge(
 // Linkage row (Approach step 5)
 // ---------------------------------------------------------------------------
 
+/// Schema v2 (cameronsjo/cadence-hooks#396 review; v1 carried a raw `host`
+/// hostname and a separate `repo` field). `machine` is the salted
+/// [`crate::provenance::machine_digest`] — the same doctrine fix (cadence#248)
+/// the committed frontmatter already applies, now consistent across BOTH the
+/// committed artifact and this local-only telemetry stream. `repo` is
+/// dropped: `plan_path` is already repo-relative, so `repo` was a second,
+/// independently-drifting way to say the same thing. Confirmed no consumer
+/// (`reconstruct-journey.py`, which reads only `parent_session_id`,
+/// `body_sha256`, and `plan_path`) depends on either the old `host` or `repo`
+/// fields before making this change.
 fn plan_links_row(
     utc_now: &str,
     parent_session_id: Option<&str>,
     child_session_id: &str,
-    host: &str,
-    repo: &str,
+    machine_digest: &str,
     plan_path: &str,
     body_hash: &str,
 ) -> Value {
@@ -898,8 +1066,7 @@ fn plan_links_row(
         "ts": utc_now,
         "parent_session_id": parent_session_id,
         "child_session_id": child_session_id,
-        "host": host,
-        "repo": repo,
+        "machine": machine_digest,
         "plan_path": plan_path,
         "body_sha256": body_hash,
     })
@@ -1454,6 +1621,54 @@ mod tests {
     }
 
     #[test]
+    fn file_matches_body_frontmatter_key_matches_the_actual_quoted_emission() {
+        // `frontmatter_doc_with_hash` above uses a bare (unquoted) value —
+        // proving backward-compat with hand-edited/pre-quoting frontmatter.
+        // This test uses the value shape `render_frontmatter` ACTUALLY emits
+        // (double-quoted, cameronsjo/cadence-hooks#396 review) end to end.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("plan.md");
+        let body = "# Title\n\nbody text";
+        let hash = sha256_hex(body.as_bytes());
+        let doc = format!(
+            "---\nstatus: \"in-flight\"\nbody_sha256: {}\n---\n\n{body}\n",
+            yaml_quote(&hash)
+        );
+        fs::write(&path, doc).unwrap();
+        assert!(file_matches_body(&path, &hash));
+    }
+
+    #[test]
+    fn file_matches_body_frontmatter_tier_wins_over_a_differing_legacy_trailer() {
+        // A file carrying BOTH a frontmatter `body_sha256` key AND a
+        // differing legacy `Plan-body-SHA256:` trailer line — the frontmatter
+        // tier must win unconditionally, never fall through to consider the
+        // trailer (cameronsjo/cadence-hooks#396 review). This shape shouldn't
+        // arise from either trigger's own writes, but the precedence must
+        // hold regardless of how such a file came to exist (hand-edit, a
+        // future migration script, etc.).
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("plan.md");
+        let body = "# Title\n\nbody text";
+        let frontmatter_hash = sha256_hex(body.as_bytes());
+        let legacy_hash = "a-completely-different-legacy-hash";
+        let doc = format!(
+            "---\nstatus: \"in-flight\"\nbody_sha256: {}\n---\n\n{body}\n\n---\n\nPlan-body-SHA256: {legacy_hash}\n",
+            yaml_quote(&frontmatter_hash)
+        );
+        fs::write(&path, doc).unwrap();
+
+        assert!(
+            file_matches_body(&path, &frontmatter_hash),
+            "the frontmatter hash must match despite the differing trailer"
+        );
+        assert!(
+            !file_matches_body(&path, legacy_hash),
+            "the legacy trailer's hash must NOT match — tier 1 wins unconditionally, tier 2 is never consulted"
+        );
+    }
+
+    #[test]
     fn file_matches_body_recognizes_mutated_body_via_frontmatter_key() {
         // The exact Design-18 scenario: a plan persisted once, then its BODY
         // is mutated in place (checkbox ticked, a `## Deviations` entry
@@ -1504,6 +1719,65 @@ mod tests {
         assert_eq!(leading_frontmatter_block("# Title\n\nbody"), None);
     }
 
+    // --- canonical_plans_dir: symlink-escape guard ---
+
+    #[test]
+    fn canonical_plans_dir_resolves_normally_when_nested() {
+        let repo = TempDir::new().unwrap();
+        let (canonical_repo, canonical_plans) =
+            canonical_plans_dir(repo.path()).expect("plans dir resolves under a plain repo root");
+        assert!(canonical_plans.starts_with(&canonical_repo));
+        assert!(
+            canonical_plans.ends_with("docs/plans") || canonical_plans.ends_with("docs\\plans")
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn canonical_plans_dir_refuses_a_symlinked_docs_escaping_the_repo() {
+        // A `docs/` symlink pointing outside the checkout (planted by a
+        // malicious commit, or a stray dev-machine symlink) must not let a
+        // plan write escape the repo root entirely (cameronsjo/cadence-hooks#396
+        // review).
+        let repo = TempDir::new().unwrap();
+        let outside = TempDir::new().unwrap();
+        std::os::unix::fs::symlink(outside.path(), repo.path().join("docs")).unwrap();
+
+        assert!(
+            canonical_plans_dir(repo.path()).is_none(),
+            "a docs/ symlink escaping the repo root must be refused"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn run_persist_plan_never_writes_through_a_symlinked_docs_escaping_the_repo() {
+        // End-to-end: the same escape attempt must never reach a write, not
+        // just fail the unit-level helper in isolation.
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let outside = TempDir::new().unwrap();
+        std::os::unix::fs::symlink(outside.path(), tmp.path().join("docs")).unwrap();
+        let cwd = tmp.path().to_string_lossy().into_owned();
+
+        let input = make_user_prompt_submit(
+            "sid12345",
+            "Implement the following plan:\n\n# X\n\nbody",
+            &cwd,
+            &tmp.path().join("sid12345.jsonl").to_string_lossy(),
+        );
+        let r = run_persist_plan(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(
+            !outside
+                .path()
+                .join("plans")
+                .join("2026-07-20-x.md")
+                .exists(),
+            "nothing must be written outside the repo via the symlinked docs/"
+        );
+    }
+
     // --- cross-trigger hash normalization (Design 18) ---
 
     #[test]
@@ -1551,11 +1825,11 @@ mod tests {
     fn render_frontmatter_omits_unresolved_optional_fields() {
         let fields = base_fields("hash", "digest");
         let fm = render_frontmatter(&fields);
-        assert!(fm.starts_with("---\nstatus: in-flight\nupdated: 2026-07-25\n"));
-        assert!(fm.contains("body_sha256: hash"));
-        assert!(fm.contains("session: own-name"));
-        assert!(fm.contains("session_id: own-sid"));
-        assert!(fm.contains("machine: digest"));
+        assert!(fm.starts_with("---\nstatus: \"in-flight\"\nupdated: \"2026-07-25\"\n"));
+        assert!(fm.contains("body_sha256: \"hash\""));
+        assert!(fm.contains("session: \"own-name\""));
+        assert!(fm.contains("session_id: \"own-sid\""));
+        assert!(fm.contains("machine: \"digest\""));
         assert!(fm.ends_with("---"));
         assert!(
             !fm.contains("branch:"),
@@ -1587,11 +1861,26 @@ mod tests {
         fields.harness = Some("2.1.220");
         fields.approved_in = Some(("parent-name", "parent-sid"));
         let fm = render_frontmatter(&fields);
-        assert!(fm.contains("branch: feat/x"));
-        assert!(fm.contains("model: claude-fable-5"));
-        assert!(fm.contains("harness: claude-code 2.1.220"));
-        assert!(fm.contains("approved_in: parent-name"));
-        assert!(fm.contains("approved_session_id: parent-sid"));
+        assert!(fm.contains("branch: \"feat/x\""));
+        assert!(fm.contains("model: \"claude-fable-5\""));
+        assert!(fm.contains("harness: \"claude-code 2.1.220\""));
+        assert!(fm.contains("approved_in: \"parent-name\""));
+        assert!(fm.contains("approved_session_id: \"parent-sid\""));
+    }
+
+    #[test]
+    fn render_frontmatter_escapes_quotes_and_backslashes_in_free_text_fields() {
+        // Transcript-sourced free text (model/harness/branch) is not
+        // validated by this hook — a value embedding a literal `"` or `\`
+        // must not break the block's YAML shape (cameronsjo/cadence-hooks#396
+        // review).
+        let mut fields = base_fields("hash", "digest");
+        fields.model = Some(r#"weird"model\name"#);
+        let fm = render_frontmatter(&fields);
+        assert!(
+            fm.contains(r#"model: "weird\"model\\name""#),
+            "quotes and backslashes escaped in emission: {fm}"
+        );
     }
 
     #[test]
@@ -1601,20 +1890,46 @@ mod tests {
         let (frontmatter, body) = doc
             .split_once("---\n\n")
             .expect("closing fence + blank line");
-        assert!(frontmatter.starts_with("---\nstatus: in-flight"));
+        assert!(frontmatter.starts_with("---\nstatus: \"in-flight\""));
         assert_eq!(body, "# Title\n\nbody text\n");
+    }
+
+    #[test]
+    fn yaml_quote_and_unquote_round_trip() {
+        for value in ["plain", r#"has "quotes""#, r"has\backslash", ""] {
+            assert_eq!(yaml_unquote(&yaml_quote(value)), value);
+        }
+    }
+
+    #[test]
+    fn yaml_unquote_passes_through_an_unquoted_value() {
+        // Backward compatibility: a hand-edited or pre-quoting-era
+        // frontmatter value isn't wrapped in quotes at all.
+        assert_eq!(yaml_unquote("bare-value"), "bare-value");
     }
 
     // --- provenance: parent resolution ---
 
-    fn exit_plan_mode_line(plan: &str) -> String {
-        serde_json::json!({
-            "message": {
-                "role": "assistant",
-                "content": [{"type": "tool_use", "name": "ExitPlanMode", "input": {"plan": plan}}],
-            }
-        })
-        .to_string()
+    /// `model`/`harness_version` model the assistant line's `message.model`
+    /// and top-level `version` — both `None` reproduces an older transcript
+    /// shape carrying neither.
+    fn exit_plan_mode_line(
+        plan: &str,
+        model: Option<&str>,
+        harness_version: Option<&str>,
+    ) -> String {
+        let mut message = serde_json::json!({
+            "role": "assistant",
+            "content": [{"type": "tool_use", "name": "ExitPlanMode", "input": {"plan": plan}}],
+        });
+        if let Some(m) = model {
+            message["model"] = serde_json::json!(m);
+        }
+        let mut line = serde_json::json!({ "message": message });
+        if let Some(v) = harness_version {
+            line["version"] = serde_json::json!(v);
+        }
+        line.to_string()
     }
 
     #[test]
@@ -1623,13 +1938,67 @@ mod tests {
         let plan_text = "# Title\n\nbody text";
         let hash = sha256_hex(plan_text.as_bytes());
         let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text)).unwrap();
+        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
 
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
         let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(found.as_deref(), Some("parent-session-id"));
+        assert_eq!(
+            found,
+            Some(ParentMatch {
+                session_id: "parent-session-id".to_string(),
+                model: None,
+                harness_version: None,
+            })
+        );
+    }
+
+    #[test]
+    fn find_parent_extracts_model_and_harness_version_from_matched_line() {
+        // Real transcripts stamp the approving assistant line with both
+        // `message.model` and a top-level `version` — this is the sole
+        // source `run_persist_plan` falls back to when the EXECUTING
+        // session's own (structurally empty, on a cross-session wipe)
+        // transcript resolves neither (cameronsjo/cadence-hooks#396 review).
+        let tmp = TempDir::new().unwrap();
+        let plan_text = "# Title\n\nbody text";
+        let hash = sha256_hex(plan_text.as_bytes());
+        let sibling = tmp.path().join("parent-session-id.jsonl");
+        fs::write(
+            &sibling,
+            exit_plan_mode_line(plan_text, Some("claude-fable-5"), Some("2.1.214")),
+        )
+        .unwrap();
+        let own = tmp.path().join("own-session-id.jsonl");
+        fs::write(&own, "{}").unwrap();
+
+        let found = find_parent(&own, &hash, SystemTime::now());
+        assert_eq!(
+            found,
+            Some(ParentMatch {
+                session_id: "parent-session-id".to_string(),
+                model: Some("claude-fable-5".to_string()),
+                harness_version: Some("2.1.214".to_string()),
+            })
+        );
+    }
+
+    #[test]
+    fn find_parent_missing_model_and_harness_version_is_gracefully_none() {
+        // Older transcript lines (or a stripped-down fixture) may carry
+        // neither field — the match must still resolve, with both absent.
+        let tmp = TempDir::new().unwrap();
+        let plan_text = "# Title\n\nbody text";
+        let hash = sha256_hex(plan_text.as_bytes());
+        let sibling = tmp.path().join("parent-session-id.jsonl");
+        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
+        let own = tmp.path().join("own-session-id.jsonl");
+        fs::write(&own, "{}").unwrap();
+
+        let found = find_parent(&own, &hash, SystemTime::now()).expect("parent must be found");
+        assert_eq!(found.model, None);
+        assert_eq!(found.harness_version, None);
     }
 
     #[test]
@@ -1638,11 +2007,11 @@ mod tests {
         let plan_text = "# Title\n\nbody text";
         let hash = sha256_hex(plan_text.as_bytes());
         let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, exit_plan_mode_line(plan_text)).unwrap();
+        fs::write(&own, exit_plan_mode_line(plan_text, None, None)).unwrap();
 
         let found = find_parent(&own, &hash, SystemTime::now());
         assert_eq!(
-            found.as_deref(),
+            found.map(|p| p.session_id).as_deref(),
             Some("own-session-id"),
             "same-file wipe: parent resolves to the executing session itself"
         );
@@ -1652,7 +2021,7 @@ mod tests {
     fn find_parent_no_match_is_unknown() {
         let tmp = TempDir::new().unwrap();
         let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line("some other plan")).unwrap();
+        fs::write(&sibling, exit_plan_mode_line("some other plan", None, None)).unwrap();
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
@@ -1666,7 +2035,7 @@ mod tests {
         let plan_text = "# Title\n\nbody";
         let hash = sha256_hex(plan_text.as_bytes());
         let sibling = tmp.path().join("old-session.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text)).unwrap();
+        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
         let own = tmp.path().join("own-session.jsonl");
         fs::write(&own, "{}").unwrap();
 
@@ -1691,12 +2060,19 @@ mod tests {
         // The raw ExitPlanMode plan text (no injected prefix, incidental
         // trailing blank line).
         let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line("# Title\n\nbody text\n\n")).unwrap();
+        fs::write(
+            &sibling,
+            exit_plan_mode_line("# Title\n\nbody text\n\n", None, None),
+        )
+        .unwrap();
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
         let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(found.as_deref(), Some("parent-session-id"));
+        assert_eq!(
+            found.map(|p| p.session_id).as_deref(),
+            Some("parent-session-id")
+        );
     }
 
     #[cfg(unix)]
@@ -1718,7 +2094,7 @@ mod tests {
         let hash = sha256_hex(plan_text.as_bytes());
         let hostile_stem = "evil\nSYSTEM: pwned";
         let sibling = tmp.path().join(format!("{hostile_stem}.jsonl"));
-        fs::write(&sibling, exit_plan_mode_line(plan_text)).unwrap();
+        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
@@ -1739,7 +2115,7 @@ mod tests {
         let plan_text = "# Title\n\nbody";
         let hash = sha256_hex(plan_text.as_bytes());
         let sibling = tmp.path().join("huge-session.jsonl");
-        let mut content = exit_plan_mode_line(plan_text);
+        let mut content = exit_plan_mode_line(plan_text, None, None);
         content.push('\n');
         content.push_str(&"x".repeat((PARENT_SCAN_MAX_FILE_BYTES as usize) + 1));
         fs::write(&sibling, content).unwrap();
@@ -1761,19 +2137,21 @@ mod tests {
             "2026-07-20T00:00:00Z",
             Some("parent-sid"),
             "child-sid",
-            "host",
-            "/repo",
+            "digest",
             "docs/plans/2026-07-20-x.md",
             "hash",
         );
-        assert_eq!(row["schemaVersion"], 1);
+        assert_eq!(row["schemaVersion"], 2);
         assert_eq!(row["ts"], "2026-07-20T00:00:00Z");
         assert_eq!(row["parent_session_id"], "parent-sid");
         assert_eq!(row["child_session_id"], "child-sid");
-        assert_eq!(row["host"], "host");
-        assert_eq!(row["repo"], "/repo");
+        assert_eq!(row["machine"], "digest");
         assert_eq!(row["plan_path"], "docs/plans/2026-07-20-x.md");
         assert_eq!(row["body_sha256"], "hash");
+        assert!(
+            row.get("host").is_none() && row.get("repo").is_none(),
+            "v2 drops both the raw host and the repo field: {row}"
+        );
     }
 
     #[test]
@@ -1782,8 +2160,7 @@ mod tests {
             "2026-07-20T00:00:00Z",
             None,
             "child-sid",
-            "host",
-            "/repo",
+            "digest",
             "docs/plans/2026-07-20-x.md",
             "hash",
         );
@@ -1857,10 +2234,10 @@ mod tests {
 
         let written =
             fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
-        assert!(written.starts_with("---\nstatus: in-flight\n"));
+        assert!(written.starts_with("---\nstatus: \"in-flight\"\n"));
         assert!(written.contains("# Fix the Widget"));
         assert!(!written.contains("If this plan can be broken down"));
-        assert!(written.contains("session_id: child-session-id"));
+        assert!(written.contains("session_id: \"child-session-id\""));
         assert!(written.contains("body_sha256:"));
         assert!(
             !written.contains("approved_in:"),
@@ -1880,9 +2257,17 @@ mod tests {
         // plan_path is forward-slash-normalized regardless of platform — a
         // stable schema value for consumers, not the native separator.
         assert!(links.contains("\"plan_path\":\"docs/plans/2026-07-20-fix-the-widget.md\""));
-        // Local-only metrics KEEP the bare hostname — only the committed doc
-        // block is salted (cadence#248).
-        assert!(links.contains("\"host\":\"test-host\""));
+        // Schema v2 (cameronsjo/cadence-hooks#396 review): the local-only
+        // linkage row now ALSO carries the salted digest — matching the
+        // committed frontmatter's own `machine` field — never the raw
+        // hostname, and no separate `repo` field.
+        assert!(links.contains(&format!(
+            "\"machine\":\"{}\"",
+            crate::provenance::machine_digest("test-host")
+        )));
+        assert!(!links.contains("test-host"));
+        assert!(!links.contains("\"host\""));
+        assert!(!links.contains("\"repo\""));
     }
 
     #[test]
@@ -1917,6 +2302,70 @@ mod tests {
             first_write, second_write,
             "the file must never be rewritten"
         );
+    }
+
+    #[test]
+    fn end_to_end_model_and_harness_fall_back_to_the_approving_parent_transcript() {
+        // The regression this fold fixes (cameronsjo/cadence-hooks#396
+        // review): on approve-and-clear, the EXECUTING session's own
+        // transcript is structurally empty at this point — no assistant turn
+        // has landed there yet — so resolving model/harness against it always
+        // returns `None`. The APPROVING parent's transcript (the one
+        // `find_parent` already walks to resolve `approved_in`) is the
+        // fallback source, and it DOES carry a populated `model`/`version`.
+        //
+        // `resolve_harness` has ITS OWN internal `AI_AGENT` env fallback
+        // (legitimate in production — Claude Code sets it for every hook
+        // subprocess), which would otherwise mask the parent-fallback this
+        // test targets with whatever value happens to be ambient on the
+        // machine running `cargo test`. Pin it to `None` for the duration so
+        // only the parent-transcript fallback can supply a value, via the
+        // SAME lock `warn_commit_provenance`'s own AI_AGENT tests use (a
+        // second, independently-locked mutator of this process-global var
+        // would itself be a race, not an isolation fix).
+        crate::warn_commit_provenance::with_ai_agent_env(None, || {
+            let tmp = TempDir::new().unwrap();
+            init_repo(tmp.path());
+            let cwd = tmp.path().to_string_lossy().into_owned();
+            let metrics_dir = TempDir::new().unwrap();
+
+            let plan_text = "# Fix the Widget\n\nDo the thing.";
+            let parent_transcript = tmp.path().join("parent-session-id.jsonl");
+            fs::write(
+                &parent_transcript,
+                exit_plan_mode_line(plan_text, Some("claude-fable-5"), Some("2.1.214")),
+            )
+            .unwrap();
+
+            // Realistic shape: a fresh, just-started child session's
+            // transcript has no assistant turn yet at UserPromptSubmit time.
+            let child_transcript = tmp.path().join("child-session-id.jsonl");
+            fs::write(&child_transcript, "").unwrap();
+
+            let prompt = format!("Implement the following plan:\n\n{plan_text}");
+            let input = make_user_prompt_submit(
+                "child-session-id",
+                &prompt,
+                &cwd,
+                &child_transcript.to_string_lossy(),
+            );
+
+            with_metrics_dir(metrics_dir.path(), || {
+                run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host");
+            });
+
+            let written =
+                fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md"))
+                    .unwrap();
+            assert!(
+                written.contains("model: \"claude-fable-5\""),
+                "model falls back to the approving parent's transcript: {written}"
+            );
+            assert!(
+                written.contains("harness: \"claude-code 2.1.214\""),
+                "harness falls back to the approving parent's transcript: {written}"
+            );
+        });
     }
 
     #[test]
@@ -2027,6 +2476,74 @@ mod tests {
     }
 
     #[test]
+    fn approval_absent_is_agent_does_not_persist() {
+        // Fail-CLOSED (cameronsjo/cadence-hooks#396 review): an ABSENT
+        // `is_agent` — a future payload-shape drift, or a stripped-down
+        // fixture — must not be read as "not a subagent". Only the EXPLICIT
+        // `Some(false)` clears the gate.
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let input = exit_plan_mode_post_tool_use(
+            "sid",
+            "# X\n\nbody",
+            &cwd,
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            None,
+        );
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(
+            !tmp.path().join("docs").exists(),
+            "an absent is_agent must not be treated as a top-level approval"
+        );
+    }
+
+    #[test]
+    fn approval_agent_id_present_does_not_persist_even_with_is_agent_false() {
+        // The gate is `is_agent == Some(false) AND agent_id.is_none()` — both
+        // conditions, not either. A payload carrying `isAgent: false` but
+        // also an `agent_id` (a shape this hook has never observed, but must
+        // not trust blindly) must still skip.
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let mut input = exit_plan_mode_post_tool_use(
+            "sid",
+            "# X\n\nbody",
+            &cwd,
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            Some(false),
+        );
+        input.agent_id = Some("agent-1".into());
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(!tmp.path().join("docs").exists());
+    }
+
+    #[test]
+    fn approval_gate_pins_the_is_agent_wire_field_name() {
+        // Regression pin: `isAgent` (camelCase) is the exact field name
+        // Claude Code's payload uses — live-verified on cadence-hooks#396. A
+        // rename in either direction (this struct's `#[serde(rename)]`, or a
+        // hypothetical future payload-shape change) would silently break the
+        // fail-closed gate above without this test noticing via the
+        // Rust-struct-literal tests alone.
+        // Extra `#` in the raw-string delimiter: the payload's plan text
+        // embeds a literal `"#` (a quote immediately followed by an ATX
+        // heading marker), which would otherwise close a `r#"..."#` raw
+        // string early.
+        let json = r##"{"tool_name":"ExitPlanMode","session_id":"sid","cwd":"/tmp",
+            "tool_response":{"plan":"# X\n\nbody","isAgent":false}}"##;
+        let input: HookInput = serde_json::from_str(json).unwrap();
+        assert_eq!(
+            input.tool_response.as_ref().and_then(|tr| tr.is_agent),
+            Some(false),
+            "isAgent must deserialize into ToolResponse::is_agent"
+        );
+    }
+
+    #[test]
     fn approval_no_cwd_allows() {
         let input = HookInput {
             tool_name: Some("ExitPlanMode".into()),
@@ -2117,19 +2634,23 @@ mod tests {
 
         let written =
             fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
-        assert!(written.starts_with("---\nstatus: in-flight\n"));
+        assert!(written.starts_with("---\nstatus: \"in-flight\"\n"));
         assert!(written.contains("# Fix the Widget"));
-        assert!(written.contains("session_id: own-session-id"));
+        assert!(written.contains("session_id: \"own-session-id\""));
         assert!(written.contains(&format!(
-            "approved_in: {}",
+            "approved_in: \"{}\"",
             identity::generate_name("own-session-id")
         )));
-        assert!(written.contains("approved_session_id: own-session-id"));
+        assert!(written.contains("approved_session_id: \"own-session-id\""));
         assert!(written.contains(&crate::provenance::machine_digest("test-host")));
 
         let links = fs::read_to_string(metrics_dir.path().join("plan-links.jsonl")).unwrap();
         assert!(links.contains("\"parent_session_id\":\"own-session-id\""));
         assert!(links.contains("\"child_session_id\":\"own-session-id\""));
+        assert!(links.contains(&format!(
+            "\"machine\":\"{}\"",
+            crate::provenance::machine_digest("test-host")
+        )));
     }
 
     #[test]

--- a/crates/session/src/persist_plan.rs
+++ b/crates/session/src/persist_plan.rs
@@ -1,19 +1,34 @@
-//! `session persist-plan` — UserPromptSubmit hook (cadence#505).
+//! `session persist-plan` (UserPromptSubmit) and `session persist-plan-approval`
+//! (PostToolUse:ExitPlanMode) — persist an approved plan whose approving turn
+//! would otherwise leave no durable trace (cadence#505, cadence-hooks#396).
 //!
-//! Cameron's standard plan-approval path is "approve-and-clear": the parent
-//! transcript records `ExitPlanMode` as rejected (`[Request interrupted by
-//! user for tool use]`), and the harness injects a fresh user prompt
-//! `Implement the following plan:\n\n<full plan markdown>` — killing the
-//! post-approval turn a conversational "save the plan" rule would have relied
-//! on. This hook intercepts that injected prompt deterministically: every
-//! `UserPromptSubmit` payload is checked against an exact prefix gate, and on
-//! match the plan body is extracted, written to `docs/plans/` (idempotent by
-//! body hash), linked to its approving transcript when resolvable, and named
-//! in a context line so the session verifies placement and commits it.
+//! Two distinct gaps, two triggers, one shared persist core:
 //!
-//! Never blocks (ADR-0001): every failure path — no prompt, no match, no
-//! `cwd`, not a git repo, unsafe session id, exhausted suffix ladder — exits
-//! silently via `CheckResult::allow()`. A hook bug must not eat a user prompt.
+//! - **Cross-session wipe (`PersistPlan`, UserPromptSubmit).** Cameron's
+//!   "approve-and-clear" path: the parent transcript records `ExitPlanMode` as
+//!   rejected (`[Request interrupted by user for tool use]`), and the harness
+//!   injects a fresh user prompt `Implement the following plan:\n\n<full plan
+//!   markdown>` into a NEW session — killing the post-approval turn a
+//!   conversational "save the plan" rule would have relied on. This hook
+//!   intercepts that injected prompt deterministically via an exact prefix gate.
+//! - **Same-session approval (`PersistPlanApproval`, PostToolUse).** No wipe
+//!   occurs — the harness stays in the same session and injects no prompt at
+//!   all, so `PersistPlan`'s prefix gate structurally never fires
+//!   (cadence-hooks#396). Live probe (2026-07-25, cadence-hooks#396 comment
+//!   5080816947) established that `PostToolUse:ExitPlanMode` DOES fire here,
+//!   carrying the plan text in `tool_response.plan` — `tool_input.plan` is
+//!   EMPTY on this path.
+//!
+//! Both triggers normalize to the same body-hash-idempotent write through
+//! [`persist_and_nudge`]: `claim_target`'s `O_EXCL` collision ladder, a shared
+//! frontmatter render ([`render_document`]), and one `plan-links.jsonl` row
+//! format. `PersistPlan` alone keeps the PLAN_PREFIX/suffix-strip extraction —
+//! that pipeline is specific to the harness's re-injected prompt shape.
+//!
+//! Never blocks (ADR-0001): every failure path — no prompt/no plan text, no
+//! match, no `cwd`, not a git repo, unsafe session id, exhausted suffix ladder,
+//! a subagent-context approval — exits silently via `CheckResult::allow()`. A
+//! hook bug must not eat a user prompt or a same-session approval.
 
 use crate::identity;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
@@ -40,10 +55,9 @@ const SUFFIX_LINE_PREFIX: &str = "If this plan can be broken down";
 /// ("...before exiting plan mode..."). Live-verified 2026-07-20 (see the plan
 /// doc's execution addendum): without stripping this too, the persisted body
 /// glues harness text onto every plan AND the parent-transcript hash match
-/// (Approach step 4) systematically misses, since `ExitPlanMode`'s raw
-/// `input.plan` never carries either paragraph. Stripped by the same
-/// trailing-line-prefix mechanism as `SUFFIX_LINE_PREFIX` — a line matching
-/// EITHER prefix pops.
+/// systematically misses, since `ExitPlanMode`'s raw `input.plan` never
+/// carries either paragraph. Stripped by the same trailing-line-prefix
+/// mechanism as `SUFFIX_LINE_PREFIX` — a line matching EITHER prefix pops.
 const POINTER_PARAGRAPH_PREFIX: &str = "If you need specific details from before exiting plan mode";
 
 /// Cap on the generated slug's length (before the date prefix).
@@ -57,23 +71,39 @@ const DEFAULT_SLUG: &str = "approved-plan";
 /// suffixes taken" in the plan doc), after which [`fallback_path`] is tried.
 const NUMERIC_SUFFIXES: std::ops::RangeInclusive<u32> = 2..=9;
 
-/// The provenance line label carrying the plan body's hash. Shared by the
-/// writer ([`provenance_block`]) and the reader ([`file_matches_body`]) so the
-/// two can never drift apart: since the reader now falls back to recomputing
-/// the body when no such line is found, a label mismatch would no longer be a
-/// visible no-match — it would silently reclassify every document this hook
-/// wrote as one it didn't.
+/// The frontmatter key carrying the plan body's hash — the tier-1 idempotency
+/// anchor for every document this hook persists from birth (Design 18,
+/// cadence-hooks#396's plan). Parsed only from the LEADING frontmatter block
+/// ([`leading_frontmatter_block`]), never a whole-document scan: the body now
+/// grows by design (checkbox ticks, appended `## Deviations`/`## Learnings`
+/// sections) and may itself quote this exact key, so anchoring anywhere but
+/// the bounded frontmatter prefix would let a body-authored decoy — or a
+/// legitimately mutated body — spoof or defeat the match.
+const FRONTMATTER_HASH_KEY: &str = "body_sha256:";
+
+/// The legacy provenance line label carrying the plan body's hash, from the
+/// plain-trailer format this hook wrote before frontmatter emission
+/// (cadence-hooks#396). Only a TIER-2 fallback now — see [`file_matches_body`] —
+/// kept so plan docs already on disk in the old format stay recognized as
+/// re-fires rather than laddering into a duplicate `-2` file.
 const PROVENANCE_HASH_LABEL: &str = "Plan-body-SHA256:";
 
 /// Cap on a candidate document's size before [`file_matches_body`] declines to
-/// consider it a re-fire. Plan docs run single-digit KB; anything past 1 MiB is
-/// not a plan this hook wrote.
+/// consider it a re-fire. A living plan now grows by design over its
+/// lifecycle (frontmatter status flips, ticked checklists, `## Deviations`/
+/// `## Learnings` entries) — this cap is a defensive bound against a
+/// pathological file, not a signal that growth itself is unexpected. It
+/// remains generous against the measured corpus (single-digit KB to ~37 KiB):
+/// this hook itself still writes a plan exactly once through `create_new` and
+/// never appends, so ordinary growth is always EXTERNAL (another edit to a
+/// file this hook already wrote) — a laddered sibling on the rare doc that
+/// clears the cap, never a silently lost match.
 const IDEMPOTENCY_MAX_FILE_BYTES: u64 = 1024 * 1024;
 
-/// How many lines past an opening `---` [`strip_leading_frontmatter`] will scan
-/// for the closing fence. Real backfill frontmatter runs ~12 lines; the bound
-/// keeps a body that merely opens with a thematic break from consuming the
-/// whole document looking for a fence that was never there.
+/// How many lines past an opening `---` [`frontmatter_extent`] will scan for
+/// the closing fence. Real frontmatter runs well under this; the bound keeps
+/// a body that merely opens with a thematic break from consuming the whole
+/// document looking for a fence that was never there.
 const FRONTMATTER_SCAN_MAX_LINES: usize = 100;
 
 /// How far back a sibling transcript may sit and still be scanned for the
@@ -94,7 +124,8 @@ const PARENT_SCAN_MAX_FILE_BYTES: u64 = 32 * 1024 * 1024;
 /// existing version constants; this one lives with its own writer.
 const PLAN_LINKS_SCHEMA_VERSION: u32 = 1;
 
-/// Persist an approved plan whose post-approval turn was wiped.
+/// Persist an approved plan whose post-approval turn was wiped
+/// (approve-and-clear, cross-session).
 pub struct PersistPlan;
 
 impl Check for PersistPlan {
@@ -119,6 +150,26 @@ impl Check for PersistPlan {
         // stderr breadcrumb, no failopen row for a hook that fires on every
         // single turn.
         std::panic::catch_unwind(|| run_persist_plan(input, &utc_now, &local_date, &host))
+            .unwrap_or_else(|_| CheckResult::allow())
+    }
+}
+
+/// Persist an approved plan on same-session approval — no wipe, no injected
+/// prompt, so [`PersistPlan`]'s prefix gate never fires (cadence-hooks#396).
+pub struct PersistPlanApproval;
+
+impl Check for PersistPlanApproval {
+    fn name(&self) -> &str {
+        "persist-plan-approval"
+    }
+
+    fn run(&self, input: &HookInput) -> CheckResult {
+        let host = gethostname::gethostname().to_string_lossy().into_owned();
+        let utc_now = cadence_hooks_core::time::utc_timestamp();
+        let local_date = cadence_hooks_core::time::local_date();
+        // Same narrow defense-in-depth as `PersistPlan` above: this fires on
+        // every `ExitPlanMode` call, and a bug here must not eat the approval.
+        std::panic::catch_unwind(|| run_persist_plan_approval(input, &utc_now, &local_date, &host))
             .unwrap_or_else(|_| CheckResult::allow())
     }
 }
@@ -165,66 +216,152 @@ pub fn run_persist_plan(
     }
     let stem = format!("{local_date}-{slug}");
 
-    let parent = input
+    let parent_session_id = input
         .transcript_path()
         .and_then(|tp| find_parent(Path::new(tp), &body_hash, SystemTime::now()));
-    let parent_session_id = parent.as_ref().map(|p| p.session_id.as_str());
-    let parent_name = parent_session_id.map(identity::generate_name);
+    let parent_name = parent_session_id.as_deref().map(identity::generate_name);
     let own_name = identity::generate_name(session_id);
     let machine_digest = crate::provenance::machine_digest(host);
 
-    let approving_parent = parent
-        .as_ref()
+    let transcript_content = input
+        .transcript_path()
+        .and_then(|tp| fs::read_to_string(tp).ok());
+    let model = crate::warn_commit_provenance::resolve_model(transcript_content.as_deref());
+    let harness = crate::warn_commit_provenance::resolve_harness(transcript_content.as_deref());
+    let branch = current_branch(cwd);
+
+    let approved_in = parent_session_id
+        .as_deref()
         .zip(parent_name.as_deref())
-        .map(|(p, name)| ApprovingParent {
-            name,
-            session_id: p.session_id.as_str(),
-            model: p.model.as_deref(),
-            harness_version: p.harness_version.as_deref(),
-        });
+        .map(|(sid, name)| (name, sid));
 
-    let provenance = provenance_block(
-        approving_parent,
-        &own_name,
-        session_id,
-        &machine_digest,
-        utc_now,
-        &body_hash,
-    );
-    let document = format!("{body}\n\n---\n\n{provenance}");
-
-    let path = match claim_target(&plans_dir, &stem, session_id, &body_hash, &document) {
-        Claim::Wrote(path) | Claim::AlreadyPersisted(path) => path,
-        Claim::GiveUp => return CheckResult::allow(),
+    let fields = FrontmatterFields {
+        updated: local_date,
+        branch: branch.as_deref(),
+        body_hash: &body_hash,
+        own_name: &own_name,
+        own_session_id: session_id,
+        model: model.as_deref(),
+        harness: harness.as_deref(),
+        machine_digest: &machine_digest,
+        approved_in,
     };
+    let document = render_document(&fields, &body);
 
-    // Normalized to forward slashes (the core crate's own convention — see
-    // `cadence_hooks_core::normalize_path`) so the linkage row's `plan_path`
-    // is a stable, cross-platform value for consumers, regardless of the
-    // native separator `PathBuf::to_string_lossy` would otherwise render on
-    // Windows.
-    let plan_path_rel = cadence_hooks_core::normalize_path(
-        &path
-            .strip_prefix(&repo_root)
-            .map(|p| p.to_string_lossy().into_owned())
-            .unwrap_or_else(|_| path.to_string_lossy().into_owned()),
-    );
-    append_plan_links_row(&plan_links_row(
+    let approved_label = parent_name.as_deref().unwrap_or("unknown");
+    persist_and_nudge(
+        &plans_dir,
+        &stem,
+        session_id,
+        &body_hash,
+        &document,
         utc_now,
-        parent_session_id,
+        parent_session_id.as_deref(),
         session_id,
         host,
-        &repo_root.to_string_lossy(),
-        &plan_path_rel,
-        &body_hash,
-    ));
+        &repo_root,
+        approved_label,
+    )
+}
 
-    let parent_label = parent_name.as_deref().unwrap_or("unknown");
-    CheckResult::nudge(format!(
-        "Approved plan persisted to {} (approved in {parent_label}). Verify placement, then \
-         commit it (explicit-path git add) before implementation.",
-        path.display()
-    ))
+/// Testable core for the PostToolUse trigger. Same injected clock/host
+/// discipline as [`run_persist_plan`].
+pub fn run_persist_plan_approval(
+    input: &HookInput,
+    utc_now: &str,
+    local_date: &str,
+    host: &str,
+) -> CheckResult {
+    if input.tool_name() != Some("ExitPlanMode") {
+        return CheckResult::allow();
+    }
+    // A subagent's own plan approval doesn't persist — only a top-level
+    // session's approval does (the plan doc's Task 1 step 2). `is_agent`
+    // rides `tool_response`, alongside `plan`.
+    if input
+        .tool_response
+        .as_ref()
+        .and_then(|tr| tr.is_agent)
+        .unwrap_or(false)
+    {
+        return CheckResult::allow();
+    }
+    let Some(raw_plan) = input.tool_response_plan() else {
+        return CheckResult::allow();
+    };
+    // Same normalization `run_persist_plan` applies to its extracted body
+    // (Design 18): both triggers must hash byte-identical text so a plan
+    // approved through either path is recognized as the same re-fire.
+    let body = strip_trailing_suffix_lines_and_trim(raw_plan);
+    if body.is_empty() {
+        return CheckResult::allow();
+    }
+    let Some(cwd) = input.cwd.as_deref() else {
+        return CheckResult::allow();
+    };
+    let Some(repo_root) = crate::registry::repo_root(cwd) else {
+        return CheckResult::allow();
+    };
+    let Some(session_id) = input
+        .session_id()
+        .filter(|s| identity::is_safe_session_id(s))
+    else {
+        return CheckResult::allow();
+    };
+
+    let body_hash = sha256_hex(body.as_bytes());
+    let slug = slugify(&body);
+    let plans_dir = repo_root.join("docs").join("plans");
+    if fs::create_dir_all(&plans_dir).is_err() {
+        return CheckResult::allow();
+    }
+    let stem = format!("{local_date}-{slug}");
+
+    let own_name = identity::generate_name(session_id);
+    let machine_digest = crate::provenance::machine_digest(host);
+    let transcript_content = input
+        .transcript_path()
+        .and_then(|tp| fs::read_to_string(tp).ok());
+    let model = crate::warn_commit_provenance::resolve_model(transcript_content.as_deref());
+    let harness = crate::warn_commit_provenance::resolve_harness(transcript_content.as_deref());
+    let branch = current_branch(cwd);
+
+    let fields = FrontmatterFields {
+        updated: local_date,
+        branch: branch.as_deref(),
+        body_hash: &body_hash,
+        own_name: &own_name,
+        own_session_id: session_id,
+        model: model.as_deref(),
+        harness: harness.as_deref(),
+        machine_digest: &machine_digest,
+        // Same-session approval: the approving identity IS the executing
+        // session — no sibling-transcript scan needed (Design record item 2).
+        approved_in: Some((own_name.as_str(), session_id)),
+    };
+    let document = render_document(&fields, &body);
+
+    persist_and_nudge(
+        &plans_dir,
+        &stem,
+        session_id,
+        &body_hash,
+        &document,
+        utc_now,
+        Some(session_id),
+        session_id,
+        host,
+        &repo_root,
+        &own_name,
+    )
+}
+
+/// The current checked-out branch of the repo containing `cwd`, or `None`
+/// when unresolvable (no git repo, detached HEAD, unreadable `HEAD` file).
+/// Pure filesystem resolution ([`cadence_hooks_core::gitstate`]) — no `git`
+/// subprocess spawn on this every-turn/every-approval hot path.
+fn current_branch(cwd: &str) -> Option<String> {
+    cadence_hooks_core::gitstate::GitState::resolve(Path::new(cwd)).and_then(|gs| gs.branch)
 }
 
 // ---------------------------------------------------------------------------
@@ -364,61 +501,76 @@ fn fallback_path(dir: &Path, stem: &str, session_id: &str) -> PathBuf {
     dir.join(format!("{stem}-{}.md", identity::short_id(session_id)))
 }
 
-/// Strip a leading YAML frontmatter block, returning the document body.
+/// Byte offsets of a leading YAML frontmatter block: `(content_start,
+/// content_end, body_start)` — `content_start..content_end` is the raw text
+/// between the two `---` fences (no fence lines themselves), `body_start` is
+/// where the document's body begins (just past the closing fence line).
 ///
 /// Engages ONLY when the very first line is exactly `---` (after trimming),
 /// then scans forward at most [`FRONTMATTER_SCAN_MAX_LINES`] lines for the
-/// closing fence. **No closing fence in the window → the input is returned
-/// unchanged**, so a plan body that opens with a thematic break can at worst
-/// produce a hash mismatch (which ladders, the pre-existing behavior) and
-/// never a false match.
-fn strip_leading_frontmatter(doc: &str) -> &str {
+/// closing fence. **No closing fence in the window → `None`**, so a plan body
+/// that opens with a thematic break can at worst produce a hash mismatch
+/// (which ladders, the pre-existing behavior) and never a false match.
+fn frontmatter_extent(doc: &str) -> Option<(usize, usize, usize)> {
     let mut lines = doc.split_inclusive('\n');
-    let Some(first) = lines.next() else {
-        return doc;
-    };
+    let first = lines.next()?;
     if first.trim() != "---" {
-        return doc;
+        return None;
     }
-    let mut offset = first.len();
+    let content_start = first.len();
+    let mut offset = content_start;
     for line in lines.take(FRONTMATTER_SCAN_MAX_LINES) {
-        offset += line.len();
         if line.trim() == "---" {
-            return &doc[offset..];
+            return Some((content_start, offset, offset + line.len()));
         }
+        offset += line.len();
     }
-    doc
+    None
+}
+
+/// Strip a leading YAML frontmatter block, returning the document body.
+/// A thin wrapper over [`frontmatter_extent`] — see its doc for engagement
+/// rules. Returns `doc` unchanged when no block is found.
+fn strip_leading_frontmatter(doc: &str) -> &str {
+    match frontmatter_extent(doc) {
+        Some((_, _, body_start)) => &doc[body_start..],
+        None => doc,
+    }
+}
+
+/// The raw text of a leading YAML frontmatter block (between the fences,
+/// exclusive), or `None` when the document doesn't open with one. Thin
+/// wrapper over [`frontmatter_extent`] sharing its single scan implementation
+/// with [`strip_leading_frontmatter`].
+fn leading_frontmatter_block(doc: &str) -> Option<&str> {
+    frontmatter_extent(doc).map(|(start, end, _)| &doc[start..end])
 }
 
 /// Does the document at `path` carry the plan body `body_hash` identifies?
 ///
-/// Two sources answer that, in order, from a single capped read:
+/// Three sources answer that, tried in order, from a single capped read:
 ///
-/// 1. The LAST `Plan-body-SHA256:` provenance line. The real provenance block
-///    is always appended at the end of the document (see [`provenance_block`]),
-///    so anchoring on the last occurrence — not the first — means a plan body
-///    that itself embeds a decoy line of that exact shape can never spoof the
-///    check. When such a line exists it is authoritative: a mismatch ladders,
-///    it does not fall through to a recompute.
-/// 2. No provenance line at all — a document this hook did not write, such as a
-///    backfilled plan carrying only frontmatter (cadence-hooks#399). The body
-///    is then recomputed the way [`run_persist_plan`] computes it: strip
-///    leading frontmatter, strip the trailing harness suffix lines and trim,
-///    hash.
+/// 1. The parsed LEADING frontmatter block's [`FRONTMATTER_HASH_KEY`]
+///    (`body_sha256:`) — the format every document persisted since
+///    cadence-hooks#396 carries from birth. Bounded to the frontmatter
+///    prefix, never a whole-document scan: a living plan's body grows by
+///    design (ticked checkboxes, appended `## Deviations`/`## Learnings`),
+///    and may itself quote this exact key — anchoring anywhere else would let
+///    a body-authored decoy spoof the match, OR let a legitimately mutated
+///    body wrongly defeat it (Design 18).
+/// 2. No frontmatter key (a document predating cadence-hooks#396, or a
+///    backfilled plan carrying only ad-hoc frontmatter) — the LAST
+///    `Plan-body-SHA256:` legacy trailer line, if present. Anchored on the
+///    last occurrence, not the first, so a plan body that itself embeds a
+///    decoy line of that exact shape can never spoof the check.
+/// 3. Neither marker — a document neither trigger wrote, such as a backfilled
+///    plan carrying only frontmatter with no hash key (cadence-hooks#399). The
+///    body is recomputed the way both triggers compute it: strip leading
+///    frontmatter, strip the trailing harness suffix lines and trim, hash.
 ///
 /// Only an equality returns `true`; every ambiguity (unreadable, over
 /// [`IDEMPOTENCY_MAX_FILE_BYTES`], hash differs) returns `false` and lets the
-/// suffix ladder run. The conversion is therefore **one-way**: a document that
-/// previously read as "no marker, no match" may now match, but a document that
-/// already matched by provenance line can never stop matching — with one
-/// boundary case, stated so the invariant is not read as broader than it is.
-/// The old reader was uncapped, so a provenance-carrying file that later grows
-/// past [`IDEMPOTENCY_MAX_FILE_BYTES`] flips from match to no-match, and
-/// ladders. Nothing here reaches that: this hook writes a plan exactly once
-/// through `create_new` and never appends, and the measured corpus tops out
-/// near 37 KiB against a 1 MiB cap. It would take external growth of a
-/// document this hook already wrote, which is a laddered sibling rather than a
-/// lost one.
+/// suffix ladder run.
 fn file_matches_body(path: &Path, body_hash: &str) -> bool {
     use std::io::Read as _;
 
@@ -435,6 +587,13 @@ fn file_matches_body(path: &Path, body_hash: &str) -> bool {
         || content.len() as u64 > IDEMPOTENCY_MAX_FILE_BYTES
     {
         return false;
+    }
+
+    if let Some(recorded) = leading_frontmatter_block(&content).and_then(|fm| {
+        fm.lines()
+            .find_map(|l| l.strip_prefix(FRONTMATTER_HASH_KEY))
+    }) {
+        return recorded.trim() == body_hash;
     }
 
     if let Some(recorded) = content
@@ -492,34 +651,14 @@ fn claim_target(
 // Provenance: parent resolution (Approach step 4)
 // ---------------------------------------------------------------------------
 
-/// The parent transcript's approving turn, resolved by [`find_parent`]: the
-/// matched sibling's session id plus the fields the `Approved in:` line's
-/// bracket segment needs. `model`/`harness_version` are `None` when the
-/// matched line doesn't carry them — the bracket segment is then omitted
-/// entirely (see [`provenance_block`]) rather than rendered empty.
-#[derive(Debug, PartialEq, Eq)]
-struct ParentTuple {
-    session_id: String,
-    model: Option<String>,
-    harness_version: Option<String>,
-}
-
-/// One transcript line's `ExitPlanMode` tool_use match: the plan text plus
-/// the approving turn's model (`message.model`) and harness version
-/// (top-level `version`), when this line is an assistant message carrying an
-/// `ExitPlanMode` call. Mirrors
+/// The `ExitPlanMode` plan text on one transcript line, if `line` is an
+/// assistant message carrying that tool call. Mirrors
 /// `cadence_hooks_core::transcript::line_is_polish_skill_use`'s traversal.
-struct ExitPlanModeMatch {
-    plan_text: String,
-    model: Option<String>,
-    harness_version: Option<String>,
-}
-
-fn exit_plan_mode_match(line: &str) -> Option<ExitPlanModeMatch> {
+fn exit_plan_mode_match(line: &str) -> Option<String> {
     let value: Value = serde_json::from_str(line).ok()?;
     let message = value.get("message")?;
     let content = message.get("content")?.as_array()?;
-    let plan_text = content.iter().find_map(|block| {
+    content.iter().find_map(|block| {
         if block.get("type").and_then(Value::as_str) != Some("tool_use") {
             return None;
         }
@@ -531,19 +670,6 @@ fn exit_plan_mode_match(line: &str) -> Option<ExitPlanModeMatch> {
             .get("plan")?
             .as_str()
             .map(str::to_string)
-    })?;
-    let model = message
-        .get("model")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let harness_version = value
-        .get("version")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    Some(ExitPlanModeMatch {
-        plan_text,
-        model,
-        harness_version,
     })
 }
 
@@ -555,12 +681,12 @@ fn exit_plan_mode_match(line: &str) -> Option<ExitPlanModeMatch> {
 /// streamed line-by-line (never loading a whole sibling into memory) with a
 /// substring pre-filter on each line before any JSON parse. `now` is the
 /// caller's `SystemTime::now()`, threaded through for testability without a
-/// frozen clock. Returns a [`ParentTuple`] on the first exact match — never a
-/// fuzzy guess — and only when the sibling's file stem passes
+/// frozen clock. Returns the matched sibling's session id on the first exact
+/// match — never a fuzzy guess — and only when its file stem passes
 /// [`identity::is_safe_session_id`]; a match against a hostile-named sibling
 /// is treated as no-match (`unknown`), since the returned id flows raw into
 /// the provenance text and the linkage row.
-fn find_parent(transcript_path: &Path, target_hash: &str, now: SystemTime) -> Option<ParentTuple> {
+fn find_parent(transcript_path: &Path, target_hash: &str, now: SystemTime) -> Option<String> {
     let dir = transcript_path.parent()?;
     let mut candidates: Vec<(SystemTime, PathBuf)> = fs::read_dir(dir)
         .ok()?
@@ -599,82 +725,159 @@ fn find_parent(transcript_path: &Path, target_hash: &str, now: SystemTime) -> Op
             if !line.contains("ExitPlanMode") {
                 continue;
             }
-            let Some(exit_plan) = exit_plan_mode_match(&line) else {
+            let Some(plan_text) = exit_plan_mode_match(&line) else {
                 continue;
             };
-            let normalized = strip_trailing_suffix_lines_and_trim(&exit_plan.plan_text);
+            let normalized = strip_trailing_suffix_lines_and_trim(&plan_text);
             if sha256_hex(normalized.as_bytes()) == target_hash {
-                let stem = path.file_stem().map(|s| s.to_string_lossy().into_owned());
-                return stem
-                    .filter(|s| identity::is_safe_session_id(s))
-                    .map(|session_id| ParentTuple {
-                        session_id,
-                        model: exit_plan.model,
-                        harness_version: exit_plan.harness_version,
-                    });
+                return path
+                    .file_stem()
+                    .map(|s| s.to_string_lossy().into_owned())
+                    .filter(|s| identity::is_safe_session_id(s));
             }
         }
     }
     None
 }
 
-/// The `Approved in:`/model+harness bracket segment, e.g. `" [claude-fable-5,
-/// claude-code 2.1.214]"` — rendered with its own leading space so the
-/// caller can splice it directly after the `(id)` segment. `None` when
-/// neither field is present, so the caller omits the bracket entirely rather
-/// than printing an empty or dangling one; when only one field is present,
-/// the bracket carries just that field (still never empty).
-fn model_harness_bracket(model: Option<&str>, harness_version: Option<&str>) -> Option<String> {
-    match (model, harness_version) {
-        (Some(m), Some(v)) => Some(format!(" [{m}, claude-code {v}]")),
-        (Some(m), None) => Some(format!(" [{m}]")),
-        (None, Some(v)) => Some(format!(" [claude-code {v}]")),
-        (None, None) => None,
-    }
-}
+// ---------------------------------------------------------------------------
+// Frontmatter (Design 2 / Design 18) + shared persist tail (Approach step 5)
+// ---------------------------------------------------------------------------
 
-/// The approving parent's rendered fields for [`provenance_block`]'s
-/// `Approved in:` line — bundled to keep the render function's arity under
-/// clippy's `too_many_arguments` threshold. `name` is the parent's generated
-/// display name (`identity::generate_name`), computed by the caller since
-/// [`find_parent`] only resolves the raw [`ParentTuple`].
-struct ApprovingParent<'a> {
-    name: &'a str,
-    session_id: &'a str,
+/// Fields resolved for a newly persisted plan's frontmatter — the
+/// execution-zone metadata a resume/scan/outro reconciliation reads (the
+/// plan-as-living-document lifecycle's Design record item 2). An unresolved
+/// optional field is OMITTED from the render entirely, never written as a
+/// placeholder (`unknown`, an empty string) — silence, not a guess.
+struct FrontmatterFields<'a> {
+    /// Local date this document was (first) persisted — `updated:`.
+    updated: &'a str,
+    /// The cwd's current checked-out branch, if resolvable.
+    branch: Option<&'a str>,
+    /// The plan body's SHA-256 hex digest — the tier-1 idempotency anchor.
+    body_hash: &'a str,
+    /// The executing session's generated display name.
+    own_name: &'a str,
+    /// The executing session's id.
+    own_session_id: &'a str,
+    /// The executing session's model, resolved from its own transcript tail.
     model: Option<&'a str>,
-    harness_version: Option<&'a str>,
+    /// The executing session's harness version (transcript tail, or the
+    /// `AI_AGENT` env fallback).
+    harness: Option<&'a str>,
+    /// Salted, truncated machine digest (never the raw hostname).
+    machine_digest: &'a str,
+    /// The approving session's `(name, session_id)` — identical to
+    /// `(own_name, own_session_id)` on same-session approval, the
+    /// `find_parent`-resolved sibling on a cross-session approve-and-clear
+    /// wipe, or `None` when no approving parent was found.
+    approved_in: Option<(&'a str, &'a str)>,
 }
 
-/// Render the provenance block appended to every persisted plan.
+/// Render the frontmatter block for a newly persisted plan.
 ///
-/// `machine_digest` is the salted, truncated digest from
-/// [`crate::provenance::machine_digest`] — never the raw hostname (cadence#248
-/// fixes the doctrine violation of a bare hostname in a committed artifact).
-/// It appears on both lines: transcripts are machine-local, so a resolved
-/// parent is same-machine by construction. The executing-session line never
-/// carries model/harness — on a same-session wipe it would be identical to
-/// the parent's, and on a fresh pickup it's simply unknown.
-fn provenance_block(
-    parent: Option<ApprovingParent>,
-    own_name: &str,
-    own_session_id: &str,
-    machine_digest: &str,
-    utc_now: &str,
+/// `status: in-flight` is a fixed constant: this hook only ever fires at the
+/// moment a plan is approved, so a freshly persisted document is never
+/// anything else. Reserved keys the living-plan lifecycle owns for a later
+/// consumer — `next`, `pr`, `card`, `blocked` — are never emitted here (Task 1
+/// step 3 of the plan-as-living-document lifecycle plan); a session or the
+/// scanner fills those in on a later touch.
+///
+/// Free-text fields sourced from the transcript (`model`, `harness`) or the
+/// filesystem (`branch`) are passed through [`identity::sanitize_field`] —
+/// the same discipline `warn_commit_provenance`'s nudge applies to the same
+/// two fields — before interpolation, since none of the three come from a
+/// value this crate itself generated or validated.
+fn render_frontmatter(f: &FrontmatterFields) -> String {
+    let mut lines = vec![
+        "---".to_string(),
+        "status: in-flight".to_string(),
+        format!("updated: {}", f.updated),
+    ];
+    if let Some(b) = f.branch {
+        lines.push(format!(
+            "branch: {}",
+            identity::sanitize_field(b, identity::MAX_FIELD_DISPLAY)
+        ));
+    }
+    lines.push(format!("{FRONTMATTER_HASH_KEY} {}", f.body_hash));
+    lines.push(format!("session: {}", f.own_name));
+    lines.push(format!("session_id: {}", f.own_session_id));
+    if let Some(m) = f.model {
+        lines.push(format!(
+            "model: {}",
+            identity::sanitize_field(m, identity::MAX_FIELD_DISPLAY)
+        ));
+    }
+    if let Some(h) = f.harness {
+        lines.push(format!(
+            "harness: claude-code {}",
+            identity::sanitize_field(h, identity::MAX_FIELD_DISPLAY)
+        ));
+    }
+    lines.push(format!("machine: {}", f.machine_digest));
+    if let Some((name, sid)) = f.approved_in {
+        lines.push(format!("approved_in: {name}"));
+        lines.push(format!("approved_session_id: {sid}"));
+    }
+    lines.push("---".to_string());
+    lines.join("\n")
+}
+
+/// The full document written to disk: frontmatter, a blank line, then the
+/// plan body, trailing-newline terminated.
+fn render_document(f: &FrontmatterFields, body: &str) -> String {
+    format!("{}\n\n{body}\n", render_frontmatter(f))
+}
+
+/// The shared tail both triggers converge on once each has resolved its own
+/// body/session/approval fields: claim a target, append the linkage row,
+/// render the nudge. Never overwrites anything (see [`claim_target`]).
+#[allow(clippy::too_many_arguments)]
+fn persist_and_nudge(
+    plans_dir: &Path,
+    stem: &str,
+    session_id: &str,
     body_hash: &str,
-) -> String {
-    let approved_in = match parent {
-        Some(p) => {
-            let bracket = model_harness_bracket(p.model, p.harness_version).unwrap_or_default();
-            let name = p.name;
-            let sid = p.session_id;
-            format!("Approved in: {name} ({sid}){bracket} @ {machine_digest}")
-        }
-        None => "Approved in: unknown".to_string(),
+    document: &str,
+    utc_now: &str,
+    parent_session_id: Option<&str>,
+    child_session_id: &str,
+    host: &str,
+    repo_root: &Path,
+    approved_label: &str,
+) -> CheckResult {
+    let path = match claim_target(plans_dir, stem, session_id, body_hash, document) {
+        Claim::Wrote(path) | Claim::AlreadyPersisted(path) => path,
+        Claim::GiveUp => return CheckResult::allow(),
     };
-    format!(
-        "{approved_in}\nExecuting session: {own_name} ({own_session_id}) @ {machine_digest}\n\
-         Persisted: {utc_now}\n{PROVENANCE_HASH_LABEL} {body_hash}\n"
-    )
+
+    // Normalized to forward slashes (the core crate's own convention — see
+    // `cadence_hooks_core::normalize_path`) so the linkage row's `plan_path`
+    // is a stable, cross-platform value for consumers, regardless of the
+    // native separator `PathBuf::to_string_lossy` would otherwise render on
+    // Windows.
+    let plan_path_rel = cadence_hooks_core::normalize_path(
+        &path
+            .strip_prefix(repo_root)
+            .map(|p| p.to_string_lossy().into_owned())
+            .unwrap_or_else(|_| path.to_string_lossy().into_owned()),
+    );
+    append_plan_links_row(&plan_links_row(
+        utc_now,
+        parent_session_id,
+        child_session_id,
+        host,
+        &repo_root.to_string_lossy(),
+        &plan_path_rel,
+        body_hash,
+    ));
+
+    CheckResult::nudge(format!(
+        "Approved plan persisted to {} (approved in {approved_label}). Verify placement, then \
+         commit it (explicit-path git add) before implementation.",
+        path.display()
+    ))
 }
 
 // ---------------------------------------------------------------------------
@@ -727,6 +930,7 @@ mod tests {
     use super::*;
     use cadence_hooks_core::Outcome;
     use cadence_hooks_core::test_builders::make_user_prompt_submit;
+    use cadence_hooks_core::{ToolInput, ToolResponse};
     use tempfile::TempDir;
 
     // --- extraction: prefix gate ---
@@ -1079,8 +1283,7 @@ mod tests {
         // rejects it on its own — so neither actually exercises the `.rev()`
         // last-occurrence anchor they are named for. Only a decoy at the START
         // of a line reaches `strip_prefix`, making this the single case where
-        // the anchor is load-bearing. It matters more since cadence-hooks#399:
-        // the anchor now also decides whether the recompute fallback runs.
+        // the anchor is load-bearing.
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("plan.md");
         fs::write(
@@ -1098,8 +1301,9 @@ mod tests {
 
     #[test]
     fn file_matches_body_recomputes_when_no_hash_line() {
-        // A document this hook did not write — backfill frontmatter, no
-        // provenance block. The body must still be recognized (cadence-hooks#399).
+        // A document neither trigger wrote — backfill frontmatter, no
+        // hash key and no legacy trailer. The body must still be recognized
+        // (cadence-hooks#399).
         let tmp = TempDir::new().unwrap();
         let path = tmp.path().join("plan.md");
         let body = "# Title\n\nbody text";
@@ -1232,28 +1436,185 @@ mod tests {
         );
     }
 
+    // --- idempotency: frontmatter tier-1 anchor (Design 18) ---
+
+    fn frontmatter_doc_with_hash(hash: &str, body: &str) -> String {
+        format!("---\nstatus: in-flight\nbody_sha256: {hash}\n---\n\n{body}\n")
+    }
+
+    #[test]
+    fn file_matches_body_frontmatter_key_is_tier_one() {
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("plan.md");
+        let body = "# Title\n\nbody text";
+        let hash = sha256_hex(body.as_bytes());
+        fs::write(&path, frontmatter_doc_with_hash(&hash, body)).unwrap();
+        assert!(file_matches_body(&path, &hash));
+        assert!(!file_matches_body(&path, "some-other-hash"));
+    }
+
+    #[test]
+    fn file_matches_body_recognizes_mutated_body_via_frontmatter_key() {
+        // The exact Design-18 scenario: a plan persisted once, then its BODY
+        // is mutated in place (checkbox ticked, a `## Deviations` entry
+        // appended) while the frontmatter block is left untouched. A re-fire
+        // of the SAME original approval must still recognize this as the plan
+        // it already wrote — recomputing against the current (mutated) body
+        // would wrongly ladder to a `-2` duplicate.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("plan.md");
+        let original_body = "# Title\n\n- [ ] Task one";
+        let hash = sha256_hex(original_body.as_bytes());
+        fs::write(&path, frontmatter_doc_with_hash(&hash, original_body)).unwrap();
+
+        let mutated = format!(
+            "---\nstatus: in-flight\nbody_sha256: {hash}\n---\n\n# Title\n\n- [x] Task one\n\n\
+             ## Deviations\n\nnone\n"
+        );
+        fs::write(&path, mutated).unwrap();
+
+        assert!(
+            file_matches_body(&path, &hash),
+            "the frontmatter key must anchor the match even though the body mutated"
+        );
+    }
+
+    #[test]
+    fn file_matches_body_frontmatter_key_not_spoofed_by_body_decoy() {
+        // A body that itself quotes `body_sha256:` (e.g. explaining this exact
+        // mechanism) must not be read as the frontmatter key — only the
+        // bounded LEADING frontmatter block is ever scanned for it.
+        let tmp = TempDir::new().unwrap();
+        let path = tmp.path().join("plan.md");
+        let body = "# Title\n\nThe idempotency reader parses a leading `body_sha256: decoy` key.";
+        let hash = sha256_hex(body.as_bytes());
+        fs::write(&path, frontmatter_doc_with_hash(&hash, body)).unwrap();
+        assert!(
+            file_matches_body(&path, &hash),
+            "the real frontmatter key still matches"
+        );
+        assert!(
+            !file_matches_body(&path, "decoy"),
+            "a body-authored decoy key must never spoof the match"
+        );
+    }
+
+    #[test]
+    fn leading_frontmatter_block_returns_none_without_a_fence() {
+        assert_eq!(leading_frontmatter_block("# Title\n\nbody"), None);
+    }
+
+    // --- cross-trigger hash normalization (Design 18) ---
+
+    #[test]
+    fn cross_trigger_normalization_hashes_match() {
+        // The UserPromptSubmit path strips PLAN_PREFIX then normalizes; the
+        // PostToolUse path consumes `tool_response.plan` raw and normalizes
+        // the SAME way. Both must land on byte-identical text so a plan
+        // approved through either path hashes the same.
+        let prompt = format!(
+            "{PLAN_PREFIX}\n\n# Title\n\nbody text\n\nIf this plan can be broken down into \
+             discrete units of work, consider using the Agent tool to dispatch them."
+        );
+        let user_prompt_submit_body =
+            strip_trailing_suffix_lines_and_trim(prompt.strip_prefix(PLAN_PREFIX).unwrap());
+
+        // ExitPlanMode's own tool_input.plan never carries the harness prefix
+        // or suffix — but may carry an incidental trailing blank line.
+        let raw_exit_plan_mode_text = "# Title\n\nbody text\n\n";
+        let post_tool_use_body = strip_trailing_suffix_lines_and_trim(raw_exit_plan_mode_text);
+
+        assert_eq!(user_prompt_submit_body, post_tool_use_body);
+        assert_eq!(
+            sha256_hex(user_prompt_submit_body.as_bytes()),
+            sha256_hex(post_tool_use_body.as_bytes())
+        );
+    }
+
+    // --- frontmatter rendering ---
+
+    fn base_fields<'a>(body_hash: &'a str, machine_digest: &'a str) -> FrontmatterFields<'a> {
+        FrontmatterFields {
+            updated: "2026-07-25",
+            branch: None,
+            body_hash,
+            own_name: "own-name",
+            own_session_id: "own-sid",
+            model: None,
+            harness: None,
+            machine_digest,
+            approved_in: None,
+        }
+    }
+
+    #[test]
+    fn render_frontmatter_omits_unresolved_optional_fields() {
+        let fields = base_fields("hash", "digest");
+        let fm = render_frontmatter(&fields);
+        assert!(fm.starts_with("---\nstatus: in-flight\nupdated: 2026-07-25\n"));
+        assert!(fm.contains("body_sha256: hash"));
+        assert!(fm.contains("session: own-name"));
+        assert!(fm.contains("session_id: own-sid"));
+        assert!(fm.contains("machine: digest"));
+        assert!(fm.ends_with("---"));
+        assert!(
+            !fm.contains("branch:"),
+            "unresolved branch is omitted: {fm}"
+        );
+        assert!(!fm.contains("model:"), "unresolved model is omitted: {fm}");
+        assert!(
+            !fm.contains("harness:"),
+            "unresolved harness is omitted: {fm}"
+        );
+        assert!(
+            !fm.contains("approved_in:"),
+            "unresolved approved_in is omitted: {fm}"
+        );
+        assert!(!fm.contains("next:"), "next: is reserved, never emitted");
+        assert!(!fm.contains("pr:"), "pr: is reserved, never emitted");
+        assert!(!fm.contains("card:"), "card: is reserved, never emitted");
+        assert!(
+            !fm.contains("blocked:"),
+            "blocked: is reserved, never emitted"
+        );
+    }
+
+    #[test]
+    fn render_frontmatter_includes_every_resolved_field() {
+        let mut fields = base_fields("hash", "digest");
+        fields.branch = Some("feat/x");
+        fields.model = Some("claude-fable-5");
+        fields.harness = Some("2.1.220");
+        fields.approved_in = Some(("parent-name", "parent-sid"));
+        let fm = render_frontmatter(&fields);
+        assert!(fm.contains("branch: feat/x"));
+        assert!(fm.contains("model: claude-fable-5"));
+        assert!(fm.contains("harness: claude-code 2.1.220"));
+        assert!(fm.contains("approved_in: parent-name"));
+        assert!(fm.contains("approved_session_id: parent-sid"));
+    }
+
+    #[test]
+    fn render_document_places_body_after_the_closing_fence() {
+        let fields = base_fields("hash", "digest");
+        let doc = render_document(&fields, "# Title\n\nbody text");
+        let (frontmatter, body) = doc
+            .split_once("---\n\n")
+            .expect("closing fence + blank line");
+        assert!(frontmatter.starts_with("---\nstatus: in-flight"));
+        assert_eq!(body, "# Title\n\nbody text\n");
+    }
+
     // --- provenance: parent resolution ---
 
-    /// `model`/`harness_version` model the assistant line's `message.model`
-    /// and top-level `version` — both `None` reproduces the older transcript
-    /// shape that carries neither.
-    fn exit_plan_mode_line(
-        plan: &str,
-        model: Option<&str>,
-        harness_version: Option<&str>,
-    ) -> String {
-        let mut message = serde_json::json!({
-            "role": "assistant",
-            "content": [{"type": "tool_use", "name": "ExitPlanMode", "input": {"plan": plan}}]
-        });
-        if let Some(m) = model {
-            message["model"] = serde_json::json!(m);
-        }
-        let mut line = serde_json::json!({ "message": message });
-        if let Some(v) = harness_version {
-            line["version"] = serde_json::json!(v);
-        }
-        line.to_string()
+    fn exit_plan_mode_line(plan: &str) -> String {
+        serde_json::json!({
+            "message": {
+                "role": "assistant",
+                "content": [{"type": "tool_use", "name": "ExitPlanMode", "input": {"plan": plan}}],
+            }
+        })
+        .to_string()
     }
 
     #[test]
@@ -1262,67 +1623,13 @@ mod tests {
         let plan_text = "# Title\n\nbody text";
         let hash = sha256_hex(plan_text.as_bytes());
         let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
+        fs::write(&sibling, exit_plan_mode_line(plan_text)).unwrap();
 
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
         let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found,
-            Some(ParentTuple {
-                session_id: "parent-session-id".to_string(),
-                model: None,
-                harness_version: None,
-            })
-        );
-    }
-
-    #[test]
-    fn find_parent_extracts_model_and_harness_version_from_matched_line() {
-        // Real transcripts stamp the approving assistant line with both
-        // `message.model` and a top-level `version` — verified live against
-        // an actual ExitPlanMode transcript line (2026-07-20). A fixture
-        // carrying neither would pass this assertion vacuously, so both
-        // fields must be populated here.
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody text";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(
-            &sibling,
-            exit_plan_mode_line(plan_text, Some("claude-fable-5"), Some("2.1.214")),
-        )
-        .unwrap();
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found,
-            Some(ParentTuple {
-                session_id: "parent-session-id".to_string(),
-                model: Some("claude-fable-5".to_string()),
-                harness_version: Some("2.1.214".to_string()),
-            })
-        );
-    }
-
-    #[test]
-    fn find_parent_missing_model_and_harness_version_is_gracefully_none() {
-        // Older transcript lines (or a stripped-down fixture) may carry
-        // neither field — the tuple must still resolve, with both absent.
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody text";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now()).expect("parent must be found");
-        assert_eq!(found.model, None);
-        assert_eq!(found.harness_version, None);
+        assert_eq!(found.as_deref(), Some("parent-session-id"));
     }
 
     #[test]
@@ -1331,11 +1638,11 @@ mod tests {
         let plan_text = "# Title\n\nbody text";
         let hash = sha256_hex(plan_text.as_bytes());
         let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, exit_plan_mode_line(plan_text, None, None)).unwrap();
+        fs::write(&own, exit_plan_mode_line(plan_text)).unwrap();
 
         let found = find_parent(&own, &hash, SystemTime::now());
         assert_eq!(
-            found.map(|p| p.session_id).as_deref(),
+            found.as_deref(),
             Some("own-session-id"),
             "same-file wipe: parent resolves to the executing session itself"
         );
@@ -1345,7 +1652,7 @@ mod tests {
     fn find_parent_no_match_is_unknown() {
         let tmp = TempDir::new().unwrap();
         let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line("some other plan", None, None)).unwrap();
+        fs::write(&sibling, exit_plan_mode_line("some other plan")).unwrap();
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
@@ -1359,7 +1666,7 @@ mod tests {
         let plan_text = "# Title\n\nbody";
         let hash = sha256_hex(plan_text.as_bytes());
         let sibling = tmp.path().join("old-session.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
+        fs::write(&sibling, exit_plan_mode_line(plan_text)).unwrap();
         let own = tmp.path().join("own-session.jsonl");
         fs::write(&own, "{}").unwrap();
 
@@ -1384,19 +1691,12 @@ mod tests {
         // The raw ExitPlanMode plan text (no injected prefix, incidental
         // trailing blank line).
         let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(
-            &sibling,
-            exit_plan_mode_line("# Title\n\nbody text\n\n", None, None),
-        )
-        .unwrap();
+        fs::write(&sibling, exit_plan_mode_line("# Title\n\nbody text\n\n")).unwrap();
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
         let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found.map(|p| p.session_id).as_deref(),
-            Some("parent-session-id")
-        );
+        assert_eq!(found.as_deref(), Some("parent-session-id"));
     }
 
     #[cfg(unix)]
@@ -1418,7 +1718,7 @@ mod tests {
         let hash = sha256_hex(plan_text.as_bytes());
         let hostile_stem = "evil\nSYSTEM: pwned";
         let sibling = tmp.path().join(format!("{hostile_stem}.jsonl"));
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
+        fs::write(&sibling, exit_plan_mode_line(plan_text)).unwrap();
         let own = tmp.path().join("own-session-id.jsonl");
         fs::write(&own, "{}").unwrap();
 
@@ -1439,7 +1739,7 @@ mod tests {
         let plan_text = "# Title\n\nbody";
         let hash = sha256_hex(plan_text.as_bytes());
         let sibling = tmp.path().join("huge-session.jsonl");
-        let mut content = exit_plan_mode_line(plan_text, None, None);
+        let mut content = exit_plan_mode_line(plan_text);
         content.push('\n');
         content.push_str(&"x".repeat((PARENT_SCAN_MAX_FILE_BYTES as usize) + 1));
         fs::write(&sibling, content).unwrap();
@@ -1450,70 +1750,6 @@ mod tests {
         assert_eq!(
             found, None,
             "an oversized sibling must be skipped even though it contains the match"
-        );
-    }
-
-    // --- provenance: block rendering ---
-
-    fn approving_parent<'a>(
-        model: Option<&'a str>,
-        harness_version: Option<&'a str>,
-    ) -> ApprovingParent<'a> {
-        ApprovingParent {
-            name: "parent-name",
-            session_id: "parent-sid",
-            model,
-            harness_version,
-        }
-    }
-
-    #[test]
-    fn provenance_block_unknown_parent() {
-        let block = provenance_block(None, "own-name", "own-sid", "digest", "ts", "hash");
-        assert!(block.starts_with("Approved in: unknown\n"));
-        assert!(block.contains("Executing session: own-name (own-sid) @ digest"));
-        assert!(block.contains("Persisted: ts"));
-        assert!(block.contains("Plan-body-SHA256: hash"));
-    }
-
-    #[test]
-    fn provenance_block_found_parent_with_model_and_harness() {
-        let parent = approving_parent(Some("claude-fable-5"), Some("2.1.214"));
-        let block = provenance_block(Some(parent), "own-name", "own-sid", "digest", "ts", "hash");
-        assert!(block.starts_with(
-            "Approved in: parent-name (parent-sid) [claude-fable-5, claude-code 2.1.214] @ digest\n"
-        ));
-        // The executing-session line never carries model/harness — only name + id.
-        assert!(block.contains("Executing session: own-name (own-sid) @ digest"));
-    }
-
-    #[test]
-    fn provenance_block_found_parent_without_model_or_harness_omits_bracket() {
-        // Neither field resolved (e.g. an older transcript format) — the
-        // bracket segment must be omitted entirely, never rendered empty.
-        let parent = approving_parent(None, None);
-        let block = provenance_block(Some(parent), "own-name", "own-sid", "digest", "ts", "hash");
-        assert!(block.starts_with("Approved in: parent-name (parent-sid) @ digest\n"));
-        assert!(!block.contains('['), "no dangling/empty bracket: {block}");
-    }
-
-    #[test]
-    fn provenance_block_found_parent_with_model_only() {
-        let parent = approving_parent(Some("claude-fable-5"), None);
-        let block = provenance_block(Some(parent), "own-name", "own-sid", "digest", "ts", "hash");
-        assert!(
-            block.starts_with("Approved in: parent-name (parent-sid) [claude-fable-5] @ digest\n")
-        );
-    }
-
-    #[test]
-    fn provenance_block_found_parent_with_harness_only() {
-        let parent = approving_parent(None, Some("2.1.214"));
-        let block = provenance_block(Some(parent), "own-name", "own-sid", "digest", "ts", "hash");
-        assert!(
-            block.starts_with(
-                "Approved in: parent-name (parent-sid) [claude-code 2.1.214] @ digest\n"
-            )
         );
     }
 
@@ -1571,6 +1807,25 @@ mod tests {
         git(&["config", "user.name", "t"]);
     }
 
+    /// Crate-wide serialization lock for the `CADENCE_METRICS_DIR` env-mutating
+    /// tests, mirroring `cadence_hooks_metrics::common::ENV_LOCK`'s pattern —
+    /// this crate has its own env-mutating tests, so its own lock.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_metrics_dir<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        // SAFETY: serialized against every other test in this module via ENV_LOCK.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", dir);
+        }
+        let result = f();
+        // SAFETY: serialized against every other test in this module via ENV_LOCK.
+        unsafe {
+            std::env::remove_var("CADENCE_METRICS_DIR");
+        }
+        result
+    }
+
     #[test]
     fn end_to_end_fresh_write_produces_nudge_and_linkage_row() {
         let tmp = TempDir::new().unwrap();
@@ -1602,15 +1857,20 @@ mod tests {
 
         let written =
             fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
-        assert!(written.starts_with("# Fix the Widget"));
+        assert!(written.starts_with("---\nstatus: in-flight\n"));
+        assert!(written.contains("# Fix the Widget"));
         assert!(!written.contains("If this plan can be broken down"));
-        assert!(written.contains("Executing session:"));
-        assert!(written.contains("Plan-body-SHA256:"));
+        assert!(written.contains("session_id: child-session-id"));
+        assert!(written.contains("body_sha256:"));
+        assert!(
+            !written.contains("approved_in:"),
+            "no parent resolved — approved_in must be omitted, never written as 'unknown'"
+        );
         // Doctrine fix (cadence#248): the committed block carries the salted
         // digest, never the raw hostname.
         assert!(
             !written.contains("test-host"),
-            "the raw hostname must never reach the committed provenance block"
+            "the raw hostname must never reach the committed frontmatter"
         );
         assert!(written.contains(&crate::provenance::machine_digest("test-host")));
 
@@ -1698,22 +1958,218 @@ mod tests {
         assert!(!tmp.path().join("docs").exists(), "nothing written");
     }
 
-    /// Crate-wide serialization lock for the `CADENCE_METRICS_DIR` env-mutating
-    /// tests, mirroring `cadence_hooks_metrics::common::ENV_LOCK`'s pattern —
-    /// this crate has its own env-mutating tests, so its own lock.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // --- PersistPlanApproval: same-session PostToolUse trigger ---
 
-    fn with_metrics_dir<T>(dir: &Path, f: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        // SAFETY: serialized against every other test in this module via ENV_LOCK.
-        unsafe {
-            std::env::set_var("CADENCE_METRICS_DIR", dir);
+    fn exit_plan_mode_post_tool_use(
+        session_id: &str,
+        plan: &str,
+        cwd: &str,
+        transcript_path: &str,
+        is_agent: Option<bool>,
+    ) -> HookInput {
+        HookInput {
+            tool_name: Some("ExitPlanMode".into()),
+            tool_input: Some(ToolInput::default()),
+            tool_response: Some(ToolResponse {
+                plan: Some(plan.into()),
+                is_agent,
+                ..Default::default()
+            }),
+            session_id: Some(session_id.into()),
+            cwd: Some(cwd.into()),
+            transcript_path: Some(transcript_path.into()),
+            ..Default::default()
         }
-        let result = f();
-        // SAFETY: serialized against every other test in this module via ENV_LOCK.
-        unsafe {
-            std::env::remove_var("CADENCE_METRICS_DIR");
-        }
-        result
+    }
+
+    #[test]
+    fn approval_non_exit_plan_mode_tool_allows() {
+        let input = HookInput {
+            tool_name: Some("Bash".into()),
+            tool_response: Some(ToolResponse {
+                plan: Some("# X\n\nbody".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn approval_no_tool_response_plan_allows() {
+        let input = HookInput {
+            tool_name: Some("ExitPlanMode".into()),
+            ..Default::default()
+        };
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn approval_subagent_context_allows() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let input = exit_plan_mode_post_tool_use(
+            "sub-session-id",
+            "# X\n\nbody",
+            &cwd,
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            Some(true),
+        );
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(
+            !tmp.path().join("docs").exists(),
+            "a subagent's own plan approval must not persist"
+        );
+    }
+
+    #[test]
+    fn approval_no_cwd_allows() {
+        let input = HookInput {
+            tool_name: Some("ExitPlanMode".into()),
+            tool_response: Some(ToolResponse {
+                plan: Some("# X\n\nbody".into()),
+                ..Default::default()
+            }),
+            session_id: Some("sid".into()),
+            ..Default::default()
+        };
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn approval_non_git_repo_cwd_allows() {
+        let tmp = TempDir::new().unwrap();
+        let input = exit_plan_mode_post_tool_use(
+            "sid",
+            "# X\n\nbody",
+            &tmp.path().to_string_lossy(),
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            None,
+        );
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn approval_unsafe_session_id_allows() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let input = exit_plan_mode_post_tool_use(
+            "../escape",
+            "# X\n\nbody",
+            &cwd,
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            None,
+        );
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(!tmp.path().join("docs").exists(), "nothing written");
+    }
+
+    #[test]
+    fn approval_empty_plan_text_allows() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let input = exit_plan_mode_post_tool_use(
+            "sid",
+            "   \n\n  ",
+            &cwd,
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            None,
+        );
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn end_to_end_same_session_approval_persists_with_frontmatter() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+        let transcript_path = tmp.path().join("own-session-id.jsonl");
+        fs::write(&transcript_path, "{}").unwrap();
+
+        let input = exit_plan_mode_post_tool_use(
+            "own-session-id",
+            "# Fix the Widget\n\nDo the thing.",
+            &cwd,
+            &transcript_path.to_string_lossy(),
+            Some(false),
+        );
+
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let msg = r.message.unwrap();
+        assert!(msg.contains(&format!(
+            "approved in {}",
+            identity::generate_name("own-session-id")
+        )));
+
+        let written =
+            fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
+        assert!(written.starts_with("---\nstatus: in-flight\n"));
+        assert!(written.contains("# Fix the Widget"));
+        assert!(written.contains("session_id: own-session-id"));
+        assert!(written.contains(&format!(
+            "approved_in: {}",
+            identity::generate_name("own-session-id")
+        )));
+        assert!(written.contains("approved_session_id: own-session-id"));
+        assert!(written.contains(&crate::provenance::machine_digest("test-host")));
+
+        let links = fs::read_to_string(metrics_dir.path().join("plan-links.jsonl")).unwrap();
+        assert!(links.contains("\"parent_session_id\":\"own-session-id\""));
+        assert!(links.contains("\"child_session_id\":\"own-session-id\""));
+    }
+
+    #[test]
+    fn approval_double_fire_is_idempotent_skip_no_dash_two_file() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+        let transcript_path = tmp.path().join("own-session-id.jsonl");
+        fs::write(&transcript_path, "{}").unwrap();
+
+        let input = exit_plan_mode_post_tool_use(
+            "own-session-id",
+            "# Fix the Widget\n\nDo the thing.",
+            &cwd,
+            &transcript_path.to_string_lossy(),
+            Some(false),
+        );
+
+        with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host");
+        });
+        let first_write =
+            fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
+
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T01:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge, "re-fire still nudges");
+        assert!(
+            !tmp.path()
+                .join("docs/plans/2026-07-20-fix-the-widget-2.md")
+                .exists(),
+            "double-fire of the same approval must not ladder to a duplicate file"
+        );
+        let second_write =
+            fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
+        assert_eq!(
+            first_write, second_write,
+            "the file must never be rewritten"
+        );
     }
 }

--- a/crates/session/src/warn_commit_provenance.rs
+++ b/crates/session/src/warn_commit_provenance.rs
@@ -358,6 +358,43 @@ fn parse_ai_agent_version(value: &str) -> Option<String> {
     (!version_part.is_empty()).then(|| version_part.replace('-', "."))
 }
 
+/// Serializes tests that mutate the process-global `AI_AGENT` env var,
+/// mirroring `guardrails::guard_read_model`'s `ENV_LOCK`/`with_env` pattern.
+///
+/// `pub(crate)` and hoisted OUT of this module's own `mod tests` (rather than
+/// each test module defining its own private lock) so `persist_plan`'s tests
+/// — which exercise the SAME `resolve_harness` AI_AGENT fallback via a
+/// different call path — serialize against this exact lock. Both modules
+/// compile into one `cadence-hooks-session` test binary, and `cargo test`
+/// runs its tests multi-threaded by default: two independently-locked env
+/// mutators would not actually be mutually exclusive, just each internally
+/// consistent — a real flakiness risk for a process-global var, not a
+/// theoretical one (cameronsjo/cadence-hooks#396 review).
+#[cfg(test)]
+pub(crate) static AI_AGENT_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+#[cfg(test)]
+pub(crate) fn with_ai_agent_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
+    let _guard = AI_AGENT_ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+    let prior = std::env::var("AI_AGENT").ok();
+    // SAFETY: serialized via AI_AGENT_ENV_LOCK; restored below.
+    unsafe {
+        match value {
+            Some(v) => std::env::set_var("AI_AGENT", v),
+            None => std::env::remove_var("AI_AGENT"),
+        }
+    }
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    // SAFETY: same lock still held; restoring prior state.
+    unsafe {
+        match prior {
+            Some(v) => std::env::set_var("AI_AGENT", v),
+            None => std::env::remove_var("AI_AGENT"),
+        }
+    }
+    result.unwrap_or_else(|e| std::panic::resume_unwind(e))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -689,31 +726,12 @@ mod tests {
     }
 
     // --- AI_AGENT env fallback (process-global — serialized + restored) ---
-
-    /// Serializes tests that mutate the `AI_AGENT` env var, mirroring
-    /// `guardrails::guard_read_model`'s `ENV_LOCK`/`with_env` pattern.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn with_ai_agent_env<T>(value: Option<&str>, f: impl FnOnce() -> T) -> T {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let prior = std::env::var("AI_AGENT").ok();
-        // SAFETY: serialized via ENV_LOCK; restored below.
-        unsafe {
-            match value {
-                Some(v) => std::env::set_var("AI_AGENT", v),
-                None => std::env::remove_var("AI_AGENT"),
-            }
-        }
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-        // SAFETY: same lock still held; restoring prior state.
-        unsafe {
-            match prior {
-                Some(v) => std::env::set_var("AI_AGENT", v),
-                None => std::env::remove_var("AI_AGENT"),
-            }
-        }
-        result.unwrap_or_else(|e| std::panic::resume_unwind(e))
-    }
+    //
+    // `with_ai_agent_env`/`AI_AGENT_ENV_LOCK` now live at the module level
+    // (above `mod tests`), `pub(crate)`, so `persist_plan`'s tests share the
+    // exact same lock — see that definition's doc for why a second,
+    // independently-locked copy here would be a real cross-module race, not
+    // just a duplicate. `use super::*` brings both into scope in this module.
 
     // --- CADENCE_MARKER_DIR (process-global — serialized + restored) ---
 

--- a/crates/session/src/warn_commit_provenance.rs
+++ b/crates/session/src/warn_commit_provenance.rs
@@ -323,7 +323,11 @@ fn resolve_session_name_and_id(input: &HookInput) -> Option<(String, String)> {
 /// pattern as `guardrails::guard_read_model::GuardReadModel::run`. Takes the
 /// already-read transcript content rather than re-reading the file, so a
 /// single run resolves both `Model:` and `Harness:` off one read.
-fn resolve_model(transcript_content: Option<&str>) -> Option<String> {
+///
+/// `pub(crate)`: `persist_plan`'s frontmatter emitter reuses this rather than
+/// re-deriving model resolution a second way (cadence-hooks#396's "reuse the
+/// existing provenance machinery" design point).
+pub(crate) fn resolve_model(transcript_content: Option<&str>) -> Option<String> {
     transcript::last_assistant_model(transcript_content?)
 }
 
@@ -332,7 +336,9 @@ fn resolve_model(transcript_content: Option<&str>) -> Option<String> {
 /// (`claude-code_2-1-215_agent` → `2.1.215`) when the transcript doesn't
 /// resolve it. `None` when neither source yields a version — the `Harness:`
 /// line is then omitted entirely rather than rendered from a guess.
-fn resolve_harness(transcript_content: Option<&str>) -> Option<String> {
+///
+/// `pub(crate)`: shared with `persist_plan` — see [`resolve_model`].
+pub(crate) fn resolve_harness(transcript_content: Option<&str>) -> Option<String> {
     if let Some(content) = transcript_content
         && let Some(version) = transcript::last_assistant_harness_version(content)
     {

--- a/src/main.rs
+++ b/src/main.rs
@@ -353,6 +353,8 @@ enum SessionCommands {
     BackstopWarn,
     /// Persist an approved plan whose post-approval turn was wiped (UserPromptSubmit)
     PersistPlan,
+    /// Persist an approved plan on same-session approval (PostToolUse:ExitPlanMode)
+    PersistPlanApproval,
     /// Declare what this session is working on, so peers can assess collision risk
     Declare {
         /// What this session is working on (e.g. "cadence-hooks#54")
@@ -458,6 +460,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             SessionCommands::BackstopRecord => "backstop-record",
             SessionCommands::BackstopWarn => "backstop-warn",
             SessionCommands::PersistPlan => "persist-plan",
+            SessionCommands::PersistPlanApproval => "persist-plan-approval",
             // declare and status are CLI actions, not hooks — no hooks.json
             // wiring and not subject to CADENCE_DISABLE (same treatment as
             // dismiss-main-branch-warn).
@@ -1157,6 +1160,11 @@ fn main() {
             SessionCommands::PersistPlan => dispatch::run_logged_check(
                 &cadence_hooks_session::persist_plan::PersistPlan,
                 user_prompt_submit,
+                canonical_hook,
+            ),
+            SessionCommands::PersistPlanApproval => dispatch::run_logged_check(
+                &cadence_hooks_session::persist_plan::PersistPlanApproval,
+                post,
                 canonical_hook,
             ),
             SessionCommands::Declare {

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -411,6 +411,12 @@ pub const HOOKS: &[HookEntry] = &[
         plugin: "session",
         event: Some(HookEvent::UserPromptSubmit),
     },
+    HookEntry {
+        name: "persist-plan-approval",
+        description: "Persist an approved plan on same-session approval (PostToolUse:ExitPlanMode)",
+        plugin: "session",
+        event: Some(HookEvent::PostToolUse),
+    },
 ];
 
 /// The registry entry for `<namespace> <subcommand>`, if one exists.
@@ -525,6 +531,16 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         // real checkout exercises the actual extraction and write.
         ("session", "persist-plan") => Some(
             r#"{"session_id":"test","prompt":"Implement the following plan:\n\n# Try Sample\n\nbody text","cwd":"/tmp","transcript_path":"/tmp/test.jsonl"}"#,
+        ),
+        // persist-plan-approval gates on tool_name == "ExitPlanMode" and a
+        // non-empty tool_response.plan; the generic PostToolUse sample carries
+        // neither, so `try` would fail open before the write path.
+        ("session", "persist-plan-approval") => Some(
+            // Extra `#` in the raw-string delimiter: the payload's own plan
+            // text embeds a literal `"#` (a quote immediately followed by an
+            // ATX heading marker), which would otherwise close a `r#"..."#`
+            // raw string early.
+            r##"{"session_id":"test","tool_name":"ExitPlanMode","cwd":"/tmp","transcript_path":"/tmp/test.jsonl","tool_response":{"plan":"# Try Sample\n\nbody text","isAgent":false}}"##,
         ),
         // warn-subagent-worktree only engages on an Agent/Task spawn; the generic
         // Bash PreToolUse sample would no-op. Carry a cwd so the git checks have a


### PR DESCRIPTION
## Summary

- Cameron's approve-and-clear path (`PersistPlan`, `UserPromptSubmit`, exact-prefix gate) only ever fires on a cross-session wipe: the harness re-injects a fresh prompt in a NEW session. Same-session plan approval — the harness stays put and injects nothing — structurally never matches that gate. A live probe recorded on this issue established that `PostToolUse:ExitPlanMode` DOES fire on same-session approval, carrying the plan text in `tool_response.plan` (`tool_input.plan` is empty on this path).
- Adds a sibling `Check` (`PersistPlanApproval`, CLI subcommand `session persist-plan-approval`, `PostToolUse` event) that consumes `tool_response.plan` directly, skips subagent-context approvals (`tool_response.isAgent`), and shares a refactored persist core with the existing trigger (target claiming, the `plan-links.jsonl` row, the nudge).
- Both triggers now emit YAML frontmatter instead of the old plain-text provenance trailer — `status`, `updated`, `branch`, `body_sha256`, `session`/`session_id`, `model`/`harness` (the executing tuple), `machine`, and `approved_in`/`approved_session_id` (the approving identity — same as the executing tuple on same-session approval, the resolved sibling on a cross-session wipe). Unresolved optional fields are omitted, never written as a placeholder.
- Idempotency's reader now anchors on the LEADING frontmatter block's `body_sha256` key first (bounded scan, never a whole-document scan), falling back to the legacy trailing `Plan-body-SHA256:` line for documents already on disk in the old format, then a recompute for anything with neither marker. This is deliberate: a living plan's body now grows by design (ticked checkboxes, appended `## Deviations`/`## Learnings`), and a whole-document scan would either be spoofable by a body-authored decoy or wrongly defeated by legitimate growth. Both triggers normalize to byte-identical text before hashing (same `strip_trailing_suffix_lines_and_trim` applied to both the extracted UserPromptSubmit body and the raw `tool_response.plan`), so a plan approved through either path is recognized as the same re-fire.

## Subcommand-shape decision

Went with a **sibling subcommand** (`persist-plan-approval`) rather than branching the existing `persist-plan` subcommand on `hook_event_name`, for two reasons:

1. The CLI dispatch binds a fixed `HookEvent` per subcommand at the call site (`dispatch::run_logged_check(check, event, ...)`), and that event flows into `render_output`'s `hookEventName` field in the nudge envelope. Branching one subcommand across two real events would mean either hardcoding the wrong `hookEventName` for one of them or threading the payload's own `hook_event_name` back into the render call — a bigger, riskier change to the shared core than a second `Check` impl.
2. This repo already has precedent for the same-concept/different-event split: `backstop-record` (SessionEnd) and `backstop-warn` (SessionStart) are two subcommands for one feature, not one subcommand branching on event. `persist-plan` / `persist-plan-approval` follows the same shape.

The registry's `only_loggers_have_no_event` test requires every non-logger entry to declare a single `Some(HookEvent)` — a shared subcommand couldn't satisfy that cleanly either.

## Test summary

`cargo test -p cadence-hooks-session` (my primary target): **293 passed, 0 failed** (67 of those in `persist_plan::tests`, all green) — the pre-existing 3 failures in `start::tests` (`posture_line_fires_in_primary_checkout` etc.) reproduce identically on a clean, unmodified `origin/main` worktree checked out at the same path, confirmed by a side-by-side baseline run; unrelated to this change.

`cargo test --workspace`: everything green except:
- `hook_registration_audit::all_binary_subcommands_are_registered` — expected. The new `session persist-plan-approval` subcommand isn't wired into any `hooks.json` yet; that's the wiring PR in `cameronsjo/cadence` (the documented two-PR shape for new cadence-hooks checks).
- `cadence_hooks_core::worktree::tests::*` (5) and `cadence_hooks_guardrails::enforce_worktree::tests::*` (61) and `warn_branch_base::tests::*` (2) — pre-existing, path-dependent failures confirmed to reproduce identically on a clean `origin/main` worktree at this same scratch location (verified via a side-by-side baseline `git worktree add ... origin/main`), unrelated to this diff.

`cargo fmt --all -- --check`: clean. `cargo clippy --workspace --all-targets -- -D warnings`: clean, zero warnings.

## Files changed

- `crates/core/src/lib.rs` — `ToolResponse` gains `plan`/`filePath`/`isAgent`/`hasTaskTool`; `HookInput::tool_response_plan()` accessor.
- `crates/session/src/persist_plan.rs` — the bulk of the change: shared persist core, frontmatter render/parse, the new `PersistPlanApproval` Check, simplified parent resolution (dropped now-unused model/harness capture from the sibling-transcript scan, since frontmatter's `approved_in` doesn't render a model/harness bracket).
- `crates/session/src/warn_commit_provenance.rs` — `resolve_model`/`resolve_harness` made `pub(crate)` so `persist_plan` reuses the same model/harness resolution machinery instead of re-deriving it.
- `crates/session/src/lib.rs` — module doc table + doc-comment update.
- `src/main.rs`, `src/registry.rs` — new `PersistPlanApproval` CLI variant, dispatch wiring, registry entry + `try` sample payload.

## Deviations from the dispatch spec

None load-bearing. One scope note: the dispatch's step 1 said the shared core covers "claim_target + provenance + plan-links row + write" — I also folded in the frontmatter *emission* itself (not just its plumbing) since Design record item 2 requires the SAME format from both triggers, and doing that required touching `render` logic the old `run_persist_plan` owned outright. The dispatch's own step 3 anticipated this ("Frontmatter emission ... replacing the plain-line trailer").

Closes cameronsjo/cadence-hooks#396

Session-Name: hollow-lantern
Session-Id: 38bacaf0-7e04-40fe-a253-b89688207347
Model: claude-sonnet-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7