### PR TITLE
fix(audit): allowlist session persist-plan-approval cross-plugin dispatch

### DIFF
--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -275,6 +275,15 @@ const INTENTIONAL_CROSS_PLUGIN_HOOKS: &[(&str, &str, &str)] = &[
         "session persist-plan",
         "must ride the always-on cadence plugin; `session` is its clap namespace",
     ),
+    // Same rationale as its sibling above: the approval hook rides the
+    // always-on cadence plugin while `session` owns plan/session state.
+    // Wiring shipped in the cadence monorepo without this entry, leaving the
+    // audit red for any workspace with a current sibling checkout (#460).
+    (
+        "cadence",
+        "session persist-plan-approval",
+        "must ride the always-on cadence plugin; `session` is its clap namespace",
+    ),
     // Predates the monorepo consolidation (present in canon's manifest at the
     // subtree-add commit f61b5f6), canon is its only registrar anywhere, and it
     // sits in canon's SessionStart block beside `session start` and `session


### PR DESCRIPTION
One-tuple addition to INTENTIONAL_CROSS_PLUGIN_HOOKS with the same rationale as its persist-plan sibling — the approval hook's monorepo wiring shipped without it, so the sibling-dependent audit was red for every local workspace (CI skips it, which is why the gap survived). Verified: the failing test passes against the live sibling checkout with this entry. Test-only change; no version bump. Polish marker records the focused pass (single-tuple test-file diff, verified by running the exact failing test).

Closes #460

Session-Name: frost-garden
Session-Id: edcb9ba4-cf2a-481e-a0a0-a9380780af12
Model: claude-fable-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7