### PR TITLE
test: env-lock unification, audit tokenize, spawn bound, marker guards

### DIFF
--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -393,16 +393,27 @@ mod tests {
 
     #[test]
     fn session_marker_differs_per_session() {
-        let a = session_marker(&input_with_session("sid-a"), "kind", Some("/tmp/repo"));
-        let b = session_marker(&input_with_session("sid-b"), "kind", Some("/tmp/repo"));
-        assert_ne!(a, b, "distinct sessions must not share a marker");
+        // session_marker() reads marker_dir() (CADENCE_MARKER_DIR), so hold the
+        // shared lock via with_marker_dir even though the assertion only compares
+        // two markers — an unguarded read races a concurrent with_marker_dir
+        // test flipping the base mid-comparison (#373).
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let a = session_marker(&input_with_session("sid-a"), "kind", Some("/tmp/repo"));
+            let b = session_marker(&input_with_session("sid-b"), "kind", Some("/tmp/repo"));
+            assert_ne!(a, b, "distinct sessions must not share a marker");
+        });
     }
 
     #[test]
     fn session_marker_differs_per_repo() {
-        let a = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo-a"));
-        let b = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo-b"));
-        assert_ne!(a, b, "distinct repos must not share a marker");
+        // See session_marker_differs_per_session: guard the marker_dir() read.
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let a = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo-a"));
+            let b = session_marker(&input_with_session("sid"), "kind", Some("/tmp/repo-b"));
+            assert_ne!(a, b, "distinct repos must not share a marker");
+        });
     }
 
     #[test]
@@ -452,16 +463,25 @@ mod tests {
 
     #[test]
     fn polish_marker_differs_per_branch() {
-        let a = polish_marker("/tmp/repo", "branch-a");
-        let b = polish_marker("/tmp/repo", "branch-b");
-        assert_ne!(a, b, "distinct branches must not share a marker");
+        // polish_marker() reads marker_dir() (CADENCE_MARKER_DIR); guard the
+        // read the same way as session_marker_differs_per_session (#373).
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let a = polish_marker("/tmp/repo", "branch-a");
+            let b = polish_marker("/tmp/repo", "branch-b");
+            assert_ne!(a, b, "distinct branches must not share a marker");
+        });
     }
 
     #[test]
     fn polish_marker_differs_per_repo() {
-        let a = polish_marker("/tmp/repo-a", "main");
-        let b = polish_marker("/tmp/repo-b", "main");
-        assert_ne!(a, b, "distinct repos must not share a marker");
+        // See polish_marker_differs_per_branch: guard the marker_dir() read.
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let a = polish_marker("/tmp/repo-a", "main");
+            let b = polish_marker("/tmp/repo-b", "main");
+            assert_ne!(a, b, "distinct repos must not share a marker");
+        });
     }
 
     #[test]

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -2892,8 +2892,9 @@ mod tests {
 
     // GhWriteGuard.run() reads CADENCE_ALLOWED_OWNERS / CADENCE_ALLOWED_REPOS
     // / CADENCE_EXTRA_HOSTS via process-global env vars. Serialize all
-    // metadata-shape tests so they don't race each other.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // metadata-shape tests via the crate-shared CADENCE_ALLOWLIST_TEST_LOCK so
+    // they don't race each other or the same globals mutated in
+    // guard_push_remote / warn_issue_tracker (#446).
 
     fn input_with(command: &str, cwd: &str) -> HookInput {
         // Build via JSON to avoid private-field gymnastics; the real hook
@@ -2907,13 +2908,15 @@ mod tests {
     }
 
     fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::CADENCE_ALLOWLIST_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let prior: Vec<(String, Option<String>)> = vars
             .iter()
             .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
             .collect();
         for (k, v) in vars {
-            // SAFETY: serialized via ENV_LOCK; restored below.
+            // SAFETY: serialized via CADENCE_ALLOWLIST_TEST_LOCK; restored below.
             unsafe {
                 match v {
                     Some(val) => std::env::set_var(k, val),

--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -2888,12 +2888,13 @@ mod tests {
 
     // --- BlockMetadata payloads on hard blocks ---
 
+    use crate::with_env;
     use cadence_hooks_core::HookInput;
 
     // GhWriteGuard.run() reads CADENCE_ALLOWED_OWNERS / CADENCE_ALLOWED_REPOS
     // / CADENCE_EXTRA_HOSTS via process-global env vars. Serialize all
-    // metadata-shape tests via the crate-shared CADENCE_ALLOWLIST_TEST_LOCK so
-    // they don't race each other or the same globals mutated in
+    // metadata-shape tests via the crate-shared with_env/CADENCE_ENV_TEST_LOCK
+    // so they don't race each other or the same globals mutated in
     // guard_push_remote / warn_issue_tracker (#446).
 
     fn input_with(command: &str, cwd: &str) -> HookInput {
@@ -2905,38 +2906,6 @@ mod tests {
             "cwd": cwd,
         });
         serde_json::from_value(json).expect("HookInput deserializes")
-    }
-
-    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = crate::CADENCE_ALLOWLIST_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let prior: Vec<(String, Option<String>)> = vars
-            .iter()
-            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
-            .collect();
-        for (k, v) in vars {
-            // SAFETY: serialized via CADENCE_ALLOWLIST_TEST_LOCK; restored below.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-        for (k, v) in prior {
-            // SAFETY: same lock still held; we're restoring the prior state.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(&k, val),
-                    None => std::env::remove_var(&k),
-                }
-            }
-        }
-        if let Err(payload) = result {
-            std::panic::resume_unwind(payload);
-        }
     }
 
     #[test]

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -799,44 +799,13 @@ mod tests {
     // --- PushRemoteGuard::run(): explicit-URL ownership (#68) ---
     //
     // run() reads CADENCE_ALLOWED_OWNERS from the process-global environment,
-    // so these tests serialize via the crate-shared CADENCE_ALLOWLIST_TEST_LOCK
+    // so these tests serialize via the crate-shared with_env/CADENCE_ENV_TEST_LOCK
     // and restore prior values (#446). They run inside this crate's checkout
     // (a real git repo) so run()'s `rev-parse --git-dir` gate passes; the
     // explicit URL is validated directly and never resolves through a remote.
 
+    use crate::with_env;
     use cadence_hooks_core::test_builders::make_bash_with_cwd;
-
-    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = crate::CADENCE_ALLOWLIST_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let prior: Vec<(String, Option<String>)> = vars
-            .iter()
-            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
-            .collect();
-        for (k, v) in vars {
-            // SAFETY: serialized via CADENCE_ALLOWLIST_TEST_LOCK; restored below.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-        for (k, v) in prior {
-            // SAFETY: same lock still held; restoring prior state.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(&k, val),
-                    None => std::env::remove_var(&k),
-                }
-            }
-        }
-        if let Err(payload) = result {
-            std::panic::resume_unwind(payload);
-        }
-    }
 
     /// Allowlist = `cameronsjo` only, on the default `github.com` host.
     fn owners_only() -> Vec<(&'static str, Option<&'static str>)> {

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -799,23 +799,23 @@ mod tests {
     // --- PushRemoteGuard::run(): explicit-URL ownership (#68) ---
     //
     // run() reads CADENCE_ALLOWED_OWNERS from the process-global environment,
-    // so these tests serialize via ENV_LOCK and restore prior values. They run
-    // inside this crate's checkout (a real git repo) so run()'s
-    // `rev-parse --git-dir` gate passes; the explicit URL is validated directly
-    // and never resolves through a remote.
+    // so these tests serialize via the crate-shared CADENCE_ALLOWLIST_TEST_LOCK
+    // and restore prior values (#446). They run inside this crate's checkout
+    // (a real git repo) so run()'s `rev-parse --git-dir` gate passes; the
+    // explicit URL is validated directly and never resolves through a remote.
 
     use cadence_hooks_core::test_builders::make_bash_with_cwd;
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
     fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::CADENCE_ALLOWLIST_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let prior: Vec<(String, Option<String>)> = vars
             .iter()
             .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
             .collect();
         for (k, v) in vars {
-            // SAFETY: serialized via ENV_LOCK; restored below.
+            // SAFETY: serialized via CADENCE_ALLOWLIST_TEST_LOCK; restored below.
             unsafe {
                 match v {
                     Some(val) => std::env::set_var(k, val),

--- a/crates/guardrails/src/guard_read_model.rs
+++ b/crates/guardrails/src/guard_read_model.rs
@@ -375,41 +375,12 @@ mod tests {
     //
     // run() reads the three CADENCE_READ_MODEL_GUARD_* vars from the
     // process-global environment, so every run()-based test serializes via
-    // ENV_LOCK and explicitly pins all three (restoring prior values) — this
-    // keeps the disabled-guard assertions deterministic even if the ambient env
-    // has MODELS set, and free of races with parallel tests.
+    // the crate-shared with_env/CADENCE_ENV_TEST_LOCK and explicitly pins all
+    // three (restoring prior values) — this keeps the disabled-guard
+    // assertions deterministic even if the ambient env has MODELS set, and
+    // free of races with parallel tests (#446).
 
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let prior: Vec<(String, Option<String>)> = vars
-            .iter()
-            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
-            .collect();
-        for (k, v) in vars {
-            // SAFETY: serialized via ENV_LOCK; restored below.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-        for (k, v) in prior {
-            // SAFETY: same lock still held; restoring prior state.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(&k, val),
-                    None => std::env::remove_var(&k),
-                }
-            }
-        }
-        if let Err(payload) = result {
-            std::panic::resume_unwind(payload);
-        }
-    }
+    use crate::with_env;
 
     /// Pin all three guard vars — a common base the per-test overrides adjust.
     fn guard_env(

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -11,15 +11,64 @@
 #[cfg(test)]
 pub(crate) static CADENCE_ALLOW_MAIN_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
-/// Shared test lock serializing every test that mutates the process-global
-/// `CADENCE_ALLOWED_OWNERS` / `CADENCE_ALLOWED_REPOS` / `CADENCE_EXTRA_HOSTS`
-/// allowlist env vars — read by `guard_push_remote`, `guard_gh_write`, and
-/// `warn_issue_tracker`. These three modules used to mint separate
-/// module-local `ENV_LOCK`s over the *same* shared globals, which provide no
-/// mutual exclusion under cargo's parallel test runner (cadence-hooks#446,
-/// same root cause as #298); one crate-shared lock serializes them all.
+/// Shared test lock serializing every test in this crate that mutates a
+/// process-global env var OUTSIDE the `CADENCE_ALLOW_MAIN` family above
+/// (`guard_push_remote`, `guard_gh_write`, `warn_issue_tracker`,
+/// `warn_subagent_worktree`, `warn_going_public`, `warn_subagent_concurrency`,
+/// `guard_read_model` — seven modules, seven different var sets). Each used
+/// to mint its own module-local `ENV_LOCK`, on the theory that disjoint var
+/// sets need no shared exclusion — but that theory lives only in a doc
+/// comment, and the moment two modules' vars overlap (or a future edit adds
+/// one that does), the failure is a silent flake under cargo's parallel test
+/// runner, not a compile error (cadence-hooks#446, same root cause as #298).
+/// One lock removes the need to keep proving disjointness — mirrors the
+/// ruling `crates/metrics/src/common.rs` already made for its own env-mutating
+/// tests (one crate-wide `ENV_LOCK`, not one per var family).
 #[cfg(test)]
-pub(crate) static CADENCE_ALLOWLIST_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+static CADENCE_ENV_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Run `f` with each `(key, value)` in `vars` set (`None` removes the var),
+/// serialized against every other env-mutating test in this crate via
+/// [`CADENCE_ENV_TEST_LOCK`], and restore the *prior* value of each var
+/// afterward — panic-safe via `catch_unwind`, so a failing `f` still restores
+/// rather than leaking state into the next test in the same binary.
+///
+/// The single shared implementation for every module whose tests fit this
+/// vars-slice shape. Mirrors `core::test_builders::with_marker_dir`'s
+/// discipline: the lock lives behind this one function so a module cannot
+/// mint a rival — `use crate::with_env;`, never a module-local copy.
+#[cfg(test)]
+pub(crate) fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
+    let _guard = CADENCE_ENV_TEST_LOCK
+        .lock()
+        .unwrap_or_else(|p| p.into_inner());
+    let prior: Vec<(String, Option<String>)> = vars
+        .iter()
+        .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
+        .collect();
+    for (k, v) in vars {
+        // SAFETY: serialized via CADENCE_ENV_TEST_LOCK; restored below.
+        unsafe {
+            match v {
+                Some(val) => std::env::set_var(k, val),
+                None => std::env::remove_var(k),
+            }
+        }
+    }
+    let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
+    for (k, v) in prior {
+        // SAFETY: same lock still held; restoring prior state.
+        unsafe {
+            match v {
+                Some(val) => std::env::set_var(&k, val),
+                None => std::env::remove_var(&k),
+            }
+        }
+    }
+    if let Err(payload) = result {
+        std::panic::resume_unwind(payload);
+    }
+}
 
 /// Per-repo snooze command + helper consumed by `enforce_worktree`.
 pub mod dismiss_enforce_worktree;

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -11,6 +11,16 @@
 #[cfg(test)]
 pub(crate) static CADENCE_ALLOW_MAIN_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+/// Shared test lock serializing every test that mutates the process-global
+/// `CADENCE_ALLOWED_OWNERS` / `CADENCE_ALLOWED_REPOS` / `CADENCE_EXTRA_HOSTS`
+/// allowlist env vars — read by `guard_push_remote`, `guard_gh_write`, and
+/// `warn_issue_tracker`. These three modules used to mint separate
+/// module-local `ENV_LOCK`s over the *same* shared globals, which provide no
+/// mutual exclusion under cargo's parallel test runner (cadence-hooks#446,
+/// same root cause as #298); one crate-shared lock serializes them all.
+#[cfg(test)]
+pub(crate) static CADENCE_ALLOWLIST_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
 /// Per-repo snooze command + helper consumed by `enforce_worktree`.
 pub mod dismiss_enforce_worktree;
 /// Per-repo snooze command + helper consumed by `warn_main_branch`.

--- a/crates/guardrails/src/warn_going_public.rs
+++ b/crates/guardrails/src/warn_going_public.rs
@@ -225,42 +225,13 @@ fn nudge_message(term: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::with_env;
     use cadence_hooks_core::test_builders::make_bash;
 
-    // Serialize tests that mutate CADENCE_GOING_PUBLIC_TERMS / _IGNORE so they
-    // don't race each other (env is process-global). Per-file ENV_LOCK, matching
-    // the pattern on origin/main.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
-
-    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
-        let prior: Vec<(String, Option<String>)> = vars
-            .iter()
-            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
-            .collect();
-        for (k, v) in vars {
-            // SAFETY: serialized via ENV_LOCK; restored in the block below.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-        for (k, v) in prior {
-            // SAFETY: same lock still held; restoring prior state.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(&k, val),
-                    None => std::env::remove_var(&k),
-                }
-            }
-        }
-        if let Err(payload) = result {
-            std::panic::resume_unwind(payload);
-        }
-    }
+    // Tests that mutate CADENCE_GOING_PUBLIC_TERMS / _IGNORE serialize via the
+    // crate-shared with_env/CADENCE_ENV_TEST_LOCK so they don't race each
+    // other (env is process-global) or the globals mutated elsewhere in this
+    // crate (#446).
 
     fn outcome(cmd: &str) -> cadence_hooks_core::Outcome {
         GoingPublicGuard.run(&make_bash(cmd)).outcome

--- a/crates/guardrails/src/warn_issue_tracker.rs
+++ b/crates/guardrails/src/warn_issue_tracker.rs
@@ -246,17 +246,20 @@ mod tests {
     use std::path::PathBuf;
 
     // Serialize tests that mutate CADENCE_ALLOWED_OWNERS / CADENCE_ISSUE_TRACKER(S)
-    // so they don't race each other.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // via the crate-shared CADENCE_ALLOWLIST_TEST_LOCK so they don't race each
+    // other or the same globals mutated in guard_push_remote / guard_gh_write
+    // (#446).
 
     fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::CADENCE_ALLOWLIST_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let prior: Vec<(String, Option<String>)> = vars
             .iter()
             .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
             .collect();
         for (k, v) in vars {
-            // SAFETY: serialized via ENV_LOCK; restored in the block below.
+            // SAFETY: serialized via CADENCE_ALLOWLIST_TEST_LOCK; restored in the block below.
             unsafe {
                 match v {
                     Some(val) => std::env::set_var(k, val),
@@ -668,7 +671,8 @@ mod tests {
 
     // ---- nudge message format ----
     // These tests call canonical() which reads CADENCE_ISSUE_TRACKER — serialize
-    // with ENV_LOCK and clear the var so concurrent env-mutating tests don't race.
+    // with CADENCE_ALLOWLIST_TEST_LOCK and clear the var so concurrent
+    // env-mutating tests don't race.
 
     #[test]
     fn nudge_message_names_the_check() {

--- a/crates/guardrails/src/warn_issue_tracker.rs
+++ b/crates/guardrails/src/warn_issue_tracker.rs
@@ -241,46 +241,15 @@ mod tests {
     use cadence_hooks_core::test_builders::make_bash;
     // make_bash_with_cwd is only used by the non-windows cwd test below; gate the
     // import to match, or clippy's -D unused-imports fails the Windows build.
+    use crate::with_env;
     #[cfg(not(windows))]
     use cadence_hooks_core::test_builders::make_bash_with_cwd;
     use std::path::PathBuf;
 
-    // Serialize tests that mutate CADENCE_ALLOWED_OWNERS / CADENCE_ISSUE_TRACKER(S)
-    // via the crate-shared CADENCE_ALLOWLIST_TEST_LOCK so they don't race each
-    // other or the same globals mutated in guard_push_remote / guard_gh_write
-    // (#446).
-
-    fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
-        let _guard = crate::CADENCE_ALLOWLIST_TEST_LOCK
-            .lock()
-            .unwrap_or_else(|p| p.into_inner());
-        let prior: Vec<(String, Option<String>)> = vars
-            .iter()
-            .map(|(k, _)| ((*k).to_string(), std::env::var(*k).ok()))
-            .collect();
-        for (k, v) in vars {
-            // SAFETY: serialized via CADENCE_ALLOWLIST_TEST_LOCK; restored in the block below.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(k, val),
-                    None => std::env::remove_var(k),
-                }
-            }
-        }
-        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(f));
-        for (k, v) in prior {
-            // SAFETY: same lock still held; restoring prior state.
-            unsafe {
-                match v {
-                    Some(val) => std::env::set_var(&k, val),
-                    None => std::env::remove_var(&k),
-                }
-            }
-        }
-        if let Err(payload) = result {
-            std::panic::resume_unwind(payload);
-        }
-    }
+    // Tests that mutate CADENCE_ALLOWED_OWNERS / CADENCE_ISSUE_TRACKER(S)
+    // serialize via the crate-shared with_env/CADENCE_ENV_TEST_LOCK so they
+    // don't race each other or the same globals mutated in guard_push_remote
+    // / guard_gh_write (#446).
 
     fn workdir(path: &str) -> PathBuf {
         PathBuf::from(path)
@@ -671,8 +640,8 @@ mod tests {
 
     // ---- nudge message format ----
     // These tests call canonical() which reads CADENCE_ISSUE_TRACKER — serialize
-    // with CADENCE_ALLOWLIST_TEST_LOCK and clear the var so concurrent
-    // env-mutating tests don't race.
+    // with CADENCE_ENV_TEST_LOCK (via with_env) and clear the var so
+    // concurrent env-mutating tests don't race.
 
     #[test]
     fn nudge_message_names_the_check() {

--- a/crates/guardrails/src/warn_subagent_concurrency.rs
+++ b/crates/guardrails/src/warn_subagent_concurrency.rs
@@ -322,9 +322,9 @@ not json at all
     fn missing_log_fails_open() {
         // Point CADENCE_METRICS_DIR at an empty temp dir (no subagents.jsonl) →
         // read fails → allow. Serialized against other env-touching tests.
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::CADENCE_ENV_TEST_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
-        // SAFETY: guarded by ENV_LOCK; restored below.
+        // SAFETY: guarded by CADENCE_ENV_TEST_LOCK; restored below.
         unsafe { std::env::set_var("CADENCE_METRICS_DIR", dir.path()) };
         let input = make_agent(Some("general-purpose"), None, "/tmp");
         let result = WarnSubagentConcurrency.run(&input);
@@ -336,7 +336,7 @@ not json at all
     fn garbage_bytes_fail_open() {
         // A subagents.jsonl full of non-JSON garbage → zero live → allow (below
         // the default cap). Never panics.
-        let _guard = ENV_LOCK.lock().unwrap();
+        let _guard = crate::CADENCE_ENV_TEST_LOCK.lock().unwrap();
         let dir = tempfile::tempdir().unwrap();
         // Invalid UTF-8 bytes → read_to_string fails → fail-open; plus non-JSON
         // ASCII so even a lenient read yields zero live records.
@@ -345,7 +345,7 @@ not json at all
             b"\x00\xff garbage\nmore junk\n",
         )
         .unwrap();
-        // SAFETY: guarded by ENV_LOCK; restored below.
+        // SAFETY: guarded by CADENCE_ENV_TEST_LOCK; restored below.
         unsafe { std::env::set_var("CADENCE_METRICS_DIR", dir.path()) };
         let input = make_agent(Some("general-purpose"), None, "/tmp");
         let result = WarnSubagentConcurrency.run(&input);
@@ -353,6 +353,6 @@ not json at all
         assert_eq!(result.outcome, Outcome::Allow);
     }
 
-    // Serializes the two tests that mutate process-global env (`set_var`).
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // The two tests above that mutate process-global env (`set_var`) serialize
+    // via the crate-shared CADENCE_ENV_TEST_LOCK (#446).
 }

--- a/crates/guardrails/src/warn_subagent_worktree.rs
+++ b/crates/guardrails/src/warn_subagent_worktree.rs
@@ -369,10 +369,11 @@ mod tests {
     // fact survives the swap end to end: a dispatch from the primary checkout
     // nudges, and one from inside the sibling worktree does not.
 
-    /// Serialize the env-reading dispatch tests: `assess_spawn`'s `allowed` arm
-    /// reads `CADENCE_ALLOW_SUBAGENT_FROM_MAIN` from real process env, which an
-    /// ambient session value could otherwise flip to a false allow.
-    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // Serialize the env-reading dispatch tests via the crate-shared
+    // CADENCE_ENV_TEST_LOCK: `assess_spawn`'s `allowed` arm reads
+    // `CADENCE_ALLOW_SUBAGENT_FROM_MAIN` from real process env, which an
+    // ambient session value — or a concurrent env-mutating test elsewhere in
+    // this crate (#446) — could otherwise flip to a false allow.
 
     fn git(dir: &Path, args: &[&str]) {
         let ok = std::process::Command::new("git")
@@ -388,9 +389,11 @@ mod tests {
 
     #[test]
     fn dispatch_from_primary_with_sibling_worktree_nudges() {
-        let _guard = ENV_LOCK.lock().unwrap_or_else(|p| p.into_inner());
+        let _guard = crate::CADENCE_ENV_TEST_LOCK
+            .lock()
+            .unwrap_or_else(|p| p.into_inner());
         let prev = std::env::var("CADENCE_ALLOW_SUBAGENT_FROM_MAIN").ok();
-        // SAFETY: serialized via ENV_LOCK; restored below.
+        // SAFETY: serialized via CADENCE_ENV_TEST_LOCK; restored below.
         unsafe {
             std::env::remove_var("CADENCE_ALLOW_SUBAGENT_FROM_MAIN");
         }
@@ -443,7 +446,7 @@ mod tests {
             "Explore dispatch from primary + sibling worktree is silent (read-only by convention)"
         );
 
-        // SAFETY: serialized via ENV_LOCK.
+        // SAFETY: serialized via CADENCE_ENV_TEST_LOCK.
         unsafe {
             match prev {
                 Some(v) => std::env::set_var("CADENCE_ALLOW_SUBAGENT_FROM_MAIN", v),

--- a/tests/deadline_failopen.rs
+++ b/tests/deadline_failopen.rs
@@ -370,3 +370,191 @@ fn enforce_worktree_edit_arm_spawns_no_git() {
          filesystem walk); got {spawns} — a git probe crept back in"
     );
 }
+
+/// A primary repo fixture for the mutation-nudge spawn-bound tests below,
+/// rooted under this crate's `target/` — NOT a tempdir. `is_temp_root`
+/// exempts anything under the platform temp dir (cadence-hooks#312's
+/// documented Scratch/E2E gotcha), which would silently allow every case and
+/// make the "would block" fixture never reach the git-spawning branch at all.
+/// Mirrors `enforce_worktree`'s own in-crate `Scratch` test helper exactly —
+/// same carve-out assertion, same `Drop` cleanup (a bare `PathBuf` would leave
+/// fixtures to accumulate under `target/mutation-nudge-scratch/`, cleaned only
+/// incidentally by the *next* run's `remove_dir_all`).
+struct Scratch(std::path::PathBuf);
+
+impl Scratch {
+    fn new(tag: &str) -> Self {
+        let root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("target/mutation-nudge-scratch")
+            .join(format!("{tag}-{}", std::process::id()));
+        assert!(
+            !cadence_hooks_core::worktree::is_claude_managed_dir(&root)
+                && !cadence_hooks_core::worktree::path_under_temp_root(
+                    &root,
+                    std::env::var("TMPDIR").ok().as_deref(),
+                ),
+            "fixture root sits under a carve-out (.claude/ or temp) — run the suite \
+             from a carve-out-free checkout: {}",
+            root.display()
+        );
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(&root).unwrap();
+        Self(root)
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn git_in(dir: &std::path::Path, args: &[&str]) {
+    let ok = Command::new("git")
+        .args(args)
+        .current_dir(dir)
+        .output()
+        .map(|o| o.status.success())
+        .unwrap_or(false);
+    assert!(ok, "git {args:?} failed in {dir:?}");
+}
+
+/// Two existing tracked files in DISTINCT subdirectories, so the mutation walk
+/// produces two genuinely distinct assess-paths (not deduped to one
+/// directory) — the fixture that actually exercises "N targets in one repo",
+/// not a single target trivially giving N=1.
+fn init_mutation_nudge_repo(dir: &std::path::Path) {
+    git_in(dir, &["init", "-q", "-b", "main"]);
+    git_in(dir, &["config", "user.email", "t@t"]);
+    git_in(dir, &["config", "user.name", "t"]);
+    std::fs::write(dir.join("root_file.txt"), "x").unwrap();
+    std::fs::create_dir_all(dir.join("sub")).unwrap();
+    std::fs::write(dir.join("sub").join("sub_file.txt"), "x").unwrap();
+    git_in(dir, &["add", "-A"]);
+    git_in(dir, &["commit", "-q", "-m", "init"]);
+}
+
+/// The real `git` on PATH, resolved once per test so the counting shim can
+/// delegate to it.
+fn real_git() -> String {
+    let real_git = String::from_utf8(
+        Command::new("sh")
+            .args(["-c", "command -v git"])
+            .output()
+            .unwrap()
+            .stdout,
+    )
+    .unwrap()
+    .trim()
+    .to_string();
+    assert!(!real_git.is_empty(), "real git required for this test");
+    real_git
+}
+
+/// Number of `git` invocations the counting shim recorded.
+fn spawn_count(count_file: &std::path::Path) -> usize {
+    std::fs::read_to_string(count_file)
+        .map(|s| s.lines().count())
+        .unwrap_or(0)
+}
+
+/// Run the mutation-nudge scenario (`tee root_file.txt sub/sub_file.txt` in a
+/// fresh primary-repo `Scratch` fixture) through the real binary with a
+/// counting `git` shim on PATH, returning `(stdout, spawn count)`.
+///
+/// `allow_main` toggles `CADENCE_ALLOW_MAIN` — the one difference between the
+/// blocked-path and allow-path tests below. `CADENCE_LOG_NUDGES=0` is set
+/// unconditionally: it can't change the allow path's zero (no nudge fires
+/// there to log), and on the blocked path it isolates the assertion from the
+/// metrics/nudge-logger's own git spawn (`repo_basename`'s `rev-parse
+/// --show-toplevel`) — a separate cost from enforce-worktree's own resolution
+/// (found while writing this test: the naive count came back 2, not 1).
+fn run_mutation_nudge(tag: &str, allow_main: bool) -> (String, usize) {
+    let real_git = real_git();
+    let scratch = Scratch::new(tag);
+    init_mutation_nudge_repo(&scratch.0);
+
+    let shim = tempfile::tempdir().unwrap();
+    let counts = tempfile::tempdir().unwrap();
+    let count_file = counts.path().join("spawns");
+    write_counting_git(shim.path(), &count_file, &real_git);
+    let metrics = tempfile::tempdir().unwrap();
+
+    let payload = serde_json::json!({
+        "tool_name": "Bash",
+        "tool_input": { "command": "tee root_file.txt sub/sub_file.txt" },
+        "cwd": scratch.0.to_string_lossy(),
+    })
+    .to_string();
+
+    let mut cmd = cadence_hooks();
+    cmd.args(["guardrails", "enforce-worktree"]);
+    cmd.env("PATH", shim.path());
+    cmd.env("CADENCE_METRICS_DIR", metrics.path());
+    cmd.env("CADENCE_LOG_NUDGES", "0");
+    if allow_main {
+        cmd.env("CADENCE_ALLOW_MAIN", "true");
+    } else {
+        cmd.env_remove("CADENCE_ALLOW_MAIN");
+    }
+    cmd.env_remove("CADENCE_NO_ENFORCE_WORKTREE");
+    cmd.env_remove("CADENCE_DISABLE");
+    let out = run_with_payload(&mut cmd, &payload);
+
+    assert_eq!(
+        out.status.code(),
+        Some(0),
+        "enforce-worktree must exit 0 here (a nudge is advisory, and \
+         CADENCE_ALLOW_MAIN must allow): {}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+
+    let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
+    (stdout, spawn_count(&count_file))
+}
+
+#[test]
+fn enforce_worktree_mutation_nudge_blocked_path_spawns_one_git() {
+    // cadence-hooks#292's corrected premise: the issue as filed assumed
+    // GitState::resolve still spawned git (it's been a pure filesystem walk
+    // since #164 — deadline_failopen.rs's own edit-arm test above already
+    // pins that at zero) and that the mutation-nudge loop's spawn count scaled
+    // with the number of distinct mutation targets. It doesn't: `mutation_nudge`
+    // returns on the FIRST target whose containing repo would block, and
+    // `GitProbe::is_commitless` is memoized on repo_root regardless — so N
+    // distinct targets (here 2, in different subdirectories, so they aren't
+    // trivially deduped to one directory) in the SAME primary repo still cost
+    // exactly one `git` spawn (the `rev-list --count -n1 --all` bootstrap-
+    // exemption probe on the would-block path).
+    let (stdout, spawns) = run_mutation_nudge("blocked", false);
+
+    assert!(
+        stdout.contains("enforce-worktree: this command mutates"),
+        "expected the mutation nudge to fire in this primary-checkout fixture: {stdout}"
+    );
+    assert_eq!(
+        spawns, 1,
+        "2 distinct mutation targets in one primary repo must cost exactly 1 \
+         git spawn (is_commitless, memoized on repo_root); got {spawns}"
+    );
+}
+
+#[test]
+fn enforce_worktree_mutation_nudge_allow_path_spawns_zero_git() {
+    // Differential control for the test above: the identical fixture and
+    // command, but with CADENCE_ALLOW_MAIN set so the primary checkout is
+    // exempted — assess_dir never reaches the would-block branch, so
+    // is_commitless (the one git spawn on the blocked path) is never called,
+    // and GitState resolution is git-free regardless. Total: zero.
+    let (stdout, spawns) = run_mutation_nudge("allowed", true);
+
+    assert!(
+        !stdout.contains("enforce-worktree: this command mutates"),
+        "CADENCE_ALLOW_MAIN must suppress the nudge, not just the block: {stdout}"
+    );
+    assert_eq!(
+        spawns, 0,
+        "an exempted primary checkout must spawn zero git on the mutation-nudge \
+         path; got {spawns}"
+    );
+}

--- a/tests/deadline_failopen.rs
+++ b/tests/deadline_failopen.rs
@@ -30,14 +30,17 @@ fn write_hanging_git(dir: &std::path::Path) {
     std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o755)).unwrap();
 }
 
-/// Write an executable `git` into `dir` that appends one line to `count_file`
-/// per invocation, then delegates to the real git at `real_git`.
+/// Write an executable `git` into `dir` that appends its full argv (one line
+/// per invocation) to `count_file`, then delegates to the real git at
+/// `real_git`. Logging argv (not just a bare marker) lets a caller assert on
+/// exactly which commands ran, not merely how many — the difference between
+/// counting spawns and pinning them.
 fn write_counting_git(dir: &std::path::Path, count_file: &std::path::Path, real_git: &str) {
     let path = dir.join("git");
     std::fs::write(
         &path,
         format!(
-            "#!/bin/sh\necho x >> \"{}\"\nexec {} \"$@\"\n",
+            "#!/bin/sh\necho \"$@\" >> \"{}\"\nexec {} \"$@\"\n",
             count_file.display(),
             real_git
         ),
@@ -410,7 +413,7 @@ impl Drop for Scratch {
 }
 
 fn git_in(dir: &std::path::Path, args: &[&str]) {
-    let ok = Command::new("git")
+    let ok = Command::new(real_git())
         .args(args)
         .current_dir(dir)
         .output()
@@ -423,61 +426,81 @@ fn git_in(dir: &std::path::Path, args: &[&str]) {
 /// produces two genuinely distinct assess-paths (not deduped to one
 /// directory) — the fixture that actually exercises "N targets in one repo",
 /// not a single target trivially giving N=1.
+///
+/// Three `git` invocations, not five: the two `git config` calls fold into
+/// the commit as `-c user.email=… -c user.name=…` rather than their own
+/// spawns — this fixture setup runs with the real PATH (before the counting
+/// shim is installed for the actual test command below), so it costs nothing
+/// toward any spawn assertion, but there's no reason to pay 5 spawns when 3
+/// do the same job.
 fn init_mutation_nudge_repo(dir: &std::path::Path) {
     git_in(dir, &["init", "-q", "-b", "main"]);
-    git_in(dir, &["config", "user.email", "t@t"]);
-    git_in(dir, &["config", "user.name", "t"]);
     std::fs::write(dir.join("root_file.txt"), "x").unwrap();
     std::fs::create_dir_all(dir.join("sub")).unwrap();
     std::fs::write(dir.join("sub").join("sub_file.txt"), "x").unwrap();
     git_in(dir, &["add", "-A"]);
-    git_in(dir, &["commit", "-q", "-m", "init"]);
+    git_in(
+        dir,
+        &[
+            "-c",
+            "user.email=t@t",
+            "-c",
+            "user.name=t",
+            "commit",
+            "-q",
+            "-m",
+            "init",
+        ],
+    );
 }
 
-/// The real `git` on PATH, resolved once per test so the counting shim can
-/// delegate to it.
-fn real_git() -> String {
-    let real_git = String::from_utf8(
-        Command::new("sh")
-            .args(["-c", "command -v git"])
-            .output()
-            .unwrap()
-            .stdout,
-    )
-    .unwrap()
-    .trim()
-    .to_string();
-    assert!(!real_git.is_empty(), "real git required for this test");
-    real_git
+/// The real `git` on PATH — resolved once per test *binary* (not once per
+/// test) via `OnceLock`, since it never changes within a run. The counting
+/// shim installed on the child process's PATH delegates to this path.
+fn real_git() -> &'static str {
+    static REAL_GIT: std::sync::OnceLock<String> = std::sync::OnceLock::new();
+    REAL_GIT.get_or_init(|| {
+        let real_git = String::from_utf8(
+            Command::new("sh")
+                .args(["-c", "command -v git"])
+                .output()
+                .unwrap()
+                .stdout,
+        )
+        .unwrap()
+        .trim()
+        .to_string();
+        assert!(!real_git.is_empty(), "real git required for this test");
+        real_git
+    })
 }
 
-/// Number of `git` invocations the counting shim recorded.
-fn spawn_count(count_file: &std::path::Path) -> usize {
-    std::fs::read_to_string(count_file)
-        .map(|s| s.lines().count())
-        .unwrap_or(0)
+/// Full content the counting shim recorded — one line of argv per `git`
+/// invocation, in call order.
+fn spawn_log(count_file: &std::path::Path) -> String {
+    std::fs::read_to_string(count_file).unwrap_or_default()
 }
 
 /// Run the mutation-nudge scenario (`tee root_file.txt sub/sub_file.txt` in a
-/// fresh primary-repo `Scratch` fixture) through the real binary with a
-/// counting `git` shim on PATH, returning `(stdout, spawn count)`.
+/// fresh primary-repo `Scratch` fixture) through the real binary with an
+/// argv-recording `git` shim on PATH, returning `(stdout, spawn log)`.
 ///
-/// `allow_main` toggles `CADENCE_ALLOW_MAIN` — the one difference between the
-/// blocked-path and allow-path tests below. `CADENCE_LOG_NUDGES=0` is set
-/// unconditionally: it can't change the allow path's zero (no nudge fires
-/// there to log), and on the blocked path it isolates the assertion from the
-/// metrics/nudge-logger's own git spawn (`repo_basename`'s `rev-parse
-/// --show-toplevel`) — a separate cost from enforce-worktree's own resolution
-/// (found while writing this test: the naive count came back 2, not 1).
-fn run_mutation_nudge(tag: &str, allow_main: bool) -> (String, usize) {
-    let real_git = real_git();
+/// `allow_main` toggles `CADENCE_ALLOW_MAIN` — the ONLY difference between the
+/// blocked-path and allow-path tests below, so the differential is exact.
+/// Nudge/denial logging is left at its default (ON) rather than special-cased
+/// off: the shim recording full argv lets each test assert on exactly which
+/// commands ran, so the metrics layer's own git spawn (found while writing
+/// this test — `repo_basename`'s `rev-parse --show-toplevel`, fired by the
+/// nudge/denial logger, cadence-hooks#292 review) is pinned by name rather
+/// than suppressed by a knob that could silently grow.
+fn run_mutation_nudge(tag: &str, allow_main: bool) -> (String, String) {
     let scratch = Scratch::new(tag);
     init_mutation_nudge_repo(&scratch.0);
 
     let shim = tempfile::tempdir().unwrap();
     let counts = tempfile::tempdir().unwrap();
     let count_file = counts.path().join("spawns");
-    write_counting_git(shim.path(), &count_file, &real_git);
+    write_counting_git(shim.path(), &count_file, real_git());
     let metrics = tempfile::tempdir().unwrap();
 
     let payload = serde_json::json!({
@@ -491,7 +514,6 @@ fn run_mutation_nudge(tag: &str, allow_main: bool) -> (String, usize) {
     cmd.args(["guardrails", "enforce-worktree"]);
     cmd.env("PATH", shim.path());
     cmd.env("CADENCE_METRICS_DIR", metrics.path());
-    cmd.env("CADENCE_LOG_NUDGES", "0");
     if allow_main {
         cmd.env("CADENCE_ALLOW_MAIN", "true");
     } else {
@@ -510,7 +532,7 @@ fn run_mutation_nudge(tag: &str, allow_main: bool) -> (String, usize) {
     );
 
     let stdout = String::from_utf8_lossy(&out.stdout).into_owned();
-    (stdout, spawn_count(&count_file))
+    (stdout, spawn_log(&count_file))
 }
 
 #[test]
@@ -524,37 +546,59 @@ fn enforce_worktree_mutation_nudge_blocked_path_spawns_one_git() {
     // `GitProbe::is_commitless` is memoized on repo_root regardless — so N
     // distinct targets (here 2, in different subdirectories, so they aren't
     // trivially deduped to one directory) in the SAME primary repo still cost
-    // exactly one `git` spawn (the `rev-list --count -n1 --all` bootstrap-
-    // exemption probe on the would-block path).
-    let (stdout, spawns) = run_mutation_nudge("blocked", false);
+    // exactly one `git` spawn from enforce-worktree itself (the `rev-list
+    // --count -n1 --all` bootstrap-exemption probe on the would-block path).
+    //
+    // A second, separate spawn is real and expected here: the nudge/denial
+    // logger resolves its own `repo` field via `repo_basename`'s `rev-parse
+    // --show-toplevel` on every guard's Nudge outcome — the metrics layer's
+    // cost, not enforce-worktree's, but genuinely on PATH in the DEFAULT
+    // (nudge-logging-on) configuration. Asserting on both by name, in order,
+    // pins the full default-config cost rather than hiding one behind a knob.
+    let (stdout, log) = run_mutation_nudge("blocked", false);
 
     assert!(
         stdout.contains("enforce-worktree: this command mutates"),
         "expected the mutation nudge to fire in this primary-checkout fixture: {stdout}"
     );
+
+    let lines: Vec<&str> = log.lines().collect();
     assert_eq!(
-        spawns, 1,
-        "2 distinct mutation targets in one primary repo must cost exactly 1 \
-         git spawn (is_commitless, memoized on repo_root); got {spawns}"
+        lines.len(),
+        2,
+        "expected exactly 2 git invocations (enforce-worktree's is_commitless \
+         + the metrics logger's repo_basename); got: {lines:?}"
+    );
+    assert!(
+        lines[0].contains("rev-list") && lines[0].contains("--count") && lines[0].contains("-n1"),
+        "first spawn should be enforce-worktree's is_commitless bootstrap-exemption probe: {}",
+        lines[0]
+    );
+    assert_eq!(
+        lines[1].trim(),
+        "rev-parse --show-toplevel",
+        "second spawn should be the metrics logger's repo_basename lookup: {}",
+        lines[1]
     );
 }
 
 #[test]
 fn enforce_worktree_mutation_nudge_allow_path_spawns_zero_git() {
     // Differential control for the test above: the identical fixture and
-    // command, but with CADENCE_ALLOW_MAIN set so the primary checkout is
-    // exempted — assess_dir never reaches the would-block branch, so
-    // is_commitless (the one git spawn on the blocked path) is never called,
-    // and GitState resolution is git-free regardless. Total: zero.
-    let (stdout, spawns) = run_mutation_nudge("allowed", true);
+    // command, differing ONLY in CADENCE_ALLOW_MAIN — assess_dir never
+    // reaches the would-block branch, so is_commitless (enforce-worktree's one
+    // git spawn on the blocked path) is never called, GitState resolution is
+    // git-free regardless, and no Nudge outcome means the metrics logger's
+    // repo_basename spawn never fires either. Total: zero.
+    let (stdout, log) = run_mutation_nudge("allowed", true);
 
     assert!(
         !stdout.contains("enforce-worktree: this command mutates"),
         "CADENCE_ALLOW_MAIN must suppress the nudge, not just the block: {stdout}"
     );
     assert_eq!(
-        spawns, 0,
+        log, "",
         "an exempted primary checkout must spawn zero git on the mutation-nudge \
-         path; got {spawns}"
+         path; got: {log:?}"
     );
 }

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -1049,51 +1049,90 @@ fn namespace_list_matches_redact_check_sh() {
     );
 }
 
-/// Interpreters whose argv[0] is never itself a checkable script path — the
-/// actual script lives at argv[1].
+/// Interpreters whose argv[0] — or the command that follows a leading `env`
+/// invocation — is never itself a checkable script path. The actual script is
+/// the interpreter's first NON-FLAG argument, not necessarily argv[1]:
+/// `python3 -u /path/hook.py` has a flag in between.
 const SCRIPT_INTERPRETERS: &[&str] = &[
     "python3", "python", "bash", "sh", "zsh", "node", "ruby", "perl",
 ];
 
+/// Skip a leading `env` invocation — and its own flags / `VAR=value`
+/// assignments — to the command it actually runs.
+///
+/// `/usr/bin/env python3 /path/hook.py` must be judged as a python3
+/// invocation, not as `env` itself: `env` isn't in [`SCRIPT_INTERPRETERS`], so
+/// without unwrapping it, `/usr/bin/env` (which always exists) would be the
+/// checked target and the audit would pass having never looked at the script
+/// at all (cadence-hooks#464 review — the same bug in a different spelling).
+fn skip_env_prefix(tokens: &[String]) -> &[String] {
+    let Some(first) = tokens.first() else {
+        return tokens;
+    };
+    if cadence_hooks_core::shell::basename(first) != "env" {
+        return tokens;
+    }
+    let mut i = 1;
+    while let Some(t) = tokens.get(i) {
+        if t.starts_with('-') || t.contains('=') {
+            i += 1;
+        } else {
+            break;
+        }
+    }
+    &tokens[i..]
+}
+
 /// Pick the token in a settings.json hook `command` that names a script path
-/// to existence-check, or `None` when there isn't one to check.
+/// to existence-check.
+///
+/// - `Some(Some(path))` — check `path` for existence.
+/// - `Some(None)` — an interpreter-led command (argv[0], or the command after
+///   unwrapping a leading `env`) with no resolvable non-flag script argument
+///   at all (`python3 -u -O`). This must FAIL the audit, not skip it — an
+///   interpreter invocation with nothing to check is cadence-hooks#464's bug
+///   in a different spelling: silently unaudited, not proven safe.
+/// - `None` — a bare, non-interpreter command with no path-shaped token
+///   (`bd prime`) — nothing to check, a legitimate skip.
 ///
 /// A quoted interpreter+script command (`"/usr/bin/python3" "/path/hook.py"
 /// args`) naively PathBuf'd as one raw string never exists — quotes and args
-/// never form a real path. Tokenizing (quote-aware, [`cadence_hooks_core::shell::tokenize`])
-/// splits it into argv; when argv[0]'s basename names a known interpreter,
-/// argv[1] is the actual script and that's what gets checked instead
-/// (cadence-hooks#464). A bare command (`bd prime`, no `/` or `~`) still has
-/// nothing to check.
-fn script_check_target(command: &str) -> Option<String> {
+/// never form a real path. Tokenizing (quote-aware,
+/// [`cadence_hooks_core::shell::tokenize`]) splits it into argv first.
+fn script_check_target(command: &str) -> Option<Option<String>> {
     let tokens = cadence_hooks_core::shell::tokenize(command);
-    let first = tokens.first()?;
+    let rest = skip_env_prefix(&tokens);
+    let first = rest.first()?;
 
-    let is_interpreter = Path::new(first)
-        .file_name()
-        .and_then(|n| n.to_str())
-        .is_some_and(|name| SCRIPT_INTERPRETERS.contains(&name));
+    let is_interpreter = SCRIPT_INTERPRETERS.contains(&cadence_hooks_core::shell::basename(first));
 
-    let candidate = if is_interpreter {
-        tokens.get(1)?
-    } else {
-        first
-    };
+    if is_interpreter {
+        let script = rest.iter().skip(1).find(|t| !t.starts_with('-'));
+        return Some(script.cloned());
+    }
 
-    if candidate.contains('/') || candidate.starts_with('~') {
-        Some(candidate.clone())
+    if first.contains('/') || first.starts_with('~') {
+        Some(Some(first.clone()))
     } else {
         None
     }
 }
 
 /// Does the script a settings.json hook `command` names exist on disk, after
-/// expanding `~` against `home`? `None` when the command has no checkable
-/// script path (see [`script_check_target`]).
+/// expanding a LEADING `~` against `home` (via
+/// [`cadence_hooks_core::paths::expand_tilde_with`] — never a blind
+/// `str::replace('~', home)`, which would mangle a real path like
+/// `/opt/a~b/hook.sh` into a false missing-script report)?
+///
+/// `None` — a bare command with no checkable path, a legitimate skip.
+/// `Some(false)` covers both "the script is missing" AND "an interpreter-led
+/// command resolved no script argument at all" — the latter must fail the
+/// audit, not silently pass (see [`script_check_target`]).
 fn shell_script_exists(command: &str, home: &str) -> Option<bool> {
-    let target = script_check_target(command)?;
-    let expanded = target.replace('~', home);
-    Some(PathBuf::from(&expanded).exists())
+    match script_check_target(command)? {
+        Some(target) => Some(cadence_hooks_core::paths::expand_tilde_with(&target, home).exists()),
+        None => Some(false),
+    }
 }
 
 #[test]
@@ -1125,27 +1164,19 @@ fn settings_json_shell_scripts_exist() {
 
 #[test]
 fn shell_script_exists_quoted_interpreter_and_script() {
-    let tmp = tempfile::TempDir::new().expect("failed to create tempdir");
-    let script_path = tmp.path().join("hook.py");
-    std::fs::write(&script_path, "").expect("failed to write fixture script");
-    let cmd = format!(
-        "\"/usr/bin/python3\" \"{}\" --flag value",
-        script_path.display()
-    );
+    // Cargo.toml is a file this test binary already knows exists at compile
+    // time — no tempdir/write needed just to get an existing path.
+    let script_path = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+    let cmd = format!("\"/usr/bin/python3\" \"{script_path}\" --flag value");
 
     assert_eq!(shell_script_exists(&cmd, "/home/nobody"), Some(true));
 }
 
 #[test]
 fn shell_script_exists_bare_path() {
-    let tmp = tempfile::TempDir::new().expect("failed to create tempdir");
-    let script_path = tmp.path().join("hook.sh");
-    std::fs::write(&script_path, "").expect("failed to write fixture script");
+    let script_path = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
 
-    assert_eq!(
-        shell_script_exists(&script_path.display().to_string(), "/home/nobody"),
-        Some(true)
-    );
+    assert_eq!(shell_script_exists(script_path, "/home/nobody"), Some(true));
 }
 
 #[test]
@@ -1159,6 +1190,41 @@ fn shell_script_exists_interpreter_with_missing_script() {
 fn shell_script_exists_none_for_bare_command() {
     // "bd prime" has no `/` or `~` in either token — nothing to check.
     assert_eq!(shell_script_exists("bd prime", "/home/nobody"), None);
+}
+
+#[test]
+fn shell_script_exists_interpreter_flag_before_script() {
+    // `python3 -u /path/hook.py`: the naive "argv[1] is the script" logic
+    // would pick `-u`, a flag, as the "script" and always report missing. The
+    // real script is the interpreter's first NON-FLAG argument.
+    let script_path = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+    let cmd = format!("python3 -u {script_path}");
+
+    assert_eq!(shell_script_exists(&cmd, "/home/nobody"), Some(true));
+}
+
+#[test]
+fn shell_script_exists_env_wrapped_interpreter() {
+    // `/usr/bin/env python3 /path/hook.py`: `env` is not in
+    // SCRIPT_INTERPRETERS, so without unwrapping it, `/usr/bin/env` itself —
+    // which always exists — would be the checked target, passing the audit
+    // having never touched the script.
+    let script_path = concat!(env!("CARGO_MANIFEST_DIR"), "/Cargo.toml");
+    let cmd = format!("/usr/bin/env python3 {script_path}");
+
+    assert_eq!(shell_script_exists(&cmd, "/home/nobody"), Some(true));
+}
+
+#[test]
+fn shell_script_exists_interpreter_no_resolvable_script_fails() {
+    // An interpreter-led command whose every argument is a flag has no
+    // resolvable script at all — this must FAIL the audit (Some(false)), not
+    // silently skip it (None). A skip here is the same #464 bug in a
+    // different spelling: a hook wired to an interpreter with nothing to
+    // check would go unaudited rather than flagged.
+    let cmd = "python3 -u -O";
+
+    assert_eq!(shell_script_exists(cmd, "/home/nobody"), Some(false));
 }
 
 // ---------- Resolver + parser unit tests ----------

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -1049,6 +1049,53 @@ fn namespace_list_matches_redact_check_sh() {
     );
 }
 
+/// Interpreters whose argv[0] is never itself a checkable script path — the
+/// actual script lives at argv[1].
+const SCRIPT_INTERPRETERS: &[&str] = &[
+    "python3", "python", "bash", "sh", "zsh", "node", "ruby", "perl",
+];
+
+/// Pick the token in a settings.json hook `command` that names a script path
+/// to existence-check, or `None` when there isn't one to check.
+///
+/// A quoted interpreter+script command (`"/usr/bin/python3" "/path/hook.py"
+/// args`) naively PathBuf'd as one raw string never exists — quotes and args
+/// never form a real path. Tokenizing (quote-aware, [`cadence_hooks_core::shell::tokenize`])
+/// splits it into argv; when argv[0]'s basename names a known interpreter,
+/// argv[1] is the actual script and that's what gets checked instead
+/// (cadence-hooks#464). A bare command (`bd prime`, no `/` or `~`) still has
+/// nothing to check.
+fn script_check_target(command: &str) -> Option<String> {
+    let tokens = cadence_hooks_core::shell::tokenize(command);
+    let first = tokens.first()?;
+
+    let is_interpreter = Path::new(first)
+        .file_name()
+        .and_then(|n| n.to_str())
+        .is_some_and(|name| SCRIPT_INTERPRETERS.contains(&name));
+
+    let candidate = if is_interpreter {
+        tokens.get(1)?
+    } else {
+        first
+    };
+
+    if candidate.contains('/') || candidate.starts_with('~') {
+        Some(candidate.clone())
+    } else {
+        None
+    }
+}
+
+/// Does the script a settings.json hook `command` names exist on disk, after
+/// expanding `~` against `home`? `None` when the command has no checkable
+/// script path (see [`script_check_target`]).
+fn shell_script_exists(command: &str, home: &str) -> Option<bool> {
+    let target = script_check_target(command)?;
+    let expanded = target.replace('~', home);
+    Some(PathBuf::from(&expanded).exists())
+}
+
 #[test]
 fn settings_json_shell_scripts_exist() {
     let (shell_scripts, _) = settings_json_hooks();
@@ -1064,12 +1111,7 @@ fn settings_json_shell_scripts_exist() {
 
     let mut missing = Vec::new();
     for script in &shell_scripts {
-        // Only check paths (contain / or ~), skip bare commands like "bd prime"
-        if !script.contains('/') && !script.starts_with('~') {
-            continue;
-        }
-        let expanded = script.replace('~', &home);
-        if !PathBuf::from(&expanded).exists() {
+        if shell_script_exists(script, &home) == Some(false) {
             missing.push(format!("  {script} (file not found)"));
         }
     }
@@ -1079,6 +1121,44 @@ fn settings_json_shell_scripts_exist() {
         "settings.json references shell scripts that don't exist:\n{}",
         missing.join("\n")
     );
+}
+
+#[test]
+fn shell_script_exists_quoted_interpreter_and_script() {
+    let tmp = tempfile::TempDir::new().expect("failed to create tempdir");
+    let script_path = tmp.path().join("hook.py");
+    std::fs::write(&script_path, "").expect("failed to write fixture script");
+    let cmd = format!(
+        "\"/usr/bin/python3\" \"{}\" --flag value",
+        script_path.display()
+    );
+
+    assert_eq!(shell_script_exists(&cmd, "/home/nobody"), Some(true));
+}
+
+#[test]
+fn shell_script_exists_bare_path() {
+    let tmp = tempfile::TempDir::new().expect("failed to create tempdir");
+    let script_path = tmp.path().join("hook.sh");
+    std::fs::write(&script_path, "").expect("failed to write fixture script");
+
+    assert_eq!(
+        shell_script_exists(&script_path.display().to_string(), "/home/nobody"),
+        Some(true)
+    );
+}
+
+#[test]
+fn shell_script_exists_interpreter_with_missing_script() {
+    let cmd = "\"/usr/bin/python3\" \"/definitely/does/not/exist/hook.py\" --flag";
+
+    assert_eq!(shell_script_exists(cmd, "/home/nobody"), Some(false));
+}
+
+#[test]
+fn shell_script_exists_none_for_bare_command() {
+    // "bd prime" has no `/` or `~` in either token — nothing to check.
+    assert_eq!(shell_script_exists("bd prime", "/home/nobody"), None);
 }
 
 // ---------- Resolver + parser unit tests ----------


### PR DESCRIPTION
Closes #446, closes #373, closes #464, closes #292

Four test-hygiene fixes, zero production-code change. Three of the four issues' premises were corrected against live code before implementing.

**#446 — one crate-wide env lock, one `with_env`.** Five modules carried byte-identical copies of the same `unsafe` env save/set/`catch_unwind`/restore, so a fix to one silently missed the others. Now a single `with_env` behind a genuinely *private* mutex, mirroring `core::test_builders::with_marker_dir`'s discipline — a private lock is what makes a rival lock impossible to mint, which a `pub(crate)` one doesn't. The unrelated `CADENCE_ALLOW_MAIN_TEST_LOCK` is left alone.

**#464 — the audit's own bug, closed in three spellings.** The existence check `PathBuf`'d the whole command string, so `"/usr/bin/python3" "/path/hook.py"` always read as missing. Beyond the filed case: `python3 -u /path/hook.py` skipped the audit entirely (argv[1] is a flag), and `/usr/bin/env python3 /path/hook.py` reported *success* while checking `/usr/bin/env` and never touching the script. Now scans for the first non-flag argument, unwraps `env` (including its own flags and `VAR=val` assignments), and — the part that matters — an interpreter-led command with no resolvable script now **fails** the audit instead of silently opting out. Tilde expansion routes through `paths::expand_tilde_with` (leading-only); the previous blind `str::replace('~')` mangled any path containing a `~` into a false missing-script report.

**#292 — premise corrected, then pinned properly.** The issue's "fan out git spawns" premise is stale: `GitState::resolve` has been a pure filesystem walk since #164. The real cost is one memoized `is_commitless` spawn, so that's what's pinned. The first cut gated the measurement with `CADENCE_LOG_NUDGES=0`, which meant the metrics logger could have grown to five spawns per nudge with both tests still green — the shim now records full argv and both tests assert exact commands, so the two differ by `CADENCE_ALLOW_MAIN` alone and the differential claim is exact.

**#373** — the four remaining unguarded `marker_dir()` readers wrapped. The issue's second location no longer exists.

**One declared deviation:** the orchestrator ruled that four disjoint module-private locks should survive (accepting the implementer's own verification that only three modules coordinate shared globals); the implementer folded all of them onto the single lock instead. Kept because it's the fail-safe direction and the cost is test wall-clock rather than correctness — but it does serialize tests that were previously parallel, which is exactly what #486 exists to undo.

Follow-ups filed: **#485** (promote `Scratch` for the four hand-rolled git fixtures across `tests/`) and **#486** (a pure-resolver seam for the allowlist globals, mirroring `marker_dir_from`, which would remove the lock's need entirely and restore parallelism).

Also fixed during review: the new scratch-repo fixture had documented `Scratch`'s carve-out assertion and `Drop` cleanup in prose while implementing neither — without the assertion, the allow-path test (which asserts *absence*) passes vacuously from a `.claude/worktrees/` checkout, which is this repo family's normal working location.

Verification: `cargo test --workspace` exit 0, 3,604 passed / 0 failed; clippy `--all-targets` and fmt clean (run independently by the orchestrator).

Session-Name: tidal-viola
Session-Id: ecc24a74-e772-4644-b6ed-342b00644f0b
Model: claude-sonnet-5 (implementer) / claude-fable-5 (orchestrator)
Harness: claude-code 2.1.220
Machine: cf6e768835c7
