### PR TITLE
feat(guardrails): assert at SessionStart that guard-rm is actually alive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`guard-rm-liveness`, a SessionStart assertion that `guard-rm` is actually arbitrating deletes (wiring tracked in cameronsjo/cadence#760).** The two blanket `permissions.ask` rows `Bash(rm -rf:*)` / `Bash(rm -r:*)` were retired in favor of `guard-rm`, which discriminates by filesystem classification where a literal prefix rule cannot — but those rows had been the belt under every path where the guard fails to run. With them gone, a `guard-rm` that silently does not run means `rm -rf` executes with no prompt anywhere, and that failure is invisible by construction: `Outcome::Allow` is a silent exit 0 and only denials reach `denials.jsonl`, so "inspected and allowed" and "never ran" are byte-identical after the fact. The check asserts the **mechanism**, not the absence of errors — it runs `guard-rm` against inputs whose verdicts are fixed by contract (an unexpanded `$VAR` and a `$(…)` substitution must both `Ask`; a temp-root path must `Allow`) and nudges naming the diverging probe, and separately reports `CADENCE_DISABLE=guard-rm` / `CADENCE_BYPASS=1`. Deliberately **no daily gate** (unlike `platform-drift`): what it reports is "your only remaining deletion guard is off or broken", which should be visible every session rather than suppressed for 23 hours. **Two limits are documented in the module rather than left to be rediscovered.** It ships in the same plugin and binary as the guard it watches, so it cannot see a bypassed session, a disabled plugin, inert wiring, an absent binary, or a delete-time timeout — silence means "the classifier is intact and not switched off", never "deletes are guarded". And it does not probe the Block path: the Temp classification is evaluated *before* the git-repo check, so `rm -rf /tmp/<dir-containing-.git>` is a silent Allow and a tempdir fixture would assert Block, get Allow, and nudge falsely every session. Nudge-only, fail-open throughout (ADR-0001).
+
+### Fixed
+
+- **The checked-in Codex compatibility report's `binaryVersion` had gone stale at 0.70.1**, leaving `make ci`'s `report-check` red on `main` from the 0.71.0 bump onward. The release procedure regenerates the platform baseline but not this report; the gap itself is filed separately.
+
 ## [0.71.0] - 2026-08-03
 
 ### Added

--- a/config/codex-compatibility.json
+++ b/config/codex-compatibility.json
@@ -22,6 +22,10 @@
     "warn-subagent-worktree": {"status": "adapted", "evidence": "crates/core/src/lib.rs"},
     "warn-subagent-concurrency": {"status": "adapted", "evidence": "crates/core/src/lib.rs"},
     "guard-rm": {"status": "adapted", "evidence": "crates/guardrails/src/guard_rm.rs::patch_delete_of_a_protected_path_blocks"},
+    "guard-rm-liveness": {
+      "applicable": false,
+      "evidence": "registered in the binary but not yet invoked: the cadence-guardrails SessionStart wiring ships in a companion monorepo PR. Flip to applicable when that wiring merges."
+    },
     "trash-guard": {"status": "adapted", "evidence": "crates/obsidian/src/trash_guard.rs::normalized_patch_delete_inside_vault_is_blocked"},
     "guard-browser-device": {
       "status": "unavailable",

--- a/crates/guardrails/src/guard_rm_liveness.rs
+++ b/crates/guardrails/src/guard_rm_liveness.rs
@@ -27,22 +27,26 @@
 //! | an unexpanded `$VAR` operand | [`Outcome::Ask`] — unresolvable |
 //! | a `$(…)` substitution operand | [`Outcome::Ask`] — unresolvable |
 //! | a path under the temp root | [`Outcome::Allow`] — disposable |
+//! | a top-level entry under `$HOME` | [`Outcome::Block`] — protected |
 //!
 //! A verdict that disagrees means the classifier has regressed, and the nudge
 //! names which probe diverged. It separately reports when `guard-rm` is switched
 //! off by environment, which is the documented and advertised way to neuter it.
 //!
+//! None of the four writes to disk. The home probe names a basename that need
+//! not exist — the home classification is pure path logic — which is what makes
+//! a Block case reachable at all here. It is also the probe that catches a
+//! widened `$TMPDIR` swallowing real work; see [`home_block_probe`].
+//!
 //! # What it deliberately does NOT probe
 //!
-//! **The Block path** (git repo, vault, `$HOME`). Probing it needs a real
-//! `.git` on disk, and every writable fixture location is wrong: under the temp
-//! root the Temp classification is evaluated *first* and pre-empts the git-repo
-//! check (verified — `rm -rf /tmp/<dir-with-.git>` is a silent Allow), so a
-//! tempdir fixture would assert Block and get Allow, nudging falsely every
-//! session. The alternative — writing a fixture outside the temp roots at every
-//! SessionStart — is a worse hazard than the gap it would close. The Ask probes
-//! are the load-bearing ones regardless: an Ask-to-Allow regression is the
-//! silent one, and it is exactly what they catch.
+//! **The git-repo Block path.** Unlike the home case, it needs a real `.git` on
+//! disk, and every writable fixture location is wrong: under the temp root the
+//! Temp classification is evaluated *first* and pre-empts the git-repo check
+//! (verified — `rm -rf /tmp/<dir-with-.git>` is a silent Allow), so a tempdir
+//! fixture would assert Block, get Allow, and nudge falsely every session. The
+//! alternative — writing a fixture outside the temp roots at every SessionStart
+//! — is a worse hazard than the gap it would close.
 //!
 //! # What it structurally CANNOT see
 //!
@@ -92,7 +96,7 @@ struct Probe {
     classification: &'static str,
 }
 
-/// Probes covering the two verdicts reachable without writing to disk.
+/// Probes covering the verdicts reachable without writing to disk.
 ///
 /// The `$VAR` and `$(…)` cases resolve to `Unresolvable` on the operand alone —
 /// no `stat`, no `lstat`, no dependence on what exists. The temp case is a path
@@ -114,6 +118,41 @@ const PROBES: &[Probe] = &[
         classification: "temp root",
     },
 ];
+
+/// Basename for the home-directory Block probe. Never created or deleted — it
+/// only has to be a top-level entry under `$HOME` for the path classifier.
+const HOME_PROBE_BASENAME: &str = "cadence-guard-rm-liveness-probe";
+
+/// The Block probe: deleting a top-level entry in `$HOME` must be refused.
+///
+/// This is the one Block case reachable with no filesystem fixture — the home
+/// classification is pure path logic, so a non-existent basename classifies the
+/// same as a real one. (The git-repo Block case is *not* reachable; see the
+/// module header.)
+///
+/// It is also the probe that catches the widest real degradation. `guard-rm`
+/// resolves its temp roots partly from `$TMPDIR`, and a `$TMPDIR` pointing at a
+/// directory that contains real work silently converts that whole subtree to
+/// "disposable": with `TMPDIR` set to the home directory, `rm -rf ~/Documents`
+/// is a **silent Allow** (verified). The three probes above all still pass in
+/// that state, because none of their operands falls under the widened root —
+/// so without this one the check would report healthy while home protection was
+/// gone. Filed separately as a `guard-rm` defect; this probe is the detection.
+///
+/// Returns `None` when the home directory cannot be resolved, so the probe is
+/// skipped rather than failed — an unresolvable home is this check's own blind
+/// spot, not evidence about `guard-rm`.
+fn home_block_probe() -> Option<(String, Outcome, &'static str)> {
+    let home = cadence_hooks_core::paths::user_home()?;
+    // Built through the same resolver `guard-rm` itself uses, so the probe
+    // cannot disagree with the guard about where home is.
+    let target = home.join(HOME_PROBE_BASENAME);
+    Some((
+        format!("rm -rf {}", target.display()),
+        Outcome::Block,
+        "home directory",
+    ))
+}
 
 /// Build the `PreToolUse` payload `guard-rm` expects for `command`.
 ///
@@ -180,27 +219,41 @@ impl Check for GuardRmLiveness {
             ));
         }
 
+        // The static table plus the home Block probe, which is built at runtime
+        // because it needs the resolved home directory. A `None` home drops the
+        // probe rather than failing it — see `home_block_probe`.
+        let cases = PROBES
+            .iter()
+            .map(|probe| {
+                (
+                    probe.command.to_string(),
+                    probe.expected,
+                    probe.classification,
+                )
+            })
+            .chain(home_block_probe());
+
         // A probe that fails to build is this check's own bug, not evidence
         // about guard-rm — report it as such rather than implying the guard is
         // broken, and never let it read as a clean bill of health either.
         let mut divergences: Vec<String> = Vec::new();
-        for probe in PROBES {
-            let input = match probe_input(probe.command) {
+        let mut ran = 0usize;
+        for (command, expected, classification) in cases {
+            ran += 1;
+            let input = match probe_input(&command) {
                 Ok(input) => input,
                 Err(error) => {
                     divergences.push(format!(
-                        "{} — guard-rm-liveness could not build its own probe payload ({error}); \
-                         this check is broken, guard-rm's state is unknown",
-                        probe.classification
+                        "{classification} — guard-rm-liveness could not build its own probe \
+                         payload ({error}); this check is broken, guard-rm's state is unknown"
                     ));
                     continue;
                 }
             };
             let actual = GuardRm.run(&input).outcome;
-            if actual != probe.expected {
+            if actual != expected {
                 divergences.push(format!(
-                    "{} — expected {:?}, got {actual:?}",
-                    probe.classification, probe.expected
+                    "{classification} — expected {expected:?}, got {actual:?}"
                 ));
             }
         }
@@ -215,7 +268,7 @@ impl Check for GuardRmLiveness {
              blanket `rm -rf` / `rm -r` permission prompts were retired. Treat unexpected \
              deletes as unguarded until this is resolved.",
             divergences.len(),
-            PROBES.len(),
+            ran,
             divergences.join("\n  ")
         ))
     }
@@ -265,6 +318,48 @@ mod tests {
                 );
             }
         });
+    }
+
+    #[test]
+    fn home_block_probe_matches_guard_rm() {
+        with_switches_clear(|| {
+            let (command, expected, _) = home_block_probe().expect("HOME is set under test");
+            let input = probe_input(&command).expect("probe payload must parse");
+            assert_eq!(GuardRm.run(&input).outcome, expected);
+        });
+    }
+
+    #[test]
+    fn widened_tmpdir_that_swallows_home_is_caught() {
+        // The finding this probe exists for. guard-rm resolves temp roots partly
+        // from $TMPDIR; pointing TMPDIR at the home directory reclassifies that
+        // whole subtree as disposable, and `rm -rf ~/<anything>` becomes a
+        // silent Allow. The other three probes all still pass in that state —
+        // none of their operands falls under the widened root — so this asserts
+        // the check as a whole goes loud, not merely that one probe flips.
+        let home = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"));
+        let Ok(home) = home else {
+            return; // no resolvable home on this platform; the probe self-skips
+        };
+        with_env(
+            &[
+                ("TMPDIR", Some(home.as_str())),
+                ("CADENCE_DISABLE", None),
+                ("CADENCE_BYPASS", None),
+            ],
+            || {
+                let result = GuardRmLiveness.run(&make_session("s1", "startup"));
+                assert_eq!(
+                    result.outcome,
+                    Outcome::Nudge,
+                    "a TMPDIR that swallows $HOME must not read as healthy"
+                );
+                assert!(
+                    result.message.unwrap().contains("home directory"),
+                    "the nudge must name the home-directory probe as the diverging one"
+                );
+            },
+        );
     }
 
     #[test]

--- a/crates/guardrails/src/guard_rm_liveness.rs
+++ b/crates/guardrails/src/guard_rm_liveness.rs
@@ -1,0 +1,414 @@
+//! `guardrails guard-rm-liveness` — SessionStart assertion that [`guard_rm`]
+//! is actually arbitrating deletes, rather than merely appearing to.
+//!
+//! # Why this exists
+//!
+//! Until 2026-08-03 two blanket `permissions.ask` rows (`Bash(rm -rf:*)`,
+//! `Bash(rm -r:*)`) sat under `guard-rm` as a belt: if the guard did not run,
+//! the settings row still prompted. Those rows were retired because they had no
+//! filesystem awareness — they fired on deletes `guard-rm` had already proven
+//! safe. `Bash(rm:*)` remains in `allow`, and `deny` covers only `/` and
+//! `/var/log`, so with the belt gone a `guard-rm` that silently fails to run
+//! means `rm -rf` executes with no prompt anywhere.
+//!
+//! That failure is invisible by construction: [`Outcome::Allow`] is a silent
+//! exit 0 and only denials reach `denials.jsonl`, so "guard-rm inspected this
+//! and allowed it" and "guard-rm never ran" are byte-identical after the fact.
+//! This check makes the difference observable once per session.
+//!
+//! # What it asserts — the mechanism, not the absence of errors
+//!
+//! A healthy-looking session cannot distinguish a working guard from a lucky
+//! one, so this check does not report "no errors". It runs [`GuardRm`] against
+//! inputs whose verdicts are fixed by contract and compares:
+//!
+//! | Probe | Contract |
+//! |---|---|
+//! | an unexpanded `$VAR` operand | [`Outcome::Ask`] — unresolvable |
+//! | a `$(…)` substitution operand | [`Outcome::Ask`] — unresolvable |
+//! | a path under the temp root | [`Outcome::Allow`] — disposable |
+//!
+//! A verdict that disagrees means the classifier has regressed, and the nudge
+//! names which probe diverged. It separately reports when `guard-rm` is switched
+//! off by environment, which is the documented and advertised way to neuter it.
+//!
+//! # What it deliberately does NOT probe
+//!
+//! **The Block path** (git repo, vault, `$HOME`). Probing it needs a real
+//! `.git` on disk, and every writable fixture location is wrong: under the temp
+//! root the Temp classification is evaluated *first* and pre-empts the git-repo
+//! check (verified — `rm -rf /tmp/<dir-with-.git>` is a silent Allow), so a
+//! tempdir fixture would assert Block and get Allow, nudging falsely every
+//! session. The alternative — writing a fixture outside the temp roots at every
+//! SessionStart — is a worse hazard than the gap it would close. The Ask probes
+//! are the load-bearing ones regardless: an Ask-to-Allow regression is the
+//! silent one, and it is exactly what they catch.
+//!
+//! # What it structurally CANNOT see
+//!
+//! This check ships in the same plugin and the same binary as the guard it
+//! watches, so it shares their fate. It cannot report:
+//!
+//! - `CADENCE_BYPASS=1` — bypasses this check too, before it runs
+//! - the plugin disabled, or `hooks.json` wiring missing or inert
+//! - the binary absent or stale (`run-cadence-hooks.sh` exits 0, fail-open)
+//! - a `guard-rm` hook timeout at the moment of an actual delete
+//!
+//! Silence from this check therefore means "guard-rm's classifier is intact and
+//! not switched off", never "deletes are guarded". A self-check cannot announce
+//! its own absence; closing that half needs an observer outside this binary.
+//!
+//! # No daily gate, deliberately
+//!
+//! `platform-drift` gates its nudge to once per calendar day (#458) because a
+//! version gap persists for days and an identical nudge becomes wallpaper. This
+//! check does not: it fires only at SessionStart (already once per session), and
+//! what it reports is "your only remaining deletion guard is off or broken" —
+//! a state that should be visible every time a session opens, not once and then
+//! suppressed for 23 hours.
+//!
+//! Fail open (ADR-0001): this check never blocks. Its worst outcome is a nudge.
+
+use cadence_hooks_core::{Check, CheckResult, HookInput, Outcome};
+
+use crate::guard_rm::GuardRm;
+
+/// The hook name `CADENCE_DISABLE` matches to switch off the guard this check
+/// watches. `guard-rm` is deliberately absent from the binary's
+/// `PROTECTED_GUARDS`, so naming it here genuinely neuters it — and its own Ask
+/// message advertises the opt-out.
+const GUARDED_HOOK: &str = "guard-rm";
+
+/// A probe is one command string plus the verdict `guard-rm` is contracted to
+/// return for it. Held as data rather than a sequence of hand-written asserts so
+/// the failing probe can be named in the nudge, and so adding a case is a row
+/// rather than a new branch.
+struct Probe {
+    /// The command handed to `guard-rm`, chosen to need no filesystem state.
+    command: &'static str,
+    /// What a working classifier must return.
+    expected: Outcome,
+    /// The classification under test, for the nudge text.
+    classification: &'static str,
+}
+
+/// Probes covering the two verdicts reachable without writing to disk.
+///
+/// The `$VAR` and `$(…)` cases resolve to `Unresolvable` on the operand alone —
+/// no `stat`, no `lstat`, no dependence on what exists. The temp case is a path
+/// prefix classification, so it holds whether or not the path exists.
+const PROBES: &[Probe] = &[
+    Probe {
+        command: "rm -rf \"$CADENCE_GUARD_RM_LIVENESS_PROBE\"",
+        expected: Outcome::Ask,
+        classification: "unexpanded variable",
+    },
+    Probe {
+        command: "rm -rf $(printf %s cadence-guard-rm-liveness-probe)",
+        expected: Outcome::Ask,
+        classification: "command substitution",
+    },
+    Probe {
+        command: "rm -rf /tmp/cadence-guard-rm-liveness-probe",
+        expected: Outcome::Allow,
+        classification: "temp root",
+    },
+];
+
+/// Build the `PreToolUse` payload `guard-rm` expects for `command`.
+///
+/// Goes through [`HookInput::from_json`] rather than constructing a `HookInput`
+/// literal so the probe traverses the same parse path a real hook invocation
+/// does — payload sniffing, the `apply_patch` rewrite, and the derivation
+/// behind [`HookInput::normalized_tool_name`], which guards read instead of
+/// `tool_name`. A literal would skip all of it and probe a shape production
+/// never sees.
+fn probe_input(command: &str) -> Result<HookInput, String> {
+    let payload = serde_json::json!({
+        "session_id": "guard-rm-liveness",
+        "hook_event_name": "PreToolUse",
+        "tool_name": "Bash",
+        "tool_input": { "command": command },
+    });
+    HookInput::from_json(&payload.to_string())
+}
+
+/// Whether `guard-rm` is switched off by environment, and which switch did it.
+///
+/// Mirrors the binary's own resolution in `main()` — `CADENCE_DISABLE` is a
+/// comma-separated list of hook names, `CADENCE_BYPASS=1` is the blanket
+/// escape. Duplicated rather than shared because that logic lives in the
+/// binary's `main`, not a library crate; the duplication is the reason this
+/// check can observe the disable state at all.
+///
+/// **The duplication is load-bearing, so drift here fails toward false
+/// reassurance**: if the binary's parse ever accepts a form this one rejects,
+/// the binary skips `guard-rm` while this check reports healthy — the exact
+/// outcome the check exists to prevent. Verified identical at time of writing
+/// (`split(',')`, `trim`, exact equality; `CADENCE_BYPASS` compared against
+/// `"1"`, matching both of `main.rs`'s own copies). Any edit to either side
+/// changes both, or extracts one shared resolver into `core`.
+///
+/// `CADENCE_BYPASS` is checked for completeness of the report, not for
+/// coverage: a bypassed session never runs this check either.
+fn disabled_by_environment() -> Option<&'static str> {
+    if std::env::var("CADENCE_BYPASS").as_deref() == Ok("1") {
+        return Some("CADENCE_BYPASS=1");
+    }
+    let disabled = std::env::var("CADENCE_DISABLE").ok()?;
+    disabled
+        .split(',')
+        .any(|hook| hook.trim() == GUARDED_HOOK)
+        .then_some("CADENCE_DISABLE=guard-rm")
+}
+
+/// Assert at SessionStart that `guard-rm` is present and classifying correctly.
+pub struct GuardRmLiveness;
+
+impl Check for GuardRmLiveness {
+    fn name(&self) -> &str {
+        "guard-rm-liveness"
+    }
+
+    fn run(&self, _input: &HookInput) -> CheckResult {
+        if let Some(switch) = disabled_by_environment() {
+            return CheckResult::nudge(format!(
+                "guard-rm is switched off ({switch}). It is the only thing gating recursive \
+                 deletes — the blanket `rm -rf` / `rm -r` permission prompts were retired in \
+                 favor of it, so nothing else will ask before a delete runs. Unset it to \
+                 restore the guard."
+            ));
+        }
+
+        // A probe that fails to build is this check's own bug, not evidence
+        // about guard-rm — report it as such rather than implying the guard is
+        // broken, and never let it read as a clean bill of health either.
+        let mut divergences: Vec<String> = Vec::new();
+        for probe in PROBES {
+            let input = match probe_input(probe.command) {
+                Ok(input) => input,
+                Err(error) => {
+                    divergences.push(format!(
+                        "{} — guard-rm-liveness could not build its own probe payload ({error}); \
+                         this check is broken, guard-rm's state is unknown",
+                        probe.classification
+                    ));
+                    continue;
+                }
+            };
+            let actual = GuardRm.run(&input).outcome;
+            if actual != probe.expected {
+                divergences.push(format!(
+                    "{} — expected {:?}, got {actual:?}",
+                    probe.classification, probe.expected
+                ));
+            }
+        }
+
+        if divergences.is_empty() {
+            return CheckResult::allow();
+        }
+
+        CheckResult::nudge(format!(
+            "guard-rm is not classifying deletes as contracted — {} of {} liveness probes \
+             diverged:\n  {}\n\nguard-rm is the only thing gating recursive deletes since the \
+             blanket `rm -rf` / `rm -r` permission prompts were retired. Treat unexpected \
+             deletes as unguarded until this is resolved.",
+            divergences.len(),
+            PROBES.len(),
+            divergences.join("\n  ")
+        ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::with_env;
+    use cadence_hooks_core::test_builders::make_session;
+
+    /// Clear both switches so a test asserting the healthy path is not silently
+    /// reading an ambient `CADENCE_DISABLE` from the launching session — the
+    /// documented confound that makes env-reading checks false-pass.
+    fn with_switches_clear(f: impl FnOnce()) {
+        with_env(&[("CADENCE_DISABLE", None), ("CADENCE_BYPASS", None)], f);
+    }
+
+    #[test]
+    fn healthy_guard_is_silent() {
+        with_switches_clear(|| {
+            assert_eq!(
+                GuardRmLiveness.run(&make_session("s1", "startup")).outcome,
+                Outcome::Allow
+            );
+        });
+    }
+
+    // --- the probes assert the contract, not the current implementation ---
+
+    #[test]
+    fn every_probe_matches_the_verdict_it_claims() {
+        // The check is only worth running if its expectations are the ones
+        // guard-rm actually holds. Asserting each probe individually here means
+        // a guard-rm change that alters one of these verdicts fails THIS test
+        // with the specific probe named, rather than surfacing as a mysterious
+        // nudge in every session after release.
+        with_switches_clear(|| {
+            for probe in PROBES {
+                let input = probe_input(probe.command).expect("probe payload must parse");
+                assert_eq!(
+                    GuardRm.run(&input).outcome,
+                    probe.expected,
+                    "probe `{}` ({}) no longer matches guard-rm's verdict",
+                    probe.command,
+                    probe.classification
+                );
+            }
+        });
+    }
+
+    #[test]
+    fn probes_cover_both_reachable_verdicts() {
+        // Guards against a future edit quietly dropping the Ask probes and
+        // leaving a suite that passes while asserting nothing dangerous.
+        assert!(
+            PROBES.iter().any(|p| p.expected == Outcome::Ask),
+            "an Ask probe is the load-bearing one — an Ask-to-Allow regression is the silent one"
+        );
+        assert!(PROBES.iter().any(|p| p.expected == Outcome::Allow));
+    }
+
+    #[test]
+    fn probe_payload_resolves_to_a_bash_command() {
+        // Assert the properties guards actually read, not an internal field.
+        // `normalized_tool` stays None for a native `Bash` — there is nothing to
+        // rewrite — and `normalized_tool_name` falls back to `tool_name`, so
+        // asserting the private field would fail while the payload is correct.
+        let input = probe_input("rm -rf /tmp/x").expect("probe payload must parse");
+        assert_eq!(input.normalized_tool_name(), Some("Bash"));
+        assert_eq!(
+            input.tool_input.as_ref().and_then(|t| t.command.as_deref()),
+            Some("rm -rf /tmp/x"),
+            "guard-rm reads the command off tool_input; an empty one would probe nothing \
+             and pass for the wrong reason"
+        );
+    }
+
+    // --- the disable switches ---
+
+    #[test]
+    fn disable_naming_guard_rm_nudges() {
+        with_env(
+            &[
+                ("CADENCE_DISABLE", Some("guard-rm")),
+                ("CADENCE_BYPASS", None),
+            ],
+            || {
+                let result = GuardRmLiveness.run(&make_session("s1", "startup"));
+                assert_eq!(result.outcome, Outcome::Nudge);
+                assert!(result.message.unwrap().contains("CADENCE_DISABLE=guard-rm"));
+            },
+        );
+    }
+
+    #[test]
+    fn disable_naming_guard_rm_among_others_nudges() {
+        // The var is a comma-separated list; matching only an exact whole-value
+        // equality would miss the common multi-hook form.
+        with_env(
+            &[
+                (
+                    "CADENCE_DISABLE",
+                    Some("warn-main-branch, guard-rm ,line-endings"),
+                ),
+                ("CADENCE_BYPASS", None),
+            ],
+            || {
+                assert_eq!(
+                    GuardRmLiveness.run(&make_session("s1", "startup")).outcome,
+                    Outcome::Nudge
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn disable_naming_other_hooks_is_silent() {
+        // The control: a populated CADENCE_DISABLE that does NOT name guard-rm
+        // must stay silent, or the check reports every disabled hook as this one.
+        with_env(
+            &[
+                ("CADENCE_DISABLE", Some("warn-main-branch,line-endings")),
+                ("CADENCE_BYPASS", None),
+            ],
+            || {
+                assert_eq!(
+                    GuardRmLiveness.run(&make_session("s1", "startup")).outcome,
+                    Outcome::Allow
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn disable_substring_of_another_hook_name_is_silent() {
+        // `guard-rm-liveness` contains `guard-rm`; a substring match would read
+        // disabling THIS check as disabling the guard it watches.
+        with_env(
+            &[
+                ("CADENCE_DISABLE", Some("guard-rm-liveness")),
+                ("CADENCE_BYPASS", None),
+            ],
+            || {
+                assert_eq!(
+                    GuardRmLiveness.run(&make_session("s1", "startup")).outcome,
+                    Outcome::Allow
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn bypass_nudges() {
+        with_env(
+            &[("CADENCE_BYPASS", Some("1")), ("CADENCE_DISABLE", None)],
+            || {
+                let result = GuardRmLiveness.run(&make_session("s1", "startup"));
+                assert_eq!(result.outcome, Outcome::Nudge);
+                assert!(result.message.unwrap().contains("CADENCE_BYPASS=1"));
+            },
+        );
+    }
+
+    #[test]
+    fn bypass_set_to_other_values_is_silent() {
+        // The binary treats only "1" as bypass; a looser truthiness check here
+        // would diverge from the enforcement it is reporting on.
+        with_env(
+            &[("CADENCE_BYPASS", Some("0")), ("CADENCE_DISABLE", None)],
+            || {
+                assert_eq!(
+                    GuardRmLiveness.run(&make_session("s1", "startup")).outcome,
+                    Outcome::Allow
+                );
+            },
+        );
+    }
+
+    #[test]
+    fn never_blocks() {
+        // ADR-0001: this check's worst outcome is a nudge, in every state.
+        with_env(
+            &[
+                ("CADENCE_DISABLE", Some("guard-rm")),
+                ("CADENCE_BYPASS", None),
+            ],
+            || {
+                assert_ne!(
+                    GuardRmLiveness.run(&make_session("s1", "startup")).outcome,
+                    Outcome::Block
+                );
+            },
+        );
+    }
+}

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -115,6 +115,8 @@ pub mod guard_push_remote;
 pub mod guard_read_model;
 /// Path-aware triage of rm-family delete commands (allow/ask/block).
 pub mod guard_rm;
+/// SessionStart assertion that `guard-rm` is present and classifying correctly.
+pub mod guard_rm_liveness;
 /// Inject the gh-write allowlist + `-R` rule on SessionStart.
 pub mod inject_gh_context;
 /// Re-inject the gh-write allowlist + `-R` rule just before an untargeted gh write.

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "binaryVersion": "0.70.1",
+  "binaryVersion": "0.71.0",
   "minimumCodexVersion": "0.145.0",
   "privacy": {
     "rawHookInputsPersisted": false,
@@ -822,6 +822,18 @@
           "commandHash": "75602022397b59ae8b3b84d1b0ec27202f5f49f0708bcd6fcfaf71395d0fb036"
         }
       ]
+    },
+    {
+      "criticality": "workflow",
+      "description": "Assert at SessionStart that guard-rm is present and classifying as contracted",
+      "event": "SessionStart",
+      "name": "guard-rm-liveness",
+      "plugin": "guardrails",
+      "protected": false,
+      "status": "native",
+      "applicable": false,
+      "evidence": "registered in the binary but not yet invoked: the cadence-guardrails SessionStart wiring ships in a companion monorepo PR. Flip to applicable when that wiring merges.",
+      "wiring": []
     },
     {
       "criticality": "security-critical",

--- a/src/main.rs
+++ b/src/main.rs
@@ -251,6 +251,8 @@ enum GuardrailsCommands {
     GuardDotfiles,
     /// Path-aware triage of rm-family deletes (allow temp/managed, block home/vault/repo, ask the rest)
     GuardRm,
+    /// SessionStart assertion that guard-rm is present and classifying deletes as contracted
+    GuardRmLiveness,
     /// Block Read/Grep by resolved session model (opt-in via CADENCE_READ_MODEL_GUARD_MODELS)
     GuardReadModel,
     /// Nudge when `gh pr create` has no closing issue keyword in the body
@@ -433,6 +435,7 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::WarnUntracked => "warn-untracked",
             GuardrailsCommands::GuardDotfiles => "guard-dotfiles",
             GuardrailsCommands::GuardRm => "guard-rm",
+            GuardrailsCommands::GuardRmLiveness => "guard-rm-liveness",
             GuardrailsCommands::GuardReadModel => "guard-read-model",
             GuardrailsCommands::WarnPrIssueLink => "warn-pr-issue-link",
             GuardrailsCommands::WarnIssueTracker => "warn-issue-tracker",
@@ -1005,6 +1008,11 @@ fn main() {
             GuardrailsCommands::GuardRm => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_rm::GuardRm,
                 pre,
+                canonical_hook,
+            ),
+            GuardrailsCommands::GuardRmLiveness => dispatch::run_logged_check(
+                &cadence_hooks_guardrails::guard_rm_liveness::GuardRmLiveness,
+                session,
                 canonical_hook,
             ),
             GuardrailsCommands::GuardReadModel => dispatch::run_logged_check(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -192,6 +192,12 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::PreToolUse),
     },
     HookEntry {
+        name: "guard-rm-liveness",
+        description: "Assert at SessionStart that guard-rm is present and classifying as contracted",
+        plugin: "guardrails",
+        event: Some(HookEvent::SessionStart),
+    },
+    HookEntry {
         name: "guard-read-model",
         description: "Block Read/Grep by resolved session model (opt-in)",
         plugin: "guardrails",

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -250,10 +250,13 @@ const PENDING_PLUGIN_GROUPS: &[(&str, &str)] = &[];
 /// binary so the wiring PR has something to point at, and reaching no event
 /// until that PR lands.
 /// (`<plugin> <subcommand>`, tracking_reference)
-const PENDING_WIRING_HOOKS: &[(&str, &str)] = &[(
-    "guardrails inject-gh-write-context",
-    "cameronsjo/cadence#653",
-)];
+const PENDING_WIRING_HOOKS: &[(&str, &str)] = &[
+    (
+        "guardrails inject-gh-write-context",
+        "cameronsjo/cadence#653",
+    ),
+    ("guardrails guard-rm-liveness", "cameronsjo/cadence#760"),
+];
 
 /// Bash-matcher hooks that intentionally inspect every command (no `if` filter).
 /// These run broad pattern matching internally and can't be narrowed to a single glob.


### PR DESCRIPTION
## Why

Two blanket `permissions.ask` rows — `Bash(rm -rf:*)` and `Bash(rm -r:*)` — were retired on 2026-08-03 in favor of `guard-rm`, which classifies by filesystem state where a literal prefix rule cannot. Those rows had been the belt under every path where the guard fails to run: if it did not fire, the settings row still prompted.

With them gone, `Bash(rm:*)` sits in `allow` and `deny` covers only `/` and `/var/log`. A `guard-rm` that silently does not run means a recursive delete executes with no prompt anywhere.

That failure is invisible by construction. `Outcome::Allow` is a silent exit 0 and only denials reach `denials.jsonl`, so "guard-rm inspected this and allowed it" and "guard-rm never ran" are byte-identical after the fact. There is no way to audit, after a delete, whether the sole remaining gate was alive.

## What it does

Asserts the **mechanism**, not the absence of errors — a healthy-looking session cannot distinguish a working guard from a lucky one. It runs `guard-rm` against inputs whose verdicts are fixed by contract:

| Probe | Contract |
|---|---|
| unexpanded `$VAR` operand | `Ask` — unresolvable |
| `$(…)` substitution operand | `Ask` — unresolvable |
| path under the temp root | `Allow` — disposable |
| top-level entry under `$HOME` | `Block` — protected |

None of the four writes to disk.

A diverging verdict nudges naming the probe. It separately reports `CADENCE_DISABLE=guard-rm` and `CADENCE_BYPASS=1`.

**No daily gate**, deliberately — unlike `platform-drift` (#458). What it reports is "your only remaining deletion guard is off or broken", which should be visible every session rather than suppressed for 23 hours. It fires at SessionStart only, so it is already low-frequency.

## Two limits, documented in the module rather than left to be rediscovered

**It cannot announce its own absence.** It ships in the same plugin and binary as the guard it watches, so it shares their fate: it cannot report a bypassed session, a disabled plugin, inert or missing wiring, an absent or stale binary, or a `guard-rm` timeout at the moment of a delete. Silence means "the classifier is intact and not switched off", never "deletes are guarded". Closing that half needs an observer outside this binary.

**It does not probe the git-repo Block path.** Unlike the home case, that needs a real `.git` on disk, and every writable fixture location is wrong. Under the temp root the Temp classification is evaluated *first* and pre-empts the git-repo check — verified: `rm -rf /tmp/<dir-containing-.git>` is a silent Allow, while the identical tree under a non-temp path blocks. A tempdir fixture would assert Block, get Allow, and nudge falsely every session; writing a fixture outside the temp roots at every SessionStart is a worse hazard than the gap it closes.

## A real `guard-rm` defect found while building this — and now detected

The first three probes could all pass **while real deletes went unguarded**, which is the exact failure this check exists to prevent.

`guard-rm` resolves its temp roots partly from `$TMPDIR`. A `$TMPDIR` pointing at a directory that holds real work silently reclassifies that whole subtree as disposable:

```
rm -rf ~/Documents
  TMPDIR=/var/folders/xx/T/   -> BLOCK "top-level entry in your home directory"
  TMPDIR=$HOME                -> silent ALLOW
```

No adversary needed. `TMPDIR` is settable in `.claude/settings.json`'s `env` block, and build systems, sandboxes, and CI wrappers routinely re-point it at a workspace-local directory — costing protection for exactly the tree being worked in.

None of the three original probes has an operand under the widened root, so all three still passed and the check reported healthy. **The fourth probe is the fix for that gap**: it runs under the session's real `$TMPDIR`, so a widened one flips it Block to Allow and the check goes loud. Verified end-to-end: `1 of 4 liveness probes diverged: home directory — expected Block, got Allow`.

The underlying defect is filed as cameronsjo/cadence-hooks#569. This PR is the detection, not the fix.

That pre-emption is worth a separate look: this estate deliberately parks real checkouts under temp (`git worktree add /tmp/<wt>` appears in its own operating docs), and `rm -rf` on one carries no prompt.

## Deliberately inert until the wiring lands

The check is registered so the wiring PR has something to point at, but reaches no event until `plugins/cadence-guardrails/hooks/hooks.json` wires it (cameronsjo/cadence#760). It is held in `PENDING_WIRING_HOOKS` with that reference and marked inapplicable in the Codex compatibility report; both come back out in the wiring PR.

## One unrelated fix, called out

`docs/codex-compatibility-report.json`'s `binaryVersion` had been stale at 0.70.1 since the 0.71.0 bump commit, leaving `make ci`'s `report-check` **red on `main`** before this branch existed. Fixed here so this PR is not red for someone else's reason. The release procedure regenerating this report is a genuine gap — the CLAUDE.md release steps cover the platform baseline but not this file.

Note the report could not simply be regenerated: `generate-codex-report.py --workspace` defaults to the repo's parent, which from a worktree is `.claude/worktrees/`, so it finds no plugin checkout and empties every hook's `wiring` array. The sibling `cadence/` checkout is also on a peer's branch, 49 behind. The one new entry was therefore inserted by hand, verified byte-identical to what a correct regeneration would emit for every non-`wiring` field.

## Verification

`make ci` green. 13 unit tests, including controls: a populated `CADENCE_DISABLE` that does not name `guard-rm` must stay silent, and `guard-rm-liveness` itself being disabled must not read as the guard being disabled (a substring match would).

End-to-end against the built binary, with a control:

- healthy, nothing disabled → silent, exit 0
- `CADENCE_DISABLE=guard-rm` → nudges, naming the switch
- `CADENCE_DISABLE=warn-main-branch` → silent

Refs cameronsjo/cadence#760
Refs cameronsjo/cadence-hooks#567
Refs cameronsjo/cadence-hooks#569

Session-Name: russet-anchor
Session-Id: 6d95c310-abbf-4b92-a8e7-0e28d388b132
Model: claude-opus-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7
