### PR TITLE
feat: opt this checkout into cadence-dev

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,5 @@
+{
+  "enabledPlugins": {
+    "cadence-dev@workbench": true
+  }
+}


### PR DESCRIPTION
Enables the new `cadence-dev@workbench` plugin — build-repo skills (building-cadence, drilling-skill-edits, defer) extracted from cadence core (cameronsjo/cadence#696, cameronsjo/workbench#48) — for sessions working in this checkout. One new committed file, `.claude/settings.json`; the gitignore covers only `.claude/intros/` and `.claude/agent-memory/`, so the file tracks cleanly.

The plugin is deliberately absent from any global `enabledPlugins` map: per-checkout opt-in is the mechanism, and cadence-hooks is one of the four build repos (with claude-configurations, cadence, forgectl).

Session-Name: copper-anthem
Session-Id: fe34f422-8358-4cf9-9d69-680cf987bbe1
Model: claude-fable-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7