### PR TITLE
fix(config): one malformed key no longer voids its whole cadence.json section

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -222,6 +222,7 @@ dependencies = [
  "jiff",
  "regex",
  "serde",
+ "serde_ignored",
  "serde_json",
  "tempfile",
 ]
@@ -881,6 +882,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ repository = "https://github.com/cameronsjo/cadence-hooks"
 [workspace.dependencies]
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+serde_ignored = "0.1"
 regex = "1"
 clap = { version = "4", features = ["derive"] }
 brush-parser = "0.3"

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -334,14 +334,15 @@ impl Check for RedactExternalContent {
     }
 }
 
-/// Render config-load warnings as one nudge block.
+/// Render config-load warnings as one nudge block. NB this fires on every
+/// gated posting command (incl. `git commit`) until the config is fixed —
+/// accepted cost: the whole point is that the drop is no longer silent, and
+/// the fix is a one-time config edit the message names precisely.
 fn build_config_warning(warnings: &[String]) -> String {
-    let mut out =
-        String::from("⚠️  redact-external-content: config anomalies in .claude/cadence.json:\n");
-    for w in warnings {
-        out.push_str(&format!("  {w}\n"));
-    }
-    out
+    format!(
+        "⚠️  redact-external-content: config anomalies in .claude/cadence.json:\n{}",
+        cadence_hooks_core::config::render_config_warnings(warnings)
+    )
 }
 
 /// Resolve the directory to read `.claude/cadence.json` from and to resolve a

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -300,7 +300,11 @@ impl Check for RedactExternalContent {
         }
 
         // Phase 3 — config (per-repo additional patterns + allowlist + tiers).
-        let config = load_redaction_config(&base_dir);
+        // Lenient (#536): a malformed key is dropped and NAMED, the rest of
+        // the section still applies — one bad `categories` shape no longer
+        // silently voids a valid `allowlist` beside it.
+        let loaded = load_redaction_config(&base_dir);
+        let config = loaded.config;
 
         // Phase 3.5 — resolve the destination-tier ordinal once. `CADENCE_AUDIENCE`
         // wins over the config's `originAudience`; both fall back to public.
@@ -313,12 +317,31 @@ impl Check for RedactExternalContent {
             hits.extend(scan_body(body, &config, d));
         }
 
-        if hits.is_empty() {
-            CheckResult::allow()
-        } else {
-            CheckResult::nudge(build_message(&hits))
+        // Config warnings ride the nudge channel (exit 0 / stdout → lands in
+        // the transcript). A clean scan with a broken config still nudges —
+        // otherwise the drop is exactly as silent as the #536 defect was.
+        let warnings = loaded.warnings;
+        match (hits.is_empty(), warnings.is_empty()) {
+            (true, true) => CheckResult::allow(),
+            (true, false) => CheckResult::nudge(build_config_warning(&warnings)),
+            (false, true) => CheckResult::nudge(build_message(&hits)),
+            (false, false) => CheckResult::nudge(format!(
+                "{}\n{}",
+                build_message(&hits),
+                build_config_warning(&warnings)
+            )),
         }
     }
+}
+
+/// Render config-load warnings as one nudge block.
+fn build_config_warning(warnings: &[String]) -> String {
+    let mut out =
+        String::from("⚠️  redact-external-content: config anomalies in .claude/cadence.json:\n");
+    for w in warnings {
+        out.push_str(&format!("  {w}\n"));
+    }
+    out
 }
 
 /// Resolve the directory to read `.claude/cadence.json` from and to resolve a
@@ -434,11 +457,16 @@ fn read_body_file(path: &str, base_dir: &str) -> Option<String> {
 /// default (empty) config. The legacy `.claude/redaction.json` is no longer
 /// read (hard cut); `cadence-hooks migrate-config` converts a repo and
 /// `cadence-hooks doctor` warns on an orphaned legacy file.
-fn load_redaction_config(base_dir: &str) -> RedactionConfig {
+fn load_redaction_config(
+    base_dir: &str,
+) -> cadence_hooks_core::config::SectionLoad<RedactionConfig> {
     let Some(root) = cadence_hooks_core::paths::find_git_root(base_dir) else {
-        return RedactionConfig::default();
+        return cadence_hooks_core::config::SectionLoad {
+            config: RedactionConfig::default(),
+            warnings: Vec::new(),
+        };
     };
-    cadence_hooks_core::config::load_cadence_section(&root, "redaction")
+    cadence_hooks_core::config::load_cadence_section_lenient(&root, "redaction")
 }
 
 /// Resolve the destination-tier ordinal (PURE — env passed as an argument, never
@@ -1221,6 +1249,47 @@ mod tests {
         let cmd = "gh pr create --body \"see cadence:attune\"";
         let input = make_bash_with_cwd(cmd, repo.path().to_str().unwrap());
         assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Nudge);
+    }
+
+    #[test]
+    fn malformed_key_does_not_void_valid_allowlist() {
+        // #536's exact shape: bare strings under additionalPatterns (the
+        // struct wants objects) used to void the WHOLE redaction section, so
+        // the valid allowlist beside it went inert. Lenient loading drops
+        // only the malformed key; the allowlist still suppresses.
+        let repo = temp_repo_with_config(
+            r#"{"allowlist":["tool_input"],"additionalPatterns":["zorblax"]}"#,
+        );
+        let cmd = "gh pr create --body \"rename tool_input everywhere\"";
+        let input = make_bash_with_cwd(cmd, repo.path().to_str().unwrap());
+        let result = RedactExternalContent.run(&input);
+        // The suppression works (no harness-noun hit), and the drop is named
+        // in the transcript instead of silent: outcome is a Nudge carrying
+        // the config warning, not a clean Allow.
+        assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.expect("config warning should surface");
+        assert!(
+            msg.contains("additionalPatterns"),
+            "warning must name the dropped key: {msg}"
+        );
+        assert!(
+            !msg.contains("[harness-noun]"),
+            "allowlist must still suppress the scan hit: {msg}"
+        );
+    }
+
+    #[test]
+    fn config_warning_rides_along_with_scan_hits() {
+        // Broken key + a real hit: one nudge carries both the hit lines and
+        // the config-anomaly block.
+        let repo = temp_repo_with_config(r#"{"additionalPatterns":["zorblax"]}"#);
+        let cmd = "gh pr create --body \"see cadence:attune\"";
+        let input = make_bash_with_cwd(cmd, repo.path().to_str().unwrap());
+        let result = RedactExternalContent.run(&input);
+        assert_eq!(result.outcome, Outcome::Nudge);
+        let msg = result.message.unwrap();
+        assert!(msg.contains("cadence:attune"));
+        assert!(msg.contains("additionalPatterns"));
     }
 
     #[cfg(unix)]

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -426,11 +426,10 @@ impl Check for TerminologyGuard {
         let warning_block = if config_warnings.is_empty() {
             String::new()
         } else {
-            let mut w = String::from("\nConfig anomalies in .claude/cadence.json:\n");
-            for line in &config_warnings {
-                w.push_str(&format!("  {line}\n"));
-            }
-            w
+            format!(
+                "\nConfig anomalies in .claude/cadence.json:\n{}",
+                cadence_hooks_core::config::render_config_warnings(&config_warnings)
+            )
         };
 
         // Tier 1: hard block

--- a/crates/cadence/src/terminology.rs
+++ b/crates/cadence/src/terminology.rs
@@ -289,8 +289,15 @@ fn glob_match(pattern: &str, rel_path: &str, basename: &str) -> bool {
 /// (fail-open, ADR-0001). The legacy `.claude/terminology.json` is no longer
 /// read — a hard cut; `cadence-hooks migrate-config` converts a repo and
 /// `cadence-hooks doctor` warns on an orphaned legacy file.
-fn load_terminology_config(root: &Path) -> TerminologyConfig {
-    cadence_hooks_core::config::load_cadence_section(root, "terminology")
+fn load_terminology_config(
+    root: &Path,
+) -> cadence_hooks_core::config::SectionLoad<TerminologyConfig> {
+    // Lenient (#536 family): the section's known key set is `exemptions`
+    // (entries: `paths`, `terms`, `mode`). A malformed key is dropped and
+    // named; the rest of the section applies. NB the fail direction here is
+    // already safe — dropped exemptions mean MORE blocking, never less — so
+    // the warning exists for legibility, not safety.
+    cadence_hooks_core::config::load_cadence_section_lenient(root, "terminology")
 }
 
 /// Apply per-repo `.claude/cadence.json` `terminology` softening to the accumulated
@@ -303,17 +310,18 @@ fn apply_exemptions(
     file_path: &str,
     blocks: &mut Vec<(String, String)>,
     nudges: &mut Vec<(String, String)>,
-) {
+) -> Vec<String> {
     let start_dir = Path::new(file_path)
         .parent()
         .map(|p| p.to_string_lossy().into_owned())
         .unwrap_or_else(|| ".".to_string());
     let Some(root) = cadence_hooks_core::paths::find_git_root(&start_dir) else {
-        return;
+        return Vec::new();
     };
-    let config = load_terminology_config(&root);
+    let loaded = load_terminology_config(&root);
+    let config = loaded.config;
     if config.exemptions.is_empty() {
-        return;
+        return loaded.warnings;
     }
 
     let rel_path = Path::new(file_path)
@@ -349,6 +357,7 @@ fn apply_exemptions(
             nudges.push(d);
         }
     }
+    loaded.warnings
 }
 
 /// Blocks content containing prohibited terminology and suggests alternatives.
@@ -404,11 +413,25 @@ impl Check for TerminologyGuard {
         // violation to soften and we know the file path (so a clean edit never
         // touches disk). The hardcoded is_excluded_path() baseline above still
         // applies; this only ever removes or demotes a violation, never adds one.
+        let mut config_warnings: Vec<String> = Vec::new();
         if (!blocks.is_empty() || !nudges.is_empty())
             && let Some(ref path) = input.file_path()
         {
-            apply_exemptions(path, &mut blocks, &mut nudges);
+            config_warnings = apply_exemptions(path, &mut blocks, &mut nudges);
         }
+        // Render config anomalies (a dropped malformed key, an unknown key)
+        // as one appended block — #536 family: a dropped exemption key means
+        // MORE blocking here, so the user needs the drop named to understand
+        // why an exemption they wrote is not softening.
+        let warning_block = if config_warnings.is_empty() {
+            String::new()
+        } else {
+            let mut w = String::from("\nConfig anomalies in .claude/cadence.json:\n");
+            for line in &config_warnings {
+                w.push_str(&format!("  {line}\n"));
+            }
+            w
+        };
 
         // Tier 1: hard block
         if !blocks.is_empty() {
@@ -427,6 +450,7 @@ impl Check for TerminologyGuard {
             for (term, replacement) in &blocks {
                 msg.push_str(&format!("  {term} → {replacement}\n"));
             }
+            msg.push_str(&warning_block);
 
             return CheckResult::block(msg);
         }
@@ -442,8 +466,16 @@ impl Check for TerminologyGuard {
             for (term, replacement) in &nudges {
                 msg.push_str(&format!("  {term} → {replacement}\n"));
             }
+            msg.push_str(&warning_block);
 
             return CheckResult::nudge(msg);
+        }
+
+        if !warning_block.is_empty() {
+            // Every violation was exempted away, but the config that did (or
+            // failed to do) the softening has anomalies — name them rather
+            // than exiting silent.
+            return CheckResult::nudge(format!("⚠️  terminology-guard:{warning_block}"));
         }
 
         CheckResult::allow()
@@ -1419,14 +1451,14 @@ mod tests {
     #[test]
     fn load_terminology_config_missing_file_is_default() {
         let dir = tempfile::tempdir().unwrap();
-        let config = load_terminology_config(dir.path());
+        let config = load_terminology_config(dir.path()).config;
         assert!(config.exemptions.is_empty());
     }
 
     #[test]
     fn load_terminology_config_reads_exemptions() {
         let repo = temp_repo(r#"{"exemptions":[{"paths":["a.yml"]},{"paths":["b.yml"]}]}"#);
-        let config = load_terminology_config(repo.path());
+        let config = load_terminology_config(repo.path()).config;
         assert_eq!(config.exemptions.len(), 2);
     }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -11,6 +11,7 @@ test-builders = []
 [dependencies]
 serde.workspace = true
 serde_json.workspace = true
+serde_ignored.workspace = true
 regex.workspace = true
 brush-parser.workspace = true
 jiff.workspace = true

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -392,22 +392,194 @@ pub const CADENCE_CONFIG_REL: &str = ".claude/cadence.json";
 /// sections re-reads the file N times per tool event — acceptable at N≈2 with a
 /// 1 MiB cap, and it keeps each guard's read independent and fail-open.
 pub fn load_cadence_section<T: Default + DeserializeOwned>(root: &Path, section: &str) -> T {
+    load_cadence_section_lenient(root, section).config
+}
+
+/// A leniently loaded config section: the deserialized config plus warnings
+/// naming what was dropped or unrecognized on the way.
+pub struct SectionLoad<T> {
+    pub config: T,
+    /// Human-readable, one per anomaly — a malformed known key that was
+    /// dropped (the rest of the section still applied), or an unknown key
+    /// serde ignored. Empty on a clean load AND on a wholly absent
+    /// file/section (absence is the documented default, not an anomaly).
+    pub warnings: Vec<String>,
+}
+
+/// [`load_cadence_section`], but a malformed KEY no longer voids its whole
+/// SECTION — and the drop is named instead of silent (cadence-hooks#536: a
+/// bare-string `categories` entry silently discarded a valid `allowlist`
+/// sitting next to it, which reads as "the allowlist doesn't work").
+///
+/// Semantics, per failure class:
+/// - missing file / unreadable / invalid JSON / absent `section` → default,
+///   no warnings (unchanged fail-open, ADR-0001);
+/// - `section` present but not a JSON object → default + one warning;
+/// - object that deserializes cleanly → config + a warning per unknown key
+///   (detected via `serde_ignored` — adopted over a hand-rolled known-key
+///   registry because a generic `T` cannot enumerate its own fields, which
+///   would have forced a per-guard key-set trait);
+/// - object where strict deserialization fails → per-key retry: each key is
+///   probed as a single-key object (sound: serde derives deserialize struct
+///   fields independently), failing keys are dropped with a warning naming
+///   `<section>.<key>`, and the surviving subset is deserialized. If even the
+///   surviving subset fails (shouldn't happen — every key in it probed clean),
+///   fall back to default.
+///
+/// The caller owns the warning CHANNEL: the hook surfaces warnings on stdout
+/// (nudge — exit 0, lands in the transcript), a CLI subcommand surfaces them
+/// on stderr (its stdout may be parsed by consumers).
+pub fn load_cadence_section_lenient<T: Default + DeserializeOwned>(
+    root: &Path,
+    section: &str,
+) -> SectionLoad<T> {
+    let clean = |config| SectionLoad {
+        config,
+        warnings: Vec::new(),
+    };
     let path = root.join(CADENCE_CONFIG_REL);
     let Some(content) = read_untrusted_config(&path) else {
-        return T::default();
+        return clean(T::default());
     };
     let Some(value) = parse_jsonc(&content) else {
-        return T::default();
+        return clean(T::default());
     };
-    value
-        .get(section)
-        .and_then(|v| serde_json::from_value(v.clone()).ok())
-        .unwrap_or_default()
+    let Some(section_value) = value.get(section) else {
+        return clean(T::default());
+    };
+    let Some(obj) = section_value.as_object() else {
+        return SectionLoad {
+            config: T::default(),
+            warnings: vec![format!(
+                ".claude/cadence.json: `{section}` is not an object — section ignored"
+            )],
+        };
+    };
+
+    // Happy path: strict deserialize, with serde_ignored collecting unknown
+    // keys as informational warnings (they were silently ignored before too —
+    // now they're named, so a typo'd key no longer reads as a working one).
+    let mut unknown: Vec<String> = Vec::new();
+    let strict: Result<T, _> = serde_ignored::deserialize(section_value.clone(), |ignored_path| {
+        unknown.push(format!(
+            ".claude/cadence.json: unknown key `{section}.{ignored_path}` — ignored"
+        ));
+    });
+    if let Ok(config) = strict {
+        return SectionLoad {
+            config,
+            warnings: unknown,
+        };
+    }
+
+    // Per-key retry: drop (and name) each key that fails on its own; apply
+    // the surviving subset.
+    let mut warnings: Vec<String> = Vec::new();
+    let mut good = serde_json::Map::new();
+    for (key, val) in obj {
+        let probe =
+            serde_json::Value::Object(serde_json::Map::from_iter([(key.clone(), val.clone())]));
+        if serde_json::from_value::<T>(probe).is_ok() {
+            good.insert(key.clone(), val.clone());
+        } else {
+            warnings.push(format!(
+                ".claude/cadence.json: `{section}.{key}` has an invalid shape — key ignored, rest of the section applied"
+            ));
+        }
+    }
+    let config = serde_json::from_value(serde_json::Value::Object(good)).unwrap_or_default();
+    SectionLoad { config, warnings }
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    mod lenient_section {
+        use super::super::*;
+        use serde::Deserialize;
+
+        #[derive(Debug, Default, Deserialize)]
+        #[serde(rename_all = "camelCase")]
+        struct Demo {
+            #[serde(default)]
+            allowlist: Vec<String>,
+            #[serde(default)]
+            patterns: Vec<Entry>,
+        }
+
+        #[derive(Debug, Deserialize)]
+        struct Entry {
+            #[allow(dead_code)]
+            pattern: String,
+        }
+
+        fn root_with(config: &str) -> tempfile::TempDir {
+            let dir = tempfile::tempdir().unwrap();
+            std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+            std::fs::write(dir.path().join(".claude/cadence.json"), config).unwrap();
+            dir
+        }
+
+        #[test]
+        fn malformed_key_does_not_void_section() {
+            // #536: bare strings where the struct wants objects previously
+            // voided the WHOLE section — the valid allowlist beside it died.
+            let dir = root_with(r#"{"demo":{"allowlist":["harness"],"patterns":["zorblax"]}}"#);
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert_eq!(loaded.config.allowlist, vec!["harness"]);
+            assert!(loaded.config.patterns.is_empty());
+            assert_eq!(loaded.warnings.len(), 1);
+            assert!(
+                loaded.warnings[0].contains("demo.patterns"),
+                "warning must name the dropped key: {:?}",
+                loaded.warnings
+            );
+        }
+
+        #[test]
+        fn unknown_key_warns_but_config_applies() {
+            let dir = root_with(r#"{"demo":{"allowlist":["a"],"resolveVisibilty":true}}"#);
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert_eq!(loaded.config.allowlist, vec!["a"]);
+            assert_eq!(loaded.warnings.len(), 1);
+            assert!(loaded.warnings[0].contains("resolveVisibilty"));
+        }
+
+        #[test]
+        fn clean_section_no_warnings() {
+            let dir = root_with(r#"{"demo":{"allowlist":["a"],"patterns":[{"pattern":"x"}]}}"#);
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert_eq!(loaded.config.allowlist, vec!["a"]);
+            assert_eq!(loaded.config.patterns.len(), 1);
+            assert!(loaded.warnings.is_empty());
+        }
+
+        #[test]
+        fn absent_section_is_silent_default() {
+            let dir = root_with(r#"{"other":{}}"#);
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert!(loaded.config.allowlist.is_empty());
+            assert!(loaded.warnings.is_empty());
+        }
+
+        #[test]
+        fn non_object_section_warns_and_defaults() {
+            let dir = root_with(r#"{"demo":"nope"}"#);
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert!(loaded.config.allowlist.is_empty());
+            assert_eq!(loaded.warnings.len(), 1);
+            assert!(loaded.warnings[0].contains("not an object"));
+        }
+
+        #[test]
+        fn invalid_json_is_silent_default() {
+            let dir = root_with("{not json");
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert!(loaded.config.allowlist.is_empty());
+            assert!(loaded.warnings.is_empty());
+        }
+    }
 
     #[test]
     fn space_separated() {

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -392,6 +392,10 @@ pub const CADENCE_CONFIG_REL: &str = ".claude/cadence.json";
 /// sections re-reads the file N times per tool event — acceptable at N≈2 with a
 /// 1 MiB cap, and it keeps each guard's read independent and fail-open.
 pub fn load_cadence_section<T: Default + DeserializeOwned>(root: &Path, section: &str) -> T {
+    // NB: since the lenient rework (#536), a partially-malformed section
+    // returns a PARTIAL config (surviving keys applied), not `T::default()`
+    // — only whole-file/whole-section absence or a non-object section still
+    // defaults. This wrapper just drops the warnings.
     load_cadence_section_lenient(root, section).config
 }
 
@@ -426,9 +430,21 @@ pub struct SectionLoad<T> {
 ///   surviving subset fails (shouldn't happen — every key in it probed clean),
 ///   fall back to default.
 ///
-/// The caller owns the warning CHANNEL: the hook surfaces warnings on stdout
-/// (nudge — exit 0, lands in the transcript), a CLI subcommand surfaces them
-/// on stderr (its stdout may be parsed by consumers).
+/// The caller owns the warning CHANNEL: a hook surfaces warnings on stdout
+/// (nudge — exit 0, lands in the transcript); any future CLI consumer MUST
+/// surface them on stderr instead (its stdout may be parsed) — recorded here
+/// as the rule, no CLI caller exists yet.
+///
+/// Granularity is the TOP-LEVEL key, not recursive: one malformed entry
+/// inside a `Vec`/map-typed key drops that whole key (named), keeping its
+/// valid sibling entries out too. Accepted v1 cost — recursing into
+/// container entries is a follow-up if it bites.
+///
+/// Soundness caveat for future `T`s: the per-key probe assumes top-level
+/// fields deserialize independently (true for plain derives with
+/// `#[serde(default)]`, which every current section uses). A section type
+/// with `deny_unknown_fields`, `flatten`, or jointly-validated required
+/// fields would misbehave under the probe — don't hand one to this loader.
 pub fn load_cadence_section_lenient<T: Default + DeserializeOwned>(
     root: &Path,
     section: &str,
@@ -462,7 +478,9 @@ pub fn load_cadence_section_lenient<T: Default + DeserializeOwned>(
     let mut unknown: Vec<String> = Vec::new();
     let strict: Result<T, _> = serde_ignored::deserialize(section_value.clone(), |ignored_path| {
         unknown.push(format!(
-            ".claude/cadence.json: unknown key `{section}.{ignored_path}` — ignored"
+            ".claude/cadence.json: unknown key `{}.{}` — ignored",
+            section,
+            sanitize_key(&ignored_path.to_string())
         ));
     });
     if let Ok(config) = strict {
@@ -473,7 +491,9 @@ pub fn load_cadence_section_lenient<T: Default + DeserializeOwned>(
     }
 
     // Per-key retry: drop (and name) each key that fails on its own; apply
-    // the surviving subset.
+    // the surviving subset. The final deserialize runs through serde_ignored
+    // too, so unknown keys in the surviving subset are still named — the
+    // retry path warns identically to the happy path for the same key.
     let mut warnings: Vec<String> = Vec::new();
     let mut good = serde_json::Map::new();
     for (key, val) in obj {
@@ -483,12 +503,79 @@ pub fn load_cadence_section_lenient<T: Default + DeserializeOwned>(
             good.insert(key.clone(), val.clone());
         } else {
             warnings.push(format!(
-                ".claude/cadence.json: `{section}.{key}` has an invalid shape — key ignored, rest of the section applied"
+                ".claude/cadence.json: `{}.{}` has an invalid shape — key ignored, rest of the section applied",
+                section,
+                sanitize_key(key)
             ));
         }
     }
-    let config = serde_json::from_value(serde_json::Value::Object(good)).unwrap_or_default();
-    SectionLoad { config, warnings }
+    match serde_ignored::deserialize(serde_json::Value::Object(good), |ignored_path| {
+        warnings.push(format!(
+            ".claude/cadence.json: unknown key `{}.{}` — ignored",
+            section,
+            sanitize_key(&ignored_path.to_string())
+        ));
+    }) {
+        Ok(config) => SectionLoad { config, warnings },
+        // Shouldn't happen — every surviving key probed clean individually —
+        // but if it does (a future cross-field-validated T), the earlier
+        // "rest of the section applied" warnings would be a FALSE claim about
+        // active controls. Replace them with the truth.
+        Err(_) => SectionLoad {
+            config: T::default(),
+            warnings: vec![format!(
+                ".claude/cadence.json: `{section}` could not be applied even after dropping malformed keys — whole section ignored"
+            )],
+        },
+    }
+}
+
+/// Bound what an untrusted config can echo into a hook message. The file is
+/// repo-controlled and the message is later read by a model, so a key name is
+/// reduced to a strict charset (`A-Za-z0-9 _ . - [ ]` — everything a
+/// legitimate serde path contains; anything else becomes `?`) and capped at
+/// 80 chars. No newlines/ANSI survive (they're outside the charset), so an
+/// echoed key can neither start a message line (the `Fix:`-suppression lever
+/// in render_output) nor forge additional lines.
+fn sanitize_key(key: &str) -> String {
+    let cleaned: String = key
+        .chars()
+        .take(80)
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || matches!(c, '_' | '.' | '-' | '[' | ']') {
+                c
+            } else {
+                '?'
+            }
+        })
+        .collect();
+    if key.chars().count() > 80 {
+        format!("{cleaned}…")
+    } else {
+        cleaned
+    }
+}
+
+/// Cap for rendered warning lists ([`render_config_warnings`]): a config with
+/// thousands of bad keys must not balloon the hook message it rides in.
+const MAX_RENDERED_WARNINGS: usize = 5;
+
+/// Render section-load warnings as one indented block, shared by every hook
+/// consumer so the format cannot drift. Caps at [`MAX_RENDERED_WARNINGS`]
+/// lines with an elision count — an attacker-shaped config with thousands of
+/// bad keys otherwise amplifies into megabytes of hook output.
+pub fn render_config_warnings(warnings: &[String]) -> String {
+    let mut out = String::new();
+    for w in warnings.iter().take(MAX_RENDERED_WARNINGS) {
+        out.push_str(&format!("  {w}\n"));
+    }
+    if warnings.len() > MAX_RENDERED_WARNINGS {
+        out.push_str(&format!(
+            "  … and {} more config anomalies\n",
+            warnings.len() - MAX_RENDERED_WARNINGS
+        ));
+    }
+    out
 }
 
 #[cfg(test)]
@@ -578,6 +665,49 @@ mod tests {
             let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
             assert!(loaded.config.allowlist.is_empty());
             assert!(loaded.warnings.is_empty());
+        }
+
+        #[test]
+        fn one_bad_container_entry_drops_the_whole_key() {
+            // Pins the documented v1 granularity: the probe is per TOP-LEVEL
+            // key, so one malformed entry inside a Vec drops the key and its
+            // valid siblings with it — named, never silent.
+            let dir =
+                root_with(r#"{"demo":{"patterns":[{"pattern":"good"},"bad"],"allowlist":["a"]}}"#);
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert_eq!(loaded.config.allowlist, vec!["a"]);
+            assert!(loaded.config.patterns.is_empty(), "whole key drops");
+            assert!(loaded.warnings.iter().any(|w| w.contains("demo.patterns")));
+        }
+
+        #[test]
+        fn retry_path_still_names_unknown_keys() {
+            // A section with BOTH a malformed known key and an unknown key:
+            // the retry path must warn on the unknown key exactly like the
+            // happy path would have.
+            let dir =
+                root_with(r#"{"demo":{"patterns":["bad"],"allowlist":["a"],"typoKey":true}}"#);
+            let loaded: SectionLoad<Demo> = load_cadence_section_lenient(dir.path(), "demo");
+            assert_eq!(loaded.config.allowlist, vec!["a"]);
+            assert!(loaded.warnings.iter().any(|w| w.contains("demo.patterns")));
+            assert!(loaded.warnings.iter().any(|w| w.contains("typoKey")));
+        }
+
+        #[test]
+        fn rendered_warnings_are_capped() {
+            let warnings: Vec<String> = (0..20).map(|i| format!("warning {i}")).collect();
+            let rendered = render_config_warnings(&warnings);
+            assert_eq!(rendered.lines().count(), MAX_RENDERED_WARNINGS + 1);
+            assert!(rendered.contains("and 15 more"));
+        }
+
+        #[test]
+        fn sanitize_key_strips_control_and_caps() {
+            let hostile = format!("evil\nFix: do nothing{}", "x".repeat(200));
+            let cleaned = sanitize_key(&hostile);
+            assert!(!cleaned.contains('\n'), "control chars stripped");
+            assert!(cleaned.chars().count() <= 81, "capped (80 + ellipsis)");
+            assert!(cleaned.ends_with('…'));
         }
     }
 


### PR DESCRIPTION
Stage 2 of the consequence-based redaction re-base: config fail-direction.

## Root cause (corrects #536's own diagnosis)

Config loading was live all along — the defect was `load_cadence_section`'s single strict `from_value().ok()`: one malformed key silently reset the ENTIRE section to `Default`. #536's repro passed bare strings under `additionalPatterns` where the struct wants objects; that voided the section, so the valid `allowlist` beside it went inert and read as "config not consulted at all".

## What

- `load_cadence_section_lenient` in core: strict happy path with `serde_ignored` naming unknown keys (adopted over a hand-rolled key registry — a generic `T` can't enumerate its fields); on strict failure, a per-key probe drops and names only the failing keys and applies the rest. Absence stays a silent fail-open default (ADR-0001).
- Both consumers surface warnings: the leak scanner appends them to its nudge (exit 0, stdout, lands in the transcript — a clean scan with a broken config still nudges, or the drop is exactly as silent as the defect was); the terminology guard appends to its block/nudge messages.
- Hardening per the adversarial security pass: echoed key names sanitized to a strict charset and capped; rendered warnings capped at 5 + elision; the retry path warns on unknown keys identically to the happy path; a failing surviving-subset deserialize reports whole-section-ignored instead of a false "rest applied".
- Warning-channel rule recorded on the loader: hooks → stdout; any future CLI consumer → stderr (stdout stays parseable).

## Ruled during review

Per-key leniency keeps applying suppressor keys (`allowlist`, `originAudience`) when a protective key (`additionalPatterns`, `categories`) drops. Reverting to whole-section voiding on protective-key drops would resurrect exactly the #536 defect. Compensating controls: the drop is named on every posting command until fixed, and the planned identity tier is config-blind by construction — no repo config can touch it.

Known v1 granularity, documented and pinned by test: the probe is per top-level key — one malformed entry inside a Vec/map drops that whole key (named). Recursing into container entries is a follow-up if it bites.

Closes #536.

Session-Name: cedar-tempo
Session-Id: fd5dc169-945c-417a-8dfa-e626685999ae
Model: claude-fable-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7