### PR TITLE
fix(ci): --clobber the reusable skew gate's release download

### DIFF
--- a/.github/workflows/plugin-hooks-skew.yml
+++ b/.github/workflows/plugin-hooks-skew.yml
@@ -33,8 +33,12 @@ jobs:
           set -euo pipefail
           tag="$(gh release view --repo cameronsjo/cadence-hooks --json tagName --jq .tagName)"
           echo "Latest released cadence-hooks: $tag"
+          # --clobber: on a self-hosted runner /tmp/ch survives between runs,
+          # and a leftover same-version tarball fails the download with
+          # "already exists" before any skew logic runs (observed 2026-08-03
+          # failing every hooks-touching cadence PR in ~5s).
           gh release download "$tag" --repo cameronsjo/cadence-hooks \
-            --pattern "*linux-x86_64.tar.gz" --dir /tmp/ch
+            --pattern "*linux-x86_64.tar.gz" --dir /tmp/ch --clobber
           tar -xzf /tmp/ch/*linux-x86_64.tar.gz -C /tmp/ch
           bin="$(find /tmp/ch -type f -name cadence-hooks | head -n1)"
           mkdir -p "$HOME/.local/bin"


### PR DESCRIPTION
A leftover /tmp/ch tarball on the self-hosted runner fails `gh release download` with "already exists" before any skew logic runs — every hooks-touching cadence PR fails the reusable gate in ~5s (observed on cameronsjo/cadence#749, 2026-08-03). `--clobber` makes the download idempotent; the versioned filename means no staleness risk. Consumers pin this workflow by SHA — the cadence-side pin bump follows after merge.

Session-Name: cedar-tempo
Session-Id: fd5dc169-945c-417a-8dfa-e626685999ae
Model: claude-fable-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7