### PR TITLE
chore: gitignore agent-memory + repo-domain redaction allowlist

### DIFF
--- a/.claude/cadence.json
+++ b/.claude/cadence.json
@@ -1,0 +1,9 @@
+{
+  "version": 1,
+  "redaction": {
+    "allowlist": [
+      "tool_input",
+      "tool_response"
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .DS_Store
 .review-loop.local.md
 .claude/intros/
+.claude/agent-memory/


### PR DESCRIPTION
## Summary

Two verified hygiene items:

- **.gitignore** (#431): adds `.claude/agent-memory/` — the primary checkout already carries six accumulated reviewer-agent memory dirs that `git add -A` would stage. Verified the pattern matches via `git check-ignore -v` (exit 0).
- **.claude/cadence.json** (#436, new file): repo-domain redaction allowlist carrying exactly the two literals the issue names — `tool_input` and `tool_response`, which are field names on this repo's own `HookInput` struct and unavoidable in its commit/PR prose. The issue's other example ('a config-dir path') names no specific literal and would need a category-wide `local-path` ceiling override — a redaction-coverage scope call deliberately NOT made here; re-file with the concrete term if wanted.

Closes #431, closes #436

## Verification

`cargo test --workspace`: 565 passed, 5 failed — the 5 are the known /tmp-worktree self-check (#403), proven pre-existing by stash-and-rerun with an identical panic on a clean tree. No regression from this diff (gitignore + new JSON config only).

Session-Name: issue-slate-campaign
Session-Id: ecc24a74-e772-4644-b6ed-342b00644f0b
Model: claude-sonnet-5 (implementation) / claude-fable-5 (orchestration)
Harness: claude-code 2.1.220
Machine: cf6e768835c7