### PR TITLE
feat(redact): redact-scan CLI subcommand — one engine (#390)

### DIFF
--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -113,10 +113,9 @@ fn ceiling_ord(s: &str) -> u8 {
 /// init. `mcp` is both a namespace and a prefix of `cadence-mcp`; the regex
 /// builder sorts longest-first so `cadence-mcp:x` is caught as `cadence-mcp:x`,
 /// not as `cadence` + leftover or bare `mcp`.
-/// `pub` (rather than crate-private) so the cross-sibling namespace-parity
-/// audit test (`tests/hook_registration_audit.rs`) can read it directly and
-/// diff it against the plugin-side `redact-check.sh` namespace list. Exposed
-/// for that in-repo test linkage only — not a supported public API.
+/// Since #390 this is the ONLY namespace list — the plugin's bash port
+/// (`redact-check.sh`) and its cross-sibling parity audit were deleted when
+/// the `redact-scan` CLI subcommand became the single engine.
 #[doc(hidden)]
 pub const NAMESPACES: &[&str] = &[
     "cadence",
@@ -612,6 +611,305 @@ fn build_message(hits: &[Hit]) -> String {
          replace local paths with a generic description.",
     );
     out
+}
+
+// ---------------------------------------------------------------------------
+// CLI action: `cadence-hooks cadence redact-scan` (cadence-hooks#390)
+//
+// The single engine behind the `redaction` skill's pre-post scan — replaces
+// the plugin-shipped `redact-check.sh`, whose separate bash port of these
+// regexes drifted (the script-clean/hook-nudge disagreement behind #406).
+//
+// Contract (OUTSIDE the hook contract, which reserves exit 2 for block —
+// this is a CLI subcommand and keeps the script's contract):
+//   exit 0  clean
+//   exit 1  one or more hits, printed to STDERR as `[<category>]:<line>:<snippet>`
+//   exit 2  usage / environment error
+// Stdout stays clean (parseable by consumers); hits AND warnings go to stderr.
+//
+// Parity rulings vs the deleted script (Rust semantics win, each pinned by a
+// test in the module below):
+//   - adjacent hits (`tool_input/tool_response`) both report — the script's
+//     boundary-consuming grep missed the second;
+//   - the same token twice on one line reports twice (real occurrences) —
+//     the script deduped by line+token text;
+//   - `--init` needs no jq, and re-emits an existing file via serde_json
+//     pretty-printing rather than jq's formatting (cosmetic divergence).
+// ---------------------------------------------------------------------------
+
+/// Entry for the `redact-scan` CLI action. Returns the process exit code.
+pub fn run_scan(file: Option<String>, audience: Option<String>, init: bool) -> u8 {
+    if let Some(a) = audience.as_deref()
+        && !matches!(a, "owned-internal" | "private-external" | "public")
+    {
+        eprintln!(
+            "redact-scan: invalid --audience: {a} (expected owned-internal|private-external|public)"
+        );
+        return 2;
+    }
+    let cwd = std::env::current_dir()
+        .map(|p| p.to_string_lossy().into_owned())
+        .unwrap_or_else(|_| ".".to_string());
+    let root = cadence_hooks_core::paths::find_git_root(&cwd)
+        .unwrap_or_else(|| std::path::PathBuf::from(&cwd));
+
+    if init {
+        return run_init(&root);
+    }
+
+    let input = match &file {
+        Some(path) => match std::fs::read_to_string(path) {
+            Ok(s) => s,
+            Err(_) => {
+                eprintln!("redact-scan: cannot read file: {path}");
+                return 2;
+            }
+        },
+        None => {
+            use std::io::Read;
+            let mut buf = String::new();
+            if std::io::stdin().read_to_string(&mut buf).is_err() {
+                eprintln!("redact-scan: stdin is not valid UTF-8");
+                return 2;
+            }
+            buf
+        }
+    };
+
+    // Legacy-config warning, ported from the script: a lingering
+    // .claude/redaction.json means its allowlist and additionalPatterns have
+    // silently stopped applying.
+    let legacy = root.join(".claude/redaction.json");
+    if legacy.symlink_metadata().is_ok() {
+        eprintln!(
+            "redact-scan: warning: legacy .claude/redaction.json is NO LONGER read — run 'cadence-hooks migrate-config' to fold it into .claude/cadence.json"
+        );
+    }
+
+    let loaded = cadence_hooks_core::config::load_cadence_section_lenient::<RedactionConfig>(
+        &root,
+        "redaction",
+    );
+    for w in &loaded.warnings {
+        eprintln!("redact-scan: warning: {w}");
+    }
+    let config = loaded.config;
+
+    // Destination tier: --audience flag > config originAudience > public.
+    let d = resolve_dest_tier(audience.as_deref(), &config);
+
+    let mut any = false;
+    for (idx, line) in input.lines().enumerate() {
+        let lineno = idx + 1;
+        for hit in scan_body(line, &config, d) {
+            any = true;
+            if hit.category == "custom" {
+                let repl = match hit.replacement.as_deref() {
+                    Some("") | None => "[redacted]",
+                    Some(r) => r,
+                };
+                eprintln!("[custom]:{lineno}:{} (suggest: {repl})", hit.snippet);
+            } else {
+                eprintln!("[{}]:{lineno}:{}", hit.category, hit.snippet);
+            }
+        }
+    }
+    if any { 1 } else { 0 }
+}
+
+/// Port of the script's `--init`: scaffold the `redaction` section of
+/// `.claude/cadence.json` at the repo root. Creates the file (version: 1
+/// envelope) when absent; adds the section to an existing file only when
+/// missing (idempotent — other sections are never touched). Refuses to write
+/// through a symlinked `.claude` or config file; refuses (exit 2) an existing
+/// file that is unparseable or not a JSON object.
+fn run_init(root: &std::path::Path) -> u8 {
+    let claude = root.join(".claude");
+    let is_symlink = |p: &std::path::Path| {
+        p.symlink_metadata()
+            .is_ok_and(|m| m.file_type().is_symlink())
+    };
+    if is_symlink(&claude) {
+        eprintln!(
+            "redact-scan: {} is a symlink; refusing to write through it",
+            claude.display()
+        );
+        return 0;
+    }
+    if std::fs::create_dir_all(&claude).is_err() {
+        eprintln!("redact-scan: cannot create {}", claude.display());
+        return 2;
+    }
+    let cfg = claude.join("cadence.json");
+    if is_symlink(&cfg) {
+        eprintln!(
+            "redact-scan: {} is a symlink; refusing to write through it",
+            cfg.display()
+        );
+        return 0;
+    }
+    let starter = serde_json::json!({
+        "originAudience": "public",
+        "categories": {},
+        "additionalPatterns": [],
+        "allowlist": []
+    });
+    if !cfg.exists() {
+        let doc = serde_json::json!({ "version": 1, "redaction": starter });
+        return write_config_atomically(&claude, &cfg, &doc, "wrote starter redaction section");
+    }
+    // Existing regular file: add the section only when missing.
+    let Ok(content) = std::fs::read_to_string(&cfg) else {
+        eprintln!("redact-scan: cannot read {}", cfg.display());
+        return 2;
+    };
+    let Ok(mut doc) = serde_json::from_str::<serde_json::Value>(&content) else {
+        eprintln!(
+            "redact-scan: {} exists but is not valid JSON; fix it before --init can add the redaction section",
+            cfg.display()
+        );
+        return 2;
+    };
+    let Some(obj) = doc.as_object_mut() else {
+        eprintln!(
+            "redact-scan: {} is valid JSON but its top-level value is not an object; refusing to add the redaction section",
+            cfg.display()
+        );
+        return 2;
+    };
+    if obj.contains_key("redaction") {
+        eprintln!(
+            "redact-scan: {} already has a redaction section; leaving it unchanged",
+            cfg.display()
+        );
+        return 0;
+    }
+    obj.insert("redaction".to_string(), starter);
+    write_config_atomically(&claude, &cfg, &doc, "added starter redaction section")
+}
+
+/// Same-dir temp file + rename, mirroring the script's write discipline.
+fn write_config_atomically(
+    dir: &std::path::Path,
+    cfg: &std::path::Path,
+    doc: &serde_json::Value,
+    verb: &str,
+) -> u8 {
+    let tmp = dir.join(format!(".cadence.json.{}", std::process::id()));
+    let rendered = format!(
+        "{}\n",
+        serde_json::to_string_pretty(doc).expect("static JSON value renders")
+    );
+    if std::fs::write(&tmp, rendered).is_err() {
+        eprintln!(
+            "redact-scan: write failed in {}; nothing written",
+            dir.display()
+        );
+        return 2;
+    }
+    if std::fs::rename(&tmp, cfg).is_err() {
+        let _ = std::fs::remove_file(&tmp);
+        eprintln!("redact-scan: rename failed; {} unchanged", cfg.display());
+        return 2;
+    }
+    eprintln!("redact-scan: {verb} to {}", cfg.display());
+    0
+}
+
+#[cfg(test)]
+mod cli_scan_tests {
+    use super::*;
+
+    // --- Parity rulings vs the deleted redact-check.sh (Rust semantics win) ---
+
+    #[test]
+    fn ruling_adjacent_hits_both_report() {
+        // The script's boundary-consuming grep reported one hit for
+        // `tool_input/tool_response`; the Rust \b engine reports both.
+        let hits = scan_body("tool_input/tool_response", &RedactionConfig::default(), 3);
+        assert_eq!(hits.len(), 2, "both adjacent identifiers report");
+    }
+
+    #[test]
+    fn ruling_repeated_token_on_one_line_reports_each_occurrence() {
+        // The script deduped by line+token text; each occurrence is a real
+        // instance to rephrase, so the engine reports both offsets.
+        let hits = scan_body(
+            "tool_input here and tool_input there",
+            &RedactionConfig::default(),
+            3,
+        );
+        assert_eq!(hits.len(), 2);
+    }
+
+    // --- run_init port ---
+
+    #[test]
+    fn init_creates_starter_file() {
+        let dir = tempfile::tempdir().unwrap();
+        assert_eq!(run_init(dir.path()), 0);
+        let content = std::fs::read_to_string(dir.path().join(".claude/cadence.json")).unwrap();
+        let doc: serde_json::Value = serde_json::from_str(&content).unwrap();
+        assert_eq!(doc["version"], 1);
+        assert_eq!(doc["redaction"]["originAudience"], "public");
+    }
+
+    #[test]
+    fn init_is_idempotent_and_preserves_other_sections() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(
+            dir.path().join(".claude/cadence.json"),
+            r#"{"version":1,"kanban":{"x":1}}"#,
+        )
+        .unwrap();
+        assert_eq!(run_init(dir.path()), 0);
+        let doc: serde_json::Value = serde_json::from_str(
+            &std::fs::read_to_string(dir.path().join(".claude/cadence.json")).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(doc["kanban"]["x"], 1, "other sections preserved");
+        assert!(doc["redaction"].is_object());
+        // Second run: section present → unchanged, still exit 0.
+        assert_eq!(run_init(dir.path()), 0);
+    }
+
+    #[test]
+    fn init_refuses_invalid_json() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(dir.path().join(".claude/cadence.json"), "{not json").unwrap();
+        assert_eq!(run_init(dir.path()), 2);
+    }
+
+    #[test]
+    fn init_refuses_non_object_top_level() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        std::fs::write(dir.path().join(".claude/cadence.json"), "[]").unwrap();
+        assert_eq!(run_init(dir.path()), 2);
+        assert_eq!(
+            std::fs::read_to_string(dir.path().join(".claude/cadence.json")).unwrap(),
+            "[]",
+            "refusal never rewrites the file"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn init_refuses_symlinked_config() {
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join(".claude")).unwrap();
+        let target = dir.path().join("elsewhere.json");
+        std::fs::write(&target, "{}").unwrap();
+        std::os::unix::fs::symlink(&target, dir.path().join(".claude/cadence.json")).unwrap();
+        assert_eq!(run_init(dir.path()), 0);
+        assert_eq!(
+            std::fs::read_to_string(&target).unwrap(),
+            "{}",
+            "symlink target untouched"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -639,6 +639,9 @@ fn build_message(hits: &[Hit]) -> String {
 
 /// Entry for the `redact-scan` CLI action. Returns the process exit code.
 pub fn run_scan(file: Option<String>, audience: Option<String>, init: bool) -> u8 {
+    // Audience validates BEFORE the --init branch — deliberate parity with
+    // the deleted script (`--init --audience bogus` is a usage error there
+    // too), not ordering to "fix".
     if let Some(a) = audience.as_deref()
         && !matches!(a, "owned-internal" | "private-external" | "public")
     {
@@ -686,17 +689,41 @@ pub fn run_scan(file: Option<String>, audience: Option<String>, init: bool) -> u
         );
     }
 
+    // Whole-file anomalies the lenient loader treats as silent fail-open
+    // (ADR-0001) are LOUD here — the deleted script's validate_config warned
+    // on an unparseable file and a non-object document, and SKILL.md
+    // documents that property; the CLI keeps it.
+    let cfg_path = root.join(".claude/cadence.json");
+    if let Ok(content) = std::fs::read_to_string(&cfg_path)
+        && serde_json::from_str::<serde_json::Value>(&content)
+            .map(|v| !v.is_object())
+            .unwrap_or(true)
+    {
+        eprintln!(
+            "redact-scan: warning: .claude/cadence.json is present but not a JSON object (comments are not allowed); ignoring it (fail-open)"
+        );
+    }
+
     let loaded = cadence_hooks_core::config::load_cadence_section_lenient::<RedactionConfig>(
         &root,
         "redaction",
     );
-    for w in &loaded.warnings {
-        eprintln!("redact-scan: warning: {w}");
+    if !loaded.warnings.is_empty() {
+        eprint!(
+            "redact-scan: config anomalies in .claude/cadence.json:\n{}",
+            cadence_hooks_core::config::render_config_warnings(&loaded.warnings)
+        );
     }
     let config = loaded.config;
 
-    // Destination tier: --audience flag > config originAudience > public.
-    let d = resolve_dest_tier(audience.as_deref(), &config);
+    // Destination tier: --audience flag > CADENCE_AUDIENCE env > config
+    // originAudience > public — the env fallback keeps the CLI and the hook
+    // (which reads the same env) from disagreeing in the less-redaction
+    // direction when a session has the env set but a caller omits the flag.
+    // The flag was validated strictly above; an unknown env value falls
+    // safe-wide through dest_tier_ord, same as the hook.
+    let env_audience = std::env::var("CADENCE_AUDIENCE").ok();
+    let d = resolve_dest_tier(audience.as_deref().or(env_audience.as_deref()), &config);
 
     let mut any = false;
     for (idx, line) in input.lines().enumerate() {
@@ -704,9 +731,15 @@ pub fn run_scan(file: Option<String>, audience: Option<String>, init: bool) -> u
         for hit in scan_body(line, &config, d) {
             any = true;
             if hit.category == "custom" {
+                // The replacement is untrusted repo-config text landing on a
+                // surface the model reads — strip control chars, cap length.
                 let repl = match hit.replacement.as_deref() {
-                    Some("") | None => "[redacted]",
-                    Some(r) => r,
+                    Some("") | None => "[redacted]".to_string(),
+                    Some(r) => r
+                        .chars()
+                        .filter(|c| !c.is_control())
+                        .take(120)
+                        .collect::<String>(),
                 };
                 eprintln!("[custom]:{lineno}:{} (suggest: {repl})", hit.snippet);
             } else {
@@ -724,6 +757,10 @@ pub fn run_scan(file: Option<String>, audience: Option<String>, init: bool) -> u
 /// through a symlinked `.claude` or config file; refuses (exit 2) an existing
 /// file that is unparseable or not a JSON object.
 fn run_init(root: &std::path::Path) -> u8 {
+    // Symlink refusals exit 2 — a refusal is not a success, and the deleted
+    // script's `return 0` here was the one parity choice the security review
+    // overturned (an exit-0 refusal is indistinguishable from a completed
+    // scaffold to any caller reading the code, not the message).
     let claude = root.join(".claude");
     let is_symlink = |p: &std::path::Path| {
         p.symlink_metadata()
@@ -734,7 +771,7 @@ fn run_init(root: &std::path::Path) -> u8 {
             "redact-scan: {} is a symlink; refusing to write through it",
             claude.display()
         );
-        return 0;
+        return 2;
     }
     if std::fs::create_dir_all(&claude).is_err() {
         eprintln!("redact-scan: cannot create {}", claude.display());
@@ -746,7 +783,7 @@ fn run_init(root: &std::path::Path) -> u8 {
             "redact-scan: {} is a symlink; refusing to write through it",
             cfg.display()
         );
-        return 0;
+        return 2;
     }
     let starter = serde_json::json!({
         "originAudience": "public",
@@ -789,26 +826,38 @@ fn run_init(root: &std::path::Path) -> u8 {
 }
 
 /// Same-dir temp file + rename, mirroring the script's write discipline.
+///
+/// `tempfile::NamedTempFile` supplies the two properties the script got from
+/// `mktemp` and a naive port would lose: O_EXCL creation (never writes
+/// through a pre-placed symlink) and an unguessable name (a hostile repo can
+/// commit symlinks at predictable names — a PID-suffixed temp is enumerable —
+/// and turn the scaffold into an arbitrary-file overwrite). Mode 0600, too.
 fn write_config_atomically(
     dir: &std::path::Path,
     cfg: &std::path::Path,
     doc: &serde_json::Value,
     verb: &str,
 ) -> u8 {
-    let tmp = dir.join(format!(".cadence.json.{}", std::process::id()));
+    use std::io::Write;
     let rendered = format!(
         "{}\n",
         serde_json::to_string_pretty(doc).expect("static JSON value renders")
     );
-    if std::fs::write(&tmp, rendered).is_err() {
+    let Ok(mut tmp) = tempfile::NamedTempFile::new_in(dir) else {
+        eprintln!(
+            "redact-scan: temp-file create failed in {}; nothing written",
+            dir.display()
+        );
+        return 2;
+    };
+    if tmp.write_all(rendered.as_bytes()).is_err() {
         eprintln!(
             "redact-scan: write failed in {}; nothing written",
             dir.display()
         );
         return 2;
     }
-    if std::fs::rename(&tmp, cfg).is_err() {
-        let _ = std::fs::remove_file(&tmp);
+    if tmp.persist(cfg).is_err() {
         eprintln!("redact-scan: rename failed; {} unchanged", cfg.display());
         return 2;
     }
@@ -819,6 +868,56 @@ fn write_config_atomically(
 #[cfg(test)]
 mod cli_scan_tests {
     use super::*;
+
+    // --- run_scan CLI glue ---
+
+    #[test]
+    fn scan_invalid_audience_is_usage_error() {
+        assert_eq!(run_scan(None, Some("bogus".into()), false), 2);
+        // Also before --init (parity with the script's validation order).
+        assert_eq!(run_scan(None, Some("bogus".into()), true), 2);
+    }
+
+    #[test]
+    fn scan_unreadable_file_is_usage_error() {
+        assert_eq!(
+            run_scan(Some("/nonexistent/redact-scan-test".into()), None, false),
+            2
+        );
+    }
+
+    #[test]
+    fn scan_file_hits_exit_1_and_clean_exit_0() {
+        // Exercises the full glue: file read, per-line loop, exit
+        // aggregation. Uses a skill-id hit (this repo's own allowlist covers
+        // only the harness-noun identifiers, so skill-id is cwd-robust).
+        let dir = tempfile::tempdir().unwrap();
+        let hit = dir.path().join("hit.txt");
+        std::fs::write(&hit, "line one\nsee cadence:attune here\n").unwrap();
+        assert_eq!(
+            run_scan(hit.to_str().map(String::from), Some("public".into()), false),
+            1
+        );
+        let clean = dir.path().join("clean.txt");
+        std::fs::write(&clean, "nothing to see\n").unwrap();
+        assert_eq!(
+            run_scan(
+                clean.to_str().map(String::from),
+                Some("public".into()),
+                false
+            ),
+            0
+        );
+        // owned-internal destination: the default ceiling suppresses.
+        assert_eq!(
+            run_scan(
+                hit.to_str().map(String::from),
+                Some("owned-internal".into()),
+                false
+            ),
+            0
+        );
+    }
 
     // --- Parity rulings vs the deleted redact-check.sh (Rust semantics win) ---
 
@@ -903,7 +1002,7 @@ mod cli_scan_tests {
         let target = dir.path().join("elsewhere.json");
         std::fs::write(&target, "{}").unwrap();
         std::os::unix::fs::symlink(&target, dir.path().join(".claude/cadence.json")).unwrap();
-        assert_eq!(run_init(dir.path()), 0);
+        assert_eq!(run_init(dir.path()), 2, "refusal is an error, not success");
         assert_eq!(
             std::fs::read_to_string(&target).unwrap(),
             "{}",

--- a/src/main.rs
+++ b/src/main.rs
@@ -202,6 +202,21 @@ enum CadenceCommands {
         #[arg(long, value_name = "PATH")]
         baseline: Option<String>,
     },
+    /// Scan text (stdin or --file) for redaction hits at a destination
+    /// audience tier. CLI action — the single engine behind the redaction
+    /// skill's pre-post scan (exit 0 clean / 1 hits on stderr / 2 usage)
+    RedactScan {
+        /// Scan a file instead of stdin
+        #[arg(long, value_name = "PATH")]
+        file: Option<String>,
+        /// Destination tier: owned-internal | private-external | public
+        /// (default: config originAudience, else public)
+        #[arg(long, value_name = "TIER")]
+        audience: Option<String>,
+        /// Scaffold the redaction section of .claude/cadence.json and exit
+        #[arg(long)]
+        init: bool,
+    },
     /// Record that /polish ran on this branch (writes a branch-scoped marker). CLI action.
     RecordPolish {
         /// Repository to record against (default: the current directory's).
@@ -414,10 +429,11 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             CadenceCommands::MarkdownLint => "markdown-lint",
             CadenceCommands::RedactExternalContent => "redact-external-content",
             CadenceCommands::PlatformDrift { .. } => "platform-drift",
-            // record-polish is a CLI action, not a hook — no hooks.json wiring
-            // and not subject to CADENCE_DISABLE (same treatment as declare /
-            // status / dismiss-*).
+            // record-polish and redact-scan are CLI actions, not hooks — no
+            // hooks.json wiring and not subject to CADENCE_DISABLE (same
+            // treatment as declare / status / dismiss-*).
             CadenceCommands::RecordPolish { .. } => return None,
+            CadenceCommands::RedactScan { .. } => return None,
         }),
         Commands::Guardrails(g) => Some(match g {
             GuardrailsCommands::GuardPushRemote => "guard-push-remote",
@@ -940,6 +956,16 @@ fn main() {
             } => {
                 cadence_hooks_cadence::record_polish::run_record(repo_root, branch, scope, arm);
             }
+            CadenceCommands::RedactScan {
+                file,
+                audience,
+                init,
+            } => {
+                process::exit(
+                    cadence_hooks_cadence::redact_external_content::run_scan(file, audience, init)
+                        .into(),
+                );
+            }
         },
         Commands::Guardrails(cmd) => match cmd {
             GuardrailsCommands::GuardPushRemote => dispatch::run_logged_check(
@@ -1304,6 +1330,7 @@ mod tests {
             "declare",
             "status",
             "record-polish",
+            "redact-scan",
         ];
 
         let mut clap_pairs: Vec<(String, String)> = Vec::new();

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -1003,91 +1003,10 @@ fn hook_event_types_match_hooks_json() {
     );
 }
 
-/// Parse the `NS='...'` single-quoted pipe-alternation line out of the
-/// sibling plugin's `redact-check.sh`. Matched by the `NS='` prefix, never
-/// by line number, so the script can grow unrelated lines above or below it
-/// without breaking this parse.
-///
-/// Collects every matching line (rather than returning on the first) and
-/// asserts there is exactly one — a future unrelated line shaped like
-/// `NS='...'` (e.g. a comment or a second variable) would otherwise
-/// silently win by first-match instead of failing loudly.
-fn parse_redact_check_namespaces(content: &str) -> Vec<String> {
-    let matches: Vec<&str> = content
-        .lines()
-        .map(str::trim)
-        .filter_map(|line| line.strip_prefix("NS='"))
-        .filter_map(|rest| rest.strip_suffix('\''))
-        .collect();
-
-    assert_eq!(
-        matches.len(),
-        1,
-        "expected exactly one `NS='...'` line in redact-check.sh, found {}: {matches:?}",
-        matches.len()
-    );
-
-    matches[0].split('|').map(str::to_string).collect()
-}
-
-#[test]
-fn namespace_list_matches_redact_check_sh() {
-    // Sibling plugin script that carries a bash-side copy of the same
-    // namespace list used to build `redact_external_content::NAMESPACES`.
-    //
-    // The skip is keyed off the sibling's `skills/redaction` DIRECTORY
-    // existing, not the script file — mirroring how
-    // `all_binary_subcommands_are_registered` keys its exemption off plugin
-    // directory existence. That distinguishes two different situations:
-    // the sibling checkout genuinely isn't present alongside this repo
-    // (bare CI, no siblings — benign, silent skip), versus the checkout IS
-    // present but `redact-check.sh` has moved or been renamed underneath
-    // it (a real regression this test should fail loudly on, not swallow).
-    let skill_dir = workspace_root().join("cadence/plugins/cadence/skills/redaction");
-    if !skill_dir.is_dir() {
-        eprintln!(
-            "SKIPPED: sibling cadence plugin's redaction skill dir not found at {} \
-             (plugin dir not alongside workspace)",
-            skill_dir.display()
-        );
-        return;
-    }
-
-    let script_path = skill_dir.join("scripts/redact-check.sh");
-    assert!(
-        script_path.exists(),
-        "sibling redaction skill dir exists at {} but scripts/redact-check.sh is missing — \
-         has the script moved or been renamed? Update this test's expected path.",
-        skill_dir.display()
-    );
-
-    let content = std::fs::read_to_string(&script_path)
-        .unwrap_or_else(|e| panic!("failed to read {}: {e}", script_path.display()));
-
-    let script_namespaces: BTreeSet<String> = parse_redact_check_namespaces(&content)
-        .into_iter()
-        .collect();
-
-    let rust_namespaces: BTreeSet<String> =
-        cadence_hooks_cadence::redact_external_content::NAMESPACES
-            .iter()
-            .map(|s| s.to_string())
-            .collect();
-
-    let missing_from_script: Vec<&String> =
-        rust_namespaces.difference(&script_namespaces).collect();
-    let missing_from_rust: Vec<&String> = script_namespaces.difference(&rust_namespaces).collect();
-
-    assert!(
-        missing_from_script.is_empty() && missing_from_rust.is_empty(),
-        "namespace list drift between Rust NAMESPACES and {}'s `NS=` line:\n\
-         in Rust but missing from redact-check.sh: {:?}\n\
-         in redact-check.sh but missing from Rust: {:?}",
-        script_path.display(),
-        missing_from_script,
-        missing_from_rust,
-    );
-}
+// The namespace-parity test against the plugin's `redact-check.sh` was
+// deleted with the script itself (cadence-hooks#390): the `redact-scan` CLI
+// subcommand is now the single engine, so there is no second namespace list
+// to drift.
 
 /// Interpreters whose argv[0] — or the command that follows a leading `env`
 /// invocation — is never itself a checkable script path. The actual script is


### PR DESCRIPTION
Stage 3 of the consequence-based redaction re-base: collapse the two scan implementations into one engine.

## What

- `cadence-hooks cadence redact-scan [--file <path>|stdin] [--audience <tier>] [--init]` — a CLI action (exempt from the hook contract's exit-2-means-block and from CADENCE_DISABLE, like record-polish): exit 0 clean / 1 hits on stderr as `[category]:line:snippet` / 2 usage. Stdout stays parseable-clean.
- `--init` ported from the plugin script: scaffold/merge the redaction section of `.claude/cadence.json`, idempotent, symlink-refusing, no jq dependency.
- Namespace parity test deleted — with the plugin's bash port gone (companion PR) there is no second list to drift.

## Parity gate

30 real estate PR/issue bodies produced byte-identical stderr and exit codes from the script and the subcommand at two audience tiers. Surviving divergences, each ruled Rust-wins and pinned by a test: adjacent identifiers both report (the script's boundary-consuming grep missed the second — verified live as the control case); a token repeated on one line reports per occurrence; `--init` re-emits via serde_json pretty-printing (cosmetic).

## Hardening (adversarial security pass)

- Temp-file writes use O_EXCL + randomized names + 0600 (`tempfile::NamedTempFile`) — a PID-suffixed temp written through a symlink-following create would have let a hostile repo turn `--init` into an arbitrary-file overwrite via pre-committed symlinks at enumerable names.
- Symlink refusals exit 2, not the script's 0 — a refusal is not a success (deliberate parity break, ruled during review).
- Destination resolution: flag > `CADENCE_AUDIENCE` env > config > public — the env fallback keeps the CLI and the hook from disagreeing in the less-redaction direction.
- Untrusted config text on the model-read stderr surface is control-stripped and capped; whole-file config anomalies warn loudly (preserving the script's validate_config property the lenient loader intentionally keeps silent for hooks).

Companion (merge after this): the cadence-plugin PR deletes `redact-check.sh` + its test harness and re-points the redaction skill at this subcommand with a loudly-closed binary-absent story.

Closes #390.

Session-Name: cedar-tempo
Session-Id: fd5dc169-945c-417a-8dfa-e626685999ae
Model: claude-fable-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the `cadence redact-scan` command for scanning files or standard input.
  * Supports audience-specific scanning and reports detected content with suggested replacements.
  * Added configuration initialization and updates while preserving existing settings.
  * Provides clear exit statuses for clean scans, detected content, and errors.
* **Bug Fixes**
  * Improved handling of invalid configurations, malformed input, and unsafe configuration files.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->