### PR TITLE
test(guardrails): hermeticize origin-dependent fixtures

### DIFF
--- a/crates/guardrails/src/guard_gh_write.rs
+++ b/crates/guardrails/src/guard_gh_write.rs
@@ -3552,9 +3552,11 @@ mod tests {
 
     #[test]
     fn pr_create_owned_fallback_allows() {
-        // Non-api gh writes keep the cwd-remote fallback — routine work stays green.
+        // Non-api gh writes keep the cwd-remote fallback. Use a hermetic
+        // GitHub origin rather than inheriting the enclosing clone's remote.
         with_env(&owners_env(), || {
-            let input = input_with("gh pr create --title hi", OWNED_DIR);
+            let repo = crate::github_origin_repo();
+            let input = input_with("gh pr create --title hi", &repo.path().to_string_lossy());
             let result = GhWriteGuard.run(&input);
             assert!(matches!(result.outcome, cadence_hooks_core::Outcome::Allow));
         });

--- a/crates/guardrails/src/guard_push_remote.rs
+++ b/crates/guardrails/src/guard_push_remote.rs
@@ -875,10 +875,12 @@ mod tests {
 
     #[test]
     fn push_named_remote_unchanged() {
-        // A named remote still resolves through git and validates its URL:
-        // origin → github.com/cameronsjo/cadence-hooks (owned) → allow.
+        // A named remote still resolves through git and validates its URL.
+        // The fixture pins that URL instead of trusting the enclosing clone.
         with_env(&owners_only(), || {
-            let result = PushRemoteGuard.run(&make_bash_with_cwd("git push origin main", REPO_DIR));
+            let repo = crate::github_origin_repo();
+            let cwd = repo.path().to_string_lossy();
+            let result = PushRemoteGuard.run(&make_bash_with_cwd("git push origin main", &cwd));
             assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
         });
     }

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -70,6 +70,27 @@ pub(crate) fn with_env(vars: &[(&str, Option<&str>)], f: impl FnOnce()) {
     }
 }
 
+/// A single-commit repo whose `origin` has stable GitHub owner/repo identity.
+///
+/// Tests that assert ownership or repo-name behavior must not read the
+/// enclosing checkout's live remote: a local-path clone has no owner/repo and
+/// flips those assertions (#254).
+#[cfg(test)]
+pub(crate) fn github_origin_repo() -> tempfile::TempDir {
+    let repo = tempfile::tempdir().expect("create hermetic git fixture");
+    cadence_hooks_core::git_fixtures::init_repo(repo.path());
+    cadence_hooks_core::git_fixtures::git_in(
+        repo.path(),
+        &[
+            "remote",
+            "add",
+            "origin",
+            "https://github.com/cameronsjo/cadence-hooks.git",
+        ],
+    );
+    repo
+}
+
 /// Per-repo snooze command + helper consumed by `enforce_worktree`.
 pub mod dismiss_enforce_worktree;
 /// Per-repo snooze command + helper consumed by `warn_main_branch`.

--- a/crates/guardrails/src/nudge_upgrade_after_push.rs
+++ b/crates/guardrails/src/nudge_upgrade_after_push.rs
@@ -189,8 +189,9 @@ mod tests {
 
     #[test]
     fn push_from_cadence_hooks_repo_nudges() {
-        // Use the actual cadence-hooks repo directory
-        let input = make_bash_with_cwd("git push origin main", &repo_root());
+        // Stable regardless of the enclosing checkout's origin (#254).
+        let repo = crate::github_origin_repo();
+        let input = make_bash_with_cwd("git push origin main", &repo.path().to_string_lossy());
         let result = NudgeUpgradeAfterPush.run(&input);
         assert_eq!(
             result.outcome,
@@ -236,7 +237,9 @@ mod tests {
     #[cfg(not(windows))]
     #[test]
     fn push_with_cd_to_cadence_hooks_nudges() {
-        let cmd = format!("cd {} && git push origin main", repo_root());
+        let repo = crate::github_origin_repo();
+        let path = repo.path().to_string_lossy();
+        let cmd = format!("cd {path} && git push origin main");
         let input = make_bash_with_cwd(&cmd, "/tmp");
         let result = NudgeUpgradeAfterPush.run(&input);
         assert_eq!(


### PR DESCRIPTION
Fixes #254.

## What changed

- add a shared test-only repository fixture with a pinned
  `https://github.com/cameronsjo/cadence-hooks.git` origin
- move the four ownership/repository-sensitive tests onto that fixture
- stop those tests from inheriting the enclosing checkout's live remote

This changes test infrastructure only. It does not change CLI commands, hook
registry entries, configuration keys, metrics schemas, persisted files, or
runtime fail-open behavior.

## Verification

- reproduced all four failures in a local-path-origin clone before the change
- ran each exact regression in the issue worktree
- cloned commit `e9dd15c` from a local filesystem path and reran all four exact
  regressions successfully
- `make ci`
- `git diff --check HEAD^ HEAD`


---

## Review gate

CodeRabbit did not review this branch. Its check reports SUCCESS, but that mark
reads green when the bot is rate-limited as well as when a review actually ran —
it has been rate-limited across this whole batch, and a PR opened today in a
sibling repo carries the explicit `Review rate limited` text behind the same
green mark.

The merge therefore trusts a stand-in review panel held to the same bar
(MERGE-CLEAN, no Critical or Important findings, against `origin/main...HEAD`):

- **Code-quality lens** — one reviewer, full diff. Verdict: **MERGE-CLEAN**, no
  Critical and no Important. It confirmed three things worth repeating here:
  every prod-adjacent addition is `#[cfg(test)]`-gated, so no guard decision
  logic changed in `guard_push_remote.rs` or `guard_gh_write.rs` (both of which
  other in-flight branches also touch); the four rewired tests still drive the
  same real code paths they asserted before, rather than stubbing out the thing
  under test; and the ~30 untouched `OWNED_DIR`/`REPO_DIR` call sites are safe
  as-is because they either assert Block or validate an explicit URL that never
  resolves through a remote.
- **Security lens** — not run, deliberately. The diff is test-only and changes
  no guard behavior. Every PR in this batch that touches guard, secret-leak, or
  gh-write logic did get the security lens, and on one of them it found a
  Critical the code lens had cleared.

On the absent CHANGELOG entry: the reviewer checked the file's own history
rather than applying the per-PR convention reflexively. Prior pure `test(...)`
commits carry no entry; the entries that do mention fixture work belong to large
behavior-relevant refactors. Correctly omitted here.

Independently verified before merge rather than taken from the reviewer's
report: `cargo test --workspace --no-fail-fast`, exit code captured before any
pipe — 0, no failing target. This PR adds no new tests, so the usual
"confirm each new test ran by name" check has an empty expected set; instead all
ten test functions whose bodies the diff touches were confirmed present and
passing by name in that run, so a rewired test that silently stopped executing
could not pass as a green suite.
