### PR TITLE
feat(redact): identity tier — fail-closed scanning for work-identifiable terms

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,6 +212,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "toml",
 ]
 
 [[package]]
@@ -908,6 +909,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "sha2"
 version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +1002,40 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow",
 ]
 
 [[package]]
@@ -1264,6 +1308,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ repository = "https://github.com/cameronsjo/cadence-hooks"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 serde_ignored = "0.1"
+toml = { version = "0.8", default-features = false, features = ["parse"] }
 regex = "1"
 clap = { version = "4", features = ["derive"] }
 brush-parser = "0.3"

--- a/crates/cadence/Cargo.toml
+++ b/crates/cadence/Cargo.toml
@@ -12,6 +12,7 @@ regex.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 tempfile = "3"
+toml.workspace = true
 
 [dev-dependencies]
 cadence-hooks-core = { workspace = true, features = ["test-builders"] }

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -277,6 +277,25 @@ struct AdditionalPattern {
 /// authority its descriptor declares, including by accident. The failure mode
 /// being designed out: someone adds a third config-driven softening feature and
 /// forgets to exclude the fail-closed tier from it.
+///
+/// # Status: forward-looking, and honestly labelled
+///
+/// **No production category declares [`SourceFileOnly`](Self::SourceFileOnly)
+/// today.** The identity tier does not run through this table at all — it is a
+/// separate pass whose *signature* takes no config, which is a strictly
+/// stronger guarantee than a field consulted at two sites. That is what
+/// protects identity right now.
+///
+/// This field exists for the case the identity pass ever *is* folded into the
+/// category table, or a second out-of-repo term source is added — at which
+/// point the declaration is already required and cannot be forgotten.
+///
+/// Verified by mutation rather than assumed: deleting both guards leaves the
+/// whole suite green, because nothing production reaches them. So they are
+/// exercised directly by unit tests
+/// ([`tests::source_file_only_ceiling_ignores_repo_config`] and
+/// [`tests::source_file_only_hit_ignores_repo_allowlist`]) instead of being
+/// left as a mechanism no test can tell apart from absent.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 enum ConfigScope {
     /// The repo's committed `.claude/cadence.json` may raise this category's
@@ -2215,6 +2234,69 @@ mod tests {
                 resolve_dest_tier(Some("owned-internal"), &config)
             )
             .is_empty()
+        );
+    }
+
+    // --- ConfigScope, exercised directly -----------------------------------
+    //
+    // These two are the ONLY coverage of the SourceFileOnly guards, and they
+    // exist because a mutation test proved the guard-level tests do not touch
+    // them: deleting both guards left all 968 tests green, since no production
+    // category declares SourceFileOnly and identity bypasses the table
+    // entirely. Without these, `config_scope` would be a documented safety
+    // mechanism indistinguishable from its own absence.
+
+    #[test]
+    fn source_file_only_ceiling_ignores_repo_config() {
+        let config: RedactionConfig =
+            serde_json::from_str(r#"{"categories":{"probe":{"ceiling":"public"}}}"#)
+                .expect("config parses");
+
+        let repo_scoped = CategoryDescriptor {
+            name: "probe",
+            pattern: &HARNESS_NOUN,
+            default_ceiling: "owned-internal",
+            config_scope: ConfigScope::RepoConfig,
+        };
+        let source_only = CategoryDescriptor {
+            config_scope: ConfigScope::SourceFileOnly,
+            ..repo_scoped
+        };
+
+        // Same config, same category name — the ONLY difference is the scope.
+        assert_eq!(
+            category_ceiling(&config, &repo_scoped),
+            "public",
+            "a RepoConfig category takes the committed override"
+        );
+        assert_eq!(
+            category_ceiling(&config, &source_only),
+            "owned-internal",
+            "a SourceFileOnly category must ignore it and keep its default"
+        );
+    }
+
+    #[test]
+    fn source_file_only_hit_ignores_repo_allowlist() {
+        let allowlist = vec!["tool_input".to_string()];
+        let hit = |scope| Hit {
+            category: "harness-noun",
+            snippet: "tool_input".to_string(),
+            offset: 0,
+            replacement: None,
+            config_scope: scope,
+        };
+        let repo_hit = hit(ConfigScope::RepoConfig);
+        let source_hit = hit(ConfigScope::SourceFileOnly);
+
+        assert!(
+            is_allowlisted(&repo_hit, &allowlist),
+            "a RepoConfig hit is suppressible by the committed allowlist"
+        );
+        assert!(
+            !is_allowlisted(&source_hit, &allowlist),
+            "an identical SourceFileOnly hit must not be — same entry, same \
+             snippet, only the authority differs"
         );
     }
 

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -439,10 +439,23 @@ fn run_edit(input: &HookInput, identity_list: &identity::IdentityList) -> CheckR
         // Scan only what the edit introduces. A term already present in `old`
         // is pre-existing: it is not this edit's doing, and blocking on it
         // would make the removal edit impossible.
+        //
+        // Compare OCCURRENCE COUNTS, not presence. A bare `old.contains(…)`
+        // suppresses every match in `new` the moment `old` contains the term
+        // even once — so an edit that rewrites a paragraph and duplicates the
+        // term goes unflagged. That is an ordinary accidental edit, not an
+        // adversarial one, and it silently breaks the introduced-only property
+        // this function's whole contract rests on. (Both review seats found
+        // this independently.)
+        let mut by_snippet: HashMap<String, Vec<identity::IdentityHit>> = HashMap::new();
         for hit in identity::scan_identity(new, identity_list, file_path) {
-            if !old.contains(&hit.snippet) {
-                identity_hits.push(hit);
-            }
+            by_snippet.entry(hit.snippet.clone()).or_default().push(hit);
+        }
+        for (snippet, found) in by_snippet {
+            let already = old.matches(snippet.as_str()).count();
+            // Report only the surplus — the occurrences this edit added beyond
+            // what was already there.
+            identity_hits.extend(found.into_iter().skip(already));
         }
     }
     combine(&identity_hits, &[], &[], identity_list.mode)
@@ -531,6 +544,13 @@ fn build_identity_message(
     };
     let mut out = String::from(header);
     out.push('\n');
+    // Identity DEDUPS by (id, snippet); the shaped renderer deliberately does
+    // not (a ruled decision: repeated shaped hits are real occurrences worth
+    // seeing). The tiers diverge because the messages do different jobs. A
+    // shaped nudge is a list of places to edit, so repetition is information.
+    // An identity block is a stop sign — the operator needs to know WHICH term
+    // tripped it, and printing one term forty times because a doc discusses it
+    // buries that. Do not "fix" one to match the other.
     let mut seen: HashSet<(&str, &str)> = HashSet::new();
     for hit in hits {
         if seen.insert((hit.id.as_str(), hit.snippet.as_str())) {
@@ -703,10 +723,7 @@ fn resolve_dest_tier(env_audience: Option<&str>, config: &RedactionConfig) -> u8
 /// without ever reading `config` — the repo's committed `categories` map has no
 /// path to it. That is not an exemption checked here; it is the descriptor's
 /// own declaration being honored.
-fn category_ceiling<'a>(config: &'a RedactionConfig, desc: &CategoryDescriptor) -> &'a str
-where
-    'static: 'a,
-{
+fn category_ceiling<'a>(config: &'a RedactionConfig, desc: &CategoryDescriptor) -> &'a str {
     if desc.config_scope == ConfigScope::SourceFileOnly {
         return desc.default_ceiling;
     }
@@ -2308,22 +2325,40 @@ mod tests {
 
     static TERMS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
 
+    /// Removes the named env vars when dropped — including on unwind.
+    ///
+    /// An `assert!` inside a test closure panics, and a plain
+    /// set-call-remove sequence never reaches its remove. That leak is
+    /// currently harmless (every reader of these vars takes `TERMS_ENV_LOCK`
+    /// first, and the next locker overwrites), but it is harmless by
+    /// coincidence rather than by construction, and a test added outside this
+    /// helper would silently inherit a stale path.
+    struct EnvCleanup(&'static [&'static str]);
+    impl Drop for EnvCleanup {
+        fn drop(&mut self) {
+            for k in self.0 {
+                unsafe { std::env::remove_var(k) };
+            }
+        }
+    }
+
     /// Run `body` through the guard with a fixture term source. Returns the
     /// full result so a caller can assert on outcome, message, and bypass.
     fn with_terms<F, R>(toml_body: &str, f: F) -> R
     where
         F: FnOnce() -> R,
     {
-        let guard = TERMS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TERMS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let dir = tempfile::tempdir().unwrap();
         let path = dir.path().join("redaction.toml");
         std::fs::write(&path, toml_body).unwrap();
-        // SAFETY-equivalent rationale: serialized by TERMS_ENV_LOCK above.
+        // Both vars are cleaned on unwind. CADENCE_ALLOW_SENSITIVE_TERMS is
+        // included because the bypass test sets it inside this closure —
+        // std's Mutex is not reentrant, so it cannot take its own guard.
+        let _cleanup = EnvCleanup(&["CADENCE_REDACTION_TERMS", "CADENCE_ALLOW_SENSITIVE_TERMS"]);
+        // Serialized by TERMS_ENV_LOCK, held for this whole scope.
         unsafe { std::env::set_var("CADENCE_REDACTION_TERMS", &path) };
-        let out = f();
-        unsafe { std::env::remove_var("CADENCE_REDACTION_TERMS") };
-        drop(guard);
-        out
+        f()
     }
 
     const FIXTURE: &str = r#"
@@ -2357,11 +2392,10 @@ term = "acmecorp"
 
     #[test]
     fn absent_terms_file_is_inert_not_a_hard_failure() {
-        let guard = TERMS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _guard = TERMS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _cleanup = EnvCleanup(&["CADENCE_REDACTION_TERMS"]);
         unsafe { std::env::set_var("CADENCE_REDACTION_TERMS", "/nonexistent/redaction.toml") };
         let r = run("git commit -m \"fix the acmecorp integration\"");
-        unsafe { std::env::remove_var("CADENCE_REDACTION_TERMS") };
-        drop(guard);
         // Fail-OPEN on the guard's own failure: a machine that never had the
         // file must still be able to commit. The SessionStart probe is what
         // keeps this from being silent.
@@ -2400,8 +2434,14 @@ term = "acmecorp"
 
     #[test]
     fn repo_config_cannot_soften_the_identity_tier() {
-        // The whole point of ConfigScope::SourceFileOnly. A repo that
-        // allowlists the term AND raises every ceiling still blocks.
+        // NB what this does and does not prove. It proves the end-to-end
+        // property — a repo that allowlists the term AND raises every ceiling
+        // still blocks — but it proves it via `scan_identity`'s signature
+        // blindness, NOT via ConfigScope: identity never flows through the
+        // category table, so this test passes with ConfigScope deleted (shown
+        // by mutation). The ConfigScope guards are covered by
+        // `source_file_only_*` above. Both are worth keeping: this one pins the
+        // behavior a user cares about, those pin the mechanism.
         with_terms(FIXTURE, || {
             let repo = temp_repo_with_config(
                 r#"{"allowlist":["acmecorp"],"originAudience":"owned-internal",
@@ -2440,10 +2480,9 @@ term = "acmecorp"
         with_terms(FIXTURE, || {
             // Already inside with_terms' lock — std Mutex is not reentrant, so
             // re-locking here would deadlock. The outer guard serializes both
-            // env vars.
+            // env vars, and its EnvCleanup removes this one even on unwind.
             unsafe { std::env::set_var("CADENCE_ALLOW_SENSITIVE_TERMS", "1") };
             let r = run("gh issue create --body \"acmecorp uses cadence:attune\"");
-            unsafe { std::env::remove_var("CADENCE_ALLOW_SENSITIVE_TERMS") };
             assert_eq!(r.outcome, Outcome::Nudge, "bypass downgrades the block");
             assert!(
                 r.bypass.is_some(),
@@ -2484,6 +2523,50 @@ term = "acmecorp"
                     file_path: Some("/tmp/notes.md".into()),
                     old_string: Some("we ship acmecorp tooling".into()),
                     new_string: Some("we ship the tooling".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn edit_duplicating_a_preexisting_term_still_blocks_the_new_copy() {
+        // The occurrence-count rule. A presence test (`old.contains`) would
+        // suppress BOTH matches here because `old` already held the term once,
+        // letting an ordinary rewrite-and-duplicate edit smuggle a new
+        // instance past an introduced-only guard.
+        with_terms(FIXTURE, || {
+            let input = HookInput {
+                tool_name: Some("Edit".into()),
+                tool_input: Some(cadence_hooks_core::ToolInput {
+                    file_path: Some("/tmp/notes.md".into()),
+                    old_string: Some("the acmecorp policy".into()),
+                    new_string: Some("the acmecorp policy, see also the acmecorp runbook".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            assert_eq!(
+                RedactExternalContent.run(&input).outcome,
+                Outcome::Block,
+                "the second occurrence is introduced by this edit"
+            );
+        });
+    }
+
+    #[test]
+    fn edit_preserving_one_preexisting_occurrence_does_not_block() {
+        // The other side of the same rule: carrying an existing occurrence
+        // through an unrelated edit is not an introduction.
+        with_terms(FIXTURE, || {
+            let input = HookInput {
+                tool_name: Some("Edit".into()),
+                tool_input: Some(cadence_hooks_core::ToolInput {
+                    file_path: Some("/tmp/notes.md".into()),
+                    old_string: Some("the acmecorp policy is old".into()),
+                    new_string: Some("the acmecorp policy is current".into()),
                     ..Default::default()
                 }),
                 ..Default::default()

--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -42,7 +42,9 @@
 //! nudge mode, silent failure beats false positives.
 
 use cadence_hooks_core::shell::{command_segments, strip_quotes, tokenize};
-use cadence_hooks_core::{Check, CheckResult, HookInput};
+use cadence_hooks_core::{BypassKind, BypassProvenance, Check, CheckResult, HookInput};
+mod identity;
+
 use regex::Regex;
 use serde::Deserialize;
 use std::collections::{HashMap, HashSet};
@@ -260,6 +262,43 @@ struct AdditionalPattern {
     ceiling: Option<String>,
 }
 
+/// Where a category's *softening* authority lives — the structural pin that
+/// makes config-blindness a property of the category table rather than a rule
+/// someone has to remember.
+///
+/// The governing principle (ADR-0041): **exemption authority follows
+/// term-source authority.** A category whose terms come from committed repo
+/// config may be softened by that same config. A category whose terms come from
+/// an out-of-repo source file may be softened only by that file.
+///
+/// This is deliberately *not* a runtime `if category == "identity"` check at
+/// each softening site. Two call sites read this field — [`category_ceiling`]
+/// and [`is_allowlisted`] — and a category added later inherits whichever
+/// authority its descriptor declares, including by accident. The failure mode
+/// being designed out: someone adds a third config-driven softening feature and
+/// forgets to exclude the fail-closed tier from it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ConfigScope {
+    /// The repo's committed `.claude/cadence.json` may raise this category's
+    /// ceiling and allowlist its hits.
+    RepoConfig,
+    /// Only the out-of-repo term source may soften this category. Repo config
+    /// is never consulted for it — no ceiling override, no allowlist entry.
+    SourceFileOnly,
+}
+
+/// One scanned category: its emitted name, its pattern, the ceiling it defaults
+/// to, and — load-bearing — who is allowed to soften it.
+struct CategoryDescriptor {
+    name: &'static str,
+    pattern: &'static Regex,
+    /// Ceiling used when no override applies. `always`(0) means "redact at
+    /// every destination" — the tier algebra's designed extreme, which is where
+    /// the fail-closed tier sits. It is not outside the algebra; it is its edge.
+    default_ceiling: &'static str,
+    config_scope: ConfigScope,
+}
+
 /// A single blocklist hit within one body. `offset` is the match start within
 /// that body, used only for cross-category offset dedup.
 struct Hit {
@@ -268,6 +307,9 @@ struct Hit {
     offset: usize,
     /// Replacement to surface (set only for `additionalPatterns` hits).
     replacement: Option<String>,
+    /// Carried from the producing category's descriptor so the allowlist check
+    /// can honor it without re-deriving the category→scope mapping.
+    config_scope: ConfigScope,
 }
 
 /// Flag against this nudge when it dispatches internal harness vocabulary to an
@@ -280,9 +322,16 @@ impl Check for RedactExternalContent {
     }
 
     fn run(&self, input: &HookInput) -> CheckResult {
-        // Phase 1 — early exit: only Bash carries a postable command.
+        // Phase 0 — the term source, loaded once. Every failure yields an empty
+        // list (fail-open on the guard's own failure); the SessionStart probe,
+        // not this call, is what keeps an absent file from being a silent
+        // disarm.
+        let (identity_list, _status) = identity::load();
+
+        // Phase 1 — route by surface. Only Bash carries a postable command; a
+        // Write/Edit runs the identity pass ONLY (see `run_edit`).
         let Some(command) = input.command() else {
-            return CheckResult::allow();
+            return run_edit(input, &identity_list);
         };
 
         // Phase 2 — gate and extract PER SEGMENT (#424). A segment that does
@@ -313,9 +362,16 @@ impl Check for RedactExternalContent {
         let env_audience = std::env::var("CADENCE_AUDIENCE").ok();
         let d = resolve_dest_tier(env_audience.as_deref(), &config);
 
-        // Phase 4 — scan each body, collect hits (gated on d > ceiling).
+        // Phase 4 — TWO passes over every body, deliberately without a
+        // short-circuit. An identity hit does not skip the shaped scan: a
+        // single post can carry both, and the operator fixing one should see
+        // the other in the same message rather than discovering it on the
+        // retry.
         let mut hits: Vec<Hit> = Vec::new();
+        let mut identity_hits: Vec<identity::IdentityHit> = Vec::new();
         for body in &bodies {
+            // Config-blind by signature — no config, no tier, no allowlist.
+            identity_hits.extend(identity::scan_identity(body, &identity_list, None));
             hits.extend(scan_body(body, &config, d));
         }
 
@@ -323,17 +379,151 @@ impl Check for RedactExternalContent {
         // the transcript). A clean scan with a broken config still nudges —
         // otherwise the drop is exactly as silent as the #536 defect was.
         let warnings = loaded.warnings;
-        match (hits.is_empty(), warnings.is_empty()) {
-            (true, true) => CheckResult::allow(),
-            (true, false) => CheckResult::nudge(build_config_warning(&warnings)),
-            (false, true) => CheckResult::nudge(build_message(&hits)),
-            (false, false) => CheckResult::nudge(format!(
-                "{}\n{}",
-                build_message(&hits),
-                build_config_warning(&warnings)
-            )),
+        combine(&identity_hits, &hits, &warnings, identity_list.mode)
+    }
+}
+
+/// The Write/Edit surface: the identity pass **only**, over introduced
+/// fragments.
+///
+/// Two deliberate narrowings, both load-bearing:
+///
+/// 1. **Shaped tiers never run here.** A local file edit has no audience, and
+///    `resolve_dest_tier`'s public(3) fallback would nudge on every `/Users/…`
+///    path written locally — a false-positive flood that would get the whole
+///    guard disabled, which is exactly the outcome the fail-closed tier exists
+///    to prevent.
+/// 2. **Introduced fragments, not the resulting document.** `edit_fragments()`
+///    yields what the edit *adds*; `effective_content()` would yield the whole
+///    file, so a pre-existing term anywhere in it would block every unrelated
+///    edit — including the edit that removes the term. (Its `None`-on-unreadable
+///    default is also self-locking, and its own docs warn blocking guards off
+///    it.)
+///
+/// The residual this accepts: content entering a file by some other route (a
+/// `sed -i`, an external editor) is not seen here. Named in ADR-0041; the
+/// periodic leak-ledger scan is its detection net.
+fn run_edit(input: &HookInput, identity_list: &identity::IdentityList) -> CheckResult {
+    if !identity_list.is_armed() {
+        return CheckResult::allow();
+    }
+    let Some(fragments) = input.edit_fragments() else {
+        return CheckResult::allow();
+    };
+    let file_path = input
+        .tool_input
+        .as_ref()
+        .and_then(|ti| ti.file_path.as_deref().or(ti.path.as_deref()));
+
+    let mut identity_hits: Vec<identity::IdentityHit> = Vec::new();
+    for (new, old) in &fragments {
+        // Scan only what the edit introduces. A term already present in `old`
+        // is pre-existing: it is not this edit's doing, and blocking on it
+        // would make the removal edit impossible.
+        for hit in identity::scan_identity(new, identity_list, file_path) {
+            if !old.contains(&hit.snippet) {
+                identity_hits.push(hit);
+            }
         }
     }
+    combine(&identity_hits, &[], &[], identity_list.mode)
+}
+
+/// Fold the two passes and any config warnings into one result.
+///
+/// Outcome is the max severity across the tiers ([`Outcome::merge`]), and the
+/// message carries the union — labeled, so BLOCKED findings are not read as
+/// advisory. Only the identity tier can produce a block, and only in
+/// [`identity::Mode::Enforce`].
+fn combine(
+    identity_hits: &[identity::IdentityHit],
+    hits: &[Hit],
+    warnings: &[String],
+    mode: identity::Mode,
+) -> CheckResult {
+    let bypass = std::env::var("CADENCE_ALLOW_SENSITIVE_TERMS")
+        .ok()
+        .filter(|v| !v.is_empty() && v != "0");
+
+    let mut sections: Vec<String> = Vec::new();
+    let identity_blocks = !identity_hits.is_empty() && mode == identity::Mode::Enforce;
+
+    if !identity_hits.is_empty() {
+        sections.push(build_identity_message(
+            identity_hits,
+            mode,
+            bypass.is_some(),
+        ));
+    }
+    if !hits.is_empty() {
+        sections.push(build_message(hits));
+    }
+    if !warnings.is_empty() {
+        sections.push(build_config_warning(warnings));
+    }
+    if sections.is_empty() {
+        return CheckResult::allow();
+    }
+    let message = sections.join("\n");
+
+    match (identity_blocks, bypass) {
+        // Blocking, no bypass — the fail-closed path.
+        (true, None) => CheckResult::block(message),
+        // Bypass armed. The block downgrades, but anything the shaped tiers or
+        // the config loader had to say still ships — and the provenance row is
+        // written either way, which is what makes the bypass auditable.
+        (true, Some(mechanism)) => {
+            let prov = BypassProvenance {
+                kind: BypassKind::EnvSwitch,
+                mechanism: format!("CADENCE_ALLOW_SENSITIVE_TERMS={mechanism}"),
+                reason: None,
+                expires_at: None,
+                armed_by_session: None,
+            };
+            CheckResult::nudge(message).with_bypass(prov)
+        }
+        // Warn mode, or shaped/config findings only.
+        (false, _) => CheckResult::nudge(message),
+    }
+}
+
+/// Render the identity findings.
+///
+/// **The term is named verbatim.** Ruled: the threat model is irrevocable
+/// public-facing artifacts, and a block that will not say what tripped it is a
+/// block the operator cannot act on — they retry, it blocks again, and the
+/// guard gets disabled. Transcripts are not the surface this protects.
+fn build_identity_message(
+    hits: &[identity::IdentityHit],
+    mode: identity::Mode,
+    bypassed: bool,
+) -> String {
+    let header = match (mode, bypassed) {
+        (identity::Mode::Enforce, false) => {
+            "⛔  redact-external-content: BLOCKED — work-identifiable terms in outgoing content:"
+        }
+        (identity::Mode::Enforce, true) => {
+            "⚠️  redact-external-content: work-identifiable terms found; block suppressed by \
+             CADENCE_ALLOW_SENSITIVE_TERMS (logged):"
+        }
+        (identity::Mode::Warn, _) => {
+            "⚠️  redact-external-content: work-identifiable terms found (warn mode — not blocking):"
+        }
+    };
+    let mut out = String::from(header);
+    out.push('\n');
+    let mut seen: HashSet<(&str, &str)> = HashSet::new();
+    for hit in hits {
+        if seen.insert((hit.id.as_str(), hit.snippet.as_str())) {
+            out.push_str(&format!("  [{}] {}\n", hit.id, hit.snippet));
+        }
+    }
+    out.push_str(
+        "Remove the term, or — if this context is genuinely benign — add an `allow` entry \
+         beside it in the term source (see `cadence-hooks cadence redact-scan --help`). \
+         Per-repo config cannot excuse these.",
+    );
+    out
 }
 
 /// Render config-load warnings as one nudge block. NB this fires on every
@@ -488,15 +678,24 @@ fn resolve_dest_tier(env_audience: Option<&str>, config: &RedactionConfig) -> u8
     }
 }
 
-/// Ceiling string for a universal category: the config `.categories` override or
-/// the default `owned-internal`. Returned as `&str` for a direct
-/// [`ceiling_ord`] call.
-fn category_ceiling<'a>(config: &'a RedactionConfig, category: &str) -> &'a str {
+/// Ceiling string for a scanned category. **Softening call site 1 of 2.**
+///
+/// A [`ConfigScope::SourceFileOnly`] category returns its declared default
+/// without ever reading `config` — the repo's committed `categories` map has no
+/// path to it. That is not an exemption checked here; it is the descriptor's
+/// own declaration being honored.
+fn category_ceiling<'a>(config: &'a RedactionConfig, desc: &CategoryDescriptor) -> &'a str
+where
+    'static: 'a,
+{
+    if desc.config_scope == ConfigScope::SourceFileOnly {
+        return desc.default_ceiling;
+    }
     config
         .categories
-        .get(category)
+        .get(desc.name)
         .and_then(|c| c.ceiling.as_deref())
-        .unwrap_or("owned-internal")
+        .unwrap_or(desc.default_ceiling)
 }
 
 /// Scan one body for blocklist hits, deduped by start offset across categories,
@@ -507,34 +706,62 @@ fn category_ceiling<'a>(config: &'a RedactionConfig, category: &str) -> &'a str 
 /// additional; the first to claim a start offset reports it (so a single
 /// `~/.claude/plugins/…` offset is reported once, as `marketplace`). An
 /// allowlisted hit pins its ceiling to public (never redacted here).
+///
+/// The category table. Order is load-bearing for offset-dedup: the first
+/// descriptor to claim a start offset reports it, so more specific patterns
+/// precede broader ones (`marketplace` before `local-path`).
+fn universal_categories() -> [CategoryDescriptor; 4] {
+    [
+        CategoryDescriptor {
+            name: "skill-id",
+            pattern: &SKILL_ID,
+            default_ceiling: "owned-internal",
+            config_scope: ConfigScope::RepoConfig,
+        },
+        CategoryDescriptor {
+            name: "marketplace",
+            pattern: &MARKETPLACE_PATH,
+            default_ceiling: "owned-internal",
+            config_scope: ConfigScope::RepoConfig,
+        },
+        CategoryDescriptor {
+            name: "local-path",
+            pattern: &LOCAL_PATH,
+            default_ceiling: "owned-internal",
+            config_scope: ConfigScope::RepoConfig,
+        },
+        CategoryDescriptor {
+            name: "harness-noun",
+            pattern: &HARNESS_NOUN,
+            default_ceiling: "owned-internal",
+            config_scope: ConfigScope::RepoConfig,
+        },
+    ]
+}
+
 fn scan_body(body: &str, config: &RedactionConfig, d: u8) -> Vec<Hit> {
     let mut hits: Vec<Hit> = Vec::new();
     let mut claimed: HashSet<usize> = HashSet::new();
 
-    let universal: [(&'static str, &Regex); 4] = [
-        ("skill-id", &SKILL_ID),
-        ("marketplace", &MARKETPLACE_PATH),
-        ("local-path", &LOCAL_PATH),
-        ("harness-noun", &HARNESS_NOUN),
-    ];
-    for (category, regex) in universal {
-        for m in regex.find_iter(body) {
+    for desc in universal_categories() {
+        for m in desc.pattern.find_iter(body) {
             // Claim the offset when first seen (so a lower-priority category
             // never re-reports it), then decide whether the audience gate keeps
             // it.
             if claimed.insert(m.start()) {
                 let hit = Hit {
-                    category,
+                    category: desc.name,
                     snippet: m.as_str().to_string(),
                     offset: m.start(),
                     replacement: None,
+                    config_scope: desc.config_scope,
                 };
                 // Allowlisted → ceiling public (never redacts); else the
                 // category's configured/default ceiling. Retain iff d > c.
                 let ceiling = if is_allowlisted(&hit, &config.allowlist) {
                     "public"
                 } else {
-                    category_ceiling(config, category)
+                    category_ceiling(config, &desc)
                 };
                 if d > ceiling_ord(ceiling) {
                     hits.push(hit);
@@ -562,6 +789,9 @@ fn scan_body(body: &str, config: &RedactionConfig, d: u8) -> Vec<Hit> {
                     snippet: m.as_str().to_string(),
                     offset: m.start(),
                     replacement: (!ap.replacement.is_empty()).then(|| ap.replacement.clone()),
+                    // Terms authored in repo config, so repo config softens
+                    // them — the principle running in the other direction.
+                    config_scope: ConfigScope::RepoConfig,
                 });
             }
         }
@@ -583,7 +813,15 @@ fn scan_body(body: &str, config: &RedactionConfig, d: u8) -> Vec<Hit> {
 /// identifiers as domain vocabulary — e.g. a tool-schema library discussing
 /// `tool_input` — can allowlist that literal term without suppressing the
 /// whole `harness-noun` category or a different hit like `tool_response`).
+///
+/// **Softening call site 2 of 2.** A hit from a [`ConfigScope::SourceFileOnly`]
+/// category is never allowlistable from repo config — the check short-circuits
+/// before reading a single entry. Its exemptions live in the same out-of-repo
+/// file its terms do.
 fn is_allowlisted(hit: &Hit, allowlist: &[String]) -> bool {
+    if hit.config_scope == ConfigScope::SourceFileOnly {
+        return false;
+    }
     allowlist.iter().any(|entry| {
         if entry.contains(':') {
             entry == &hit.snippet
@@ -639,6 +877,53 @@ fn build_message(hits: &[Hit]) -> String {
 //   - `--init` needs no jq, and re-emits an existing file via serde_json
 //     pretty-printing rather than jq's formatting (cosmetic divergence).
 // ---------------------------------------------------------------------------
+
+/// Entry for `redact-scan --status`. Returns the process exit code: 0 armed,
+/// 1 unarmed.
+///
+/// This exists because of an asymmetry: an armed guard announces itself every
+/// time it fires, but an *unarmed* one is indistinguishable from a clean repo.
+/// On a second machine where the term source was never replicated, every post
+/// would sail through and look exactly like success. The report goes to stdout
+/// so a SessionStart hook can surface it in the transcript.
+pub fn run_status() -> u8 {
+    let (list, status) = identity::load();
+    let path = identity::terms_path()
+        .map(|p| p.display().to_string())
+        .unwrap_or_else(|| "<unresolvable: no HOME>".to_string());
+    let report = match &status {
+        identity::Status::Armed(n) => {
+            let mode = match list.mode {
+                identity::Mode::Enforce => "enforce (blocking)",
+                identity::Mode::Warn => "warn (advisory)",
+            };
+            format!("redaction identity tier: ARMED — {n} term(s), mode {mode} [{path}]")
+        }
+        identity::Status::Absent => format!(
+            "⚠️  redaction identity tier: NOT ARMED — no term source at {path}\n\
+             Work-identifiable terms will NOT be caught on this machine. \
+             Replicate the file (1Password: cadence-redaction-terms) to arm it."
+        ),
+        identity::Status::Unreadable => format!(
+            "⚠️  redaction identity tier: NOT ARMED — term source at {path} exists but \
+             could not be read (permissions, or not a regular file).\n\
+             This is reported exactly like an absent file on purpose: from the outcome \
+             alone the two are indistinguishable, and both mean nothing is being caught."
+        ),
+        identity::Status::ZeroTerms => format!(
+            "⚠️  redaction identity tier: NOT ARMED — term source at {path} parsed but \
+             carries zero terms."
+        ),
+        identity::Status::Malformed(e) => format!(
+            "⚠️  redaction identity tier: NOT ARMED — term source at {path} failed to \
+             parse: {e}\nFix the file to re-arm; nothing is being caught until then."
+        ),
+    };
+    println!("{report}");
+    // One source of truth for "is this a state the operator must be told
+    // about" — the exit code derives from it rather than restating it per arm.
+    u8::from(status.needs_notice())
+}
 
 /// Entry for the `redact-scan` CLI action. Returns the process exit code.
 pub fn run_scan(file: Option<String>, audience: Option<String>, init: bool) -> u8 {
@@ -1930,6 +2215,235 @@ mod tests {
                 resolve_dest_tier(Some("owned-internal"), &config)
             )
             .is_empty()
+        );
+    }
+
+    // --- The identity tier, at the guard level -----------------------------
+    //
+    // These drive the real `run()`, so they set `CADENCE_REDACTION_TERMS` and
+    // must not run concurrently with each other (process-wide env). Everything
+    // reachable without env goes in `identity::tests` instead.
+
+    static TERMS_ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    /// Run `body` through the guard with a fixture term source. Returns the
+    /// full result so a caller can assert on outcome, message, and bypass.
+    fn with_terms<F, R>(toml_body: &str, f: F) -> R
+    where
+        F: FnOnce() -> R,
+    {
+        let guard = TERMS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("redaction.toml");
+        std::fs::write(&path, toml_body).unwrap();
+        // SAFETY-equivalent rationale: serialized by TERMS_ENV_LOCK above.
+        unsafe { std::env::set_var("CADENCE_REDACTION_TERMS", &path) };
+        let out = f();
+        unsafe { std::env::remove_var("CADENCE_REDACTION_TERMS") };
+        drop(guard);
+        out
+    }
+
+    const FIXTURE: &str = r#"
+version = 1
+[[terms]]
+id = "T1"
+term = "acmecorp"
+"#;
+
+    #[test]
+    fn identity_term_in_a_commit_message_blocks() {
+        with_terms(FIXTURE, || {
+            let r = run("git commit -m \"fix the acmecorp integration\"");
+            assert_eq!(r.outcome, Outcome::Block, "identity must block by default");
+            let msg = r.message.unwrap_or_default();
+            assert!(msg.contains("BLOCKED"), "labels the block: {msg}");
+            assert!(msg.contains("acmecorp"), "names the term verbatim: {msg}");
+            assert!(msg.contains("[T1]"), "names the authored id: {msg}");
+        });
+    }
+
+    #[test]
+    fn clean_body_still_allows_with_the_tier_armed() {
+        with_terms(FIXTURE, || {
+            assert_eq!(
+                run("git commit -m \"fix the parser\"").outcome,
+                Outcome::Allow
+            );
+        });
+    }
+
+    #[test]
+    fn absent_terms_file_is_inert_not_a_hard_failure() {
+        let guard = TERMS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        unsafe { std::env::set_var("CADENCE_REDACTION_TERMS", "/nonexistent/redaction.toml") };
+        let r = run("git commit -m \"fix the acmecorp integration\"");
+        unsafe { std::env::remove_var("CADENCE_REDACTION_TERMS") };
+        drop(guard);
+        // Fail-OPEN on the guard's own failure: a machine that never had the
+        // file must still be able to commit. The SessionStart probe is what
+        // keeps this from being silent.
+        assert_eq!(r.outcome, Outcome::Allow);
+    }
+
+    #[test]
+    fn malformed_terms_file_is_inert_not_a_hard_failure() {
+        with_terms("this is not [valid toml", || {
+            assert_eq!(
+                run("git commit -m \"fix the acmecorp integration\"").outcome,
+                Outcome::Allow,
+                "a broken term source must not brick every commit"
+            );
+        });
+    }
+
+    #[test]
+    fn zero_term_file_is_inert() {
+        with_terms("version = 1\n", || {
+            assert_eq!(run("git commit -m \"acmecorp\"").outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn warn_mode_nudges_instead_of_blocking() {
+        with_terms(
+            "version = 1\nmode = \"warn\"\n[[terms]]\nid = \"T1\"\nterm = \"acmecorp\"\n",
+            || {
+                let r = run("git commit -m \"the acmecorp thing\"");
+                assert_eq!(r.outcome, Outcome::Nudge);
+                assert!(r.message.unwrap_or_default().contains("warn mode"));
+            },
+        );
+    }
+
+    #[test]
+    fn repo_config_cannot_soften_the_identity_tier() {
+        // The whole point of ConfigScope::SourceFileOnly. A repo that
+        // allowlists the term AND raises every ceiling still blocks.
+        with_terms(FIXTURE, || {
+            let repo = temp_repo_with_config(
+                r#"{"allowlist":["acmecorp"],"originAudience":"owned-internal",
+                    "categories":{"identity":{"ceiling":"public"}}}"#,
+            );
+            let input = make_bash_with_cwd(
+                "git commit -m \"the acmecorp thing\"",
+                repo.path().to_str().unwrap(),
+            );
+            assert_eq!(
+                RedactExternalContent.run(&input).outcome,
+                Outcome::Block,
+                "committed config must have no path to the identity tier"
+            );
+        });
+    }
+
+    #[test]
+    fn identity_and_shaped_hits_both_appear_in_one_message() {
+        // No short-circuit: fixing one finding should not reveal the other on
+        // the retry.
+        with_terms(FIXTURE, || {
+            let r = run("gh issue create --body \"acmecorp uses cadence:attune\"");
+            assert_eq!(r.outcome, Outcome::Block);
+            let msg = r.message.unwrap_or_default();
+            assert!(msg.contains("acmecorp"), "identity finding present: {msg}");
+            assert!(
+                msg.contains("cadence:attune"),
+                "shaped finding present too: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn bypass_downgrades_the_block_but_keeps_the_message_and_logs_provenance() {
+        with_terms(FIXTURE, || {
+            // Already inside with_terms' lock — std Mutex is not reentrant, so
+            // re-locking here would deadlock. The outer guard serializes both
+            // env vars.
+            unsafe { std::env::set_var("CADENCE_ALLOW_SENSITIVE_TERMS", "1") };
+            let r = run("gh issue create --body \"acmecorp uses cadence:attune\"");
+            unsafe { std::env::remove_var("CADENCE_ALLOW_SENSITIVE_TERMS") };
+            assert_eq!(r.outcome, Outcome::Nudge, "bypass downgrades the block");
+            assert!(
+                r.bypass.is_some(),
+                "and still records provenance — an unlogged bypass is invisible"
+            );
+            let msg = r.message.unwrap_or_default();
+            assert!(
+                msg.contains("cadence:attune"),
+                "the shaped finding must survive the downgrade: {msg}"
+            );
+        });
+    }
+
+    #[test]
+    fn write_of_an_introduced_term_blocks() {
+        with_terms(FIXTURE, || {
+            let input = HookInput {
+                tool_name: Some("Write".into()),
+                tool_input: Some(cadence_hooks_core::ToolInput {
+                    file_path: Some("/tmp/notes.md".into()),
+                    content: Some("we ship acmecorp tooling".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Block);
+        });
+    }
+
+    #[test]
+    fn edit_removing_a_preexisting_term_is_not_blocked() {
+        // The introduced-only rule, in its most load-bearing case: the
+        // remediation edit itself must be possible.
+        with_terms(FIXTURE, || {
+            let input = HookInput {
+                tool_name: Some("Edit".into()),
+                tool_input: Some(cadence_hooks_core::ToolInput {
+                    file_path: Some("/tmp/notes.md".into()),
+                    old_string: Some("we ship acmecorp tooling".into()),
+                    new_string: Some("we ship the tooling".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn write_of_a_local_path_does_not_nudge() {
+        // Shaped tiers never run on Write/Edit. Without this, every locally
+        // written /Users/… path would nudge — the FP flood that gets a guard
+        // turned off.
+        with_terms(FIXTURE, || {
+            let input = HookInput {
+                tool_name: Some("Write".into()),
+                tool_input: Some(cadence_hooks_core::ToolInput {
+                    file_path: Some("/tmp/notes.md".into()),
+                    content: Some("see /Users/alice/proj and cadence:attune".into()),
+                    ..Default::default()
+                }),
+                ..Default::default()
+            };
+            assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Allow);
+        });
+    }
+
+    #[test]
+    fn an_allow_entry_in_the_term_source_does_excuse_the_hit() {
+        with_terms(
+            "version = 1\n[[terms]]\nid = \"T8\"\nterm = \"clarion\"\n\
+             [[terms.allow]]\npattern = \"(?i)clarion call\"\n",
+            || {
+                assert_eq!(
+                    run("git commit -m \"a clarion call for tests\"").outcome,
+                    Outcome::Allow
+                );
+                assert_eq!(
+                    run("git commit -m \"the clarion platform\"").outcome,
+                    Outcome::Block
+                );
+            },
         );
     }
 }

--- a/crates/cadence/src/redact_external_content/identity.rs
+++ b/crates/cadence/src/redact_external_content/identity.rs
@@ -140,19 +140,37 @@ impl Status {
     }
 }
 
-/// Resolve the term-source path. `CADENCE_REDACTION_TERMS` overrides (the test
-/// seam, and an escape hatch for a non-standard home); otherwise
-/// `$XDG_CONFIG_HOME/cadence/redaction.toml`, else `~/.config/cadence/…`.
+/// Resolve the term-source path: `$HOME/.config/cadence/redaction.toml`, and
+/// nothing else.
+///
+/// # Why no environment override in production
+///
+/// An earlier revision honored `CADENCE_REDACTION_TERMS` and
+/// `XDG_CONFIG_HOME`. A security review caught what that costs: a project's
+/// `.claude/settings.json` `env` block reaches hook subprocesses, and this
+/// codebase already documents those blocks as attacker-influenceable
+/// (`crates/metrics/src/warn_stale.rs` — the reasoning that put `CADENCE_DISABLE`
+/// behind `PROTECTED_GUARDS`). So `{"env": {"CADENCE_REDACTION_TERMS":
+/// "/dev/null"}}` in a cloned repo would resolve to an absent file, load an
+/// empty list, and fail open — **a silent disarm through a door neither
+/// softening call site guards, because it sits upstream of both.**
+///
+/// That is the same disarm `PROTECTED_GUARDS` exists to prevent, arriving by a
+/// different variable, so it gets the same answer. It does not require an
+/// adversary either: a repo that sets `XDG_CONFIG_HOME` for its own unrelated
+/// reasons disarms the tier by accident, which is squarely inside this estate's
+/// threat model.
+///
+/// The cost is that a non-standard config location is unsupported. Accepted:
+/// the override's only real consumers were tests, and an escape hatch that a
+/// committed file can pull is not an escape hatch, it is a hole. If a genuine
+/// need appears, it must come from a source no repo can write.
 pub(crate) fn terms_path() -> Option<PathBuf> {
+    #[cfg(test)]
     if let Ok(p) = std::env::var("CADENCE_REDACTION_TERMS")
         && !p.is_empty()
     {
         return Some(PathBuf::from(p));
-    }
-    if let Ok(x) = std::env::var("XDG_CONFIG_HOME")
-        && !x.is_empty()
-    {
-        return Some(PathBuf::from(x).join("cadence").join("redaction.toml"));
     }
     std::env::var("HOME")
         .ok()
@@ -209,9 +227,10 @@ fn term_regex(term: &str) -> Option<Regex> {
     if t.is_empty() {
         return None;
     }
-    let escaped = regex::escape(t);
-    // Re-open the escaped literal spaces into a separator class.
-    let body = escaped.replace("\\ ", "[ _-]").replace(' ', "[ _-]");
+    // `regex::escape` leaves spaces untouched (they are not regex metachars),
+    // so a single replace on the bare space is the whole job — an earlier
+    // version also replaced `"\\ "`, which never matched anything.
+    let body = regex::escape(t).replace(' ', "[ _-]");
     let starts_word = t
         .chars()
         .next()
@@ -427,14 +446,25 @@ mod tests {
     }
 
     #[test]
-    fn scan_is_config_blind_by_signature() {
-        // A compile-time assertion in spirit: scan_identity's parameters are
-        // (text, list, path). If a RedactionConfig ever becomes reachable here,
-        // this test stops compiling — which is the point.
-        fn assert_signature(f: fn(&str, &IdentityList, Option<&str>) -> Vec<IdentityHit>) -> bool {
-            let _ = f;
-            true
-        }
-        assert!(assert_signature(scan_identity));
+    fn identity_ignores_a_term_the_repo_allowlist_would_suppress() {
+        // Replaces an earlier `assert_signature` test that only type-checked —
+        // it would have passed at runtime no matter what the function did,
+        // because a changed signature fails compilation rather than the test.
+        //
+        // This asserts the property behaviorally instead: the exact string that
+        // a repo's allowlist DOES suppress in a shaped category is still a hit
+        // here. The shaped-side half of the pair lives in the parent module's
+        // `allowlist_bare_term_suppresses_matching_harness_noun`, which proves
+        // the same entry genuinely suppresses there — so together they show the
+        // divergence is the identity pass ignoring config, not the term simply
+        // never matching anything.
+        let l = list_of(&[("T1", "tool_input")]);
+        let hits = scan_identity("the tool_input field", &l, None);
+        assert_eq!(
+            hits.len(),
+            1,
+            "identity must flag a term that repo config allowlists for shaped categories"
+        );
+        assert_eq!(hits[0].id, "T1");
     }
 }

--- a/crates/cadence/src/redact_external_content/identity.rs
+++ b/crates/cadence/src/redact_external_content/identity.rs
@@ -1,0 +1,440 @@
+//! The identity tier — fail-closed scanning for work-identifiable terms.
+//!
+//! # Why this is a tier and not a separate guard
+//!
+//! It shares the extraction layer with the shaped tiers: per-segment command
+//! gating, `--body-file` bounded reads, the #424 hardening. That layer is where
+//! the historical bugs lived, and a standalone identity guard would duplicate
+//! exactly it. One guard name, one message surface, one extraction layer, two
+//! scan passes with different term-source authority.
+//!
+//! # Term source
+//!
+//! `~/.config/cadence/redaction.toml` — deliberately **outside every repo**
+//! (cadence-hooks#561's load-bearing property). Nothing committed to a
+//! repository can add, remove, or soften a term, because the loader reads no
+//! repo path. Softening authority follows term-source authority: the same file
+//! carries the `allow` entries.
+//!
+//! # Fail directions, which run in two different directions on purpose
+//!
+//! - **The guard's own failure is fail-open** (ADR-0001): no file, unreadable,
+//!   malformed, zero terms → the tier is inert and the check allows. A guard
+//!   that hard-fails on a missing config makes every commit impossible on a
+//!   machine that never had the file.
+//! - **A term match is fail-closed**: it blocks, and no repo config can excuse
+//!   it.
+//!
+//! The gap between those — a machine where the file is silently absent — is why
+//! [`status`] exists and why the cadence plugin's SessionStart surfaces it. A
+//! per-invocation notice on the machine you are not looking at is functionally
+//! a silent disarm.
+
+use regex::Regex;
+use serde::Deserialize;
+use std::path::PathBuf;
+
+/// Enforcement posture, read from the file's top-level `mode`.
+///
+/// **Default is [`Mode::Enforce`]** (Cameron's ruling, 2026-08-03, superseding
+/// the plan's default-warn rollout: "Default on — then we'll gather
+/// feedback/issues. Does no good if it's disabled."). An absent or unparseable
+/// `mode` therefore blocks rather than warns, which is the fail-closed
+/// direction for a field whose whole purpose is enforcement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub(crate) enum Mode {
+    #[default]
+    Enforce,
+    Warn,
+}
+
+/// One allow entry — a context in which a term is benign.
+///
+/// `path` matches when the scanned content's file path contains it (a Write/Edit
+/// surface only — a commit message has no path). `pattern` matches against the
+/// surrounding text. Either alone is sufficient; both empty is inert.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct AllowEntry {
+    #[serde(default)]
+    pub path: Option<String>,
+    #[serde(default)]
+    pub pattern: Option<String>,
+}
+
+/// One deny-list term with its explicit, stable id.
+///
+/// `id` is authored, never positional. The predecessor format derived a term's
+/// "T-code" from its line number, which drifted the moment the file was
+/// re-sorted and left older artifacts citing numbers that had moved.
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct IdentityTerm {
+    pub id: String,
+    pub term: String,
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub class: Option<String>,
+    #[serde(default)]
+    pub allow: Vec<AllowEntry>,
+}
+
+/// The parsed term source.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub(crate) struct IdentityList {
+    #[serde(default)]
+    #[allow(dead_code)]
+    pub version: Option<u32>,
+    #[serde(default)]
+    pub mode: Mode,
+    #[serde(default)]
+    pub terms: Vec<IdentityTerm>,
+    /// Global allows, applied to every term.
+    #[serde(default)]
+    pub allow: Vec<AllowEntry>,
+}
+
+impl IdentityList {
+    /// Is the tier armed? An empty term list is treated exactly like an absent
+    /// file — inert, and surfaced by [`status`]. A file that parses but carries
+    /// no terms is the silent-disarm shape, not a configuration choice.
+    pub fn is_armed(&self) -> bool {
+        !self.terms.is_empty()
+    }
+}
+
+/// One identity match. Carries the term's authored id, never its text, for any
+/// caller that logs — the block message names the term verbatim (ruled: the
+/// threat model is irrevocable public artifacts, and a block you cannot act on
+/// is not a control), but a log line is a different surface.
+#[derive(Debug, Clone)]
+pub(crate) struct IdentityHit {
+    pub id: String,
+    pub snippet: String,
+    #[allow(dead_code)]
+    pub offset: usize,
+}
+
+/// Why the tier is not scanning, when it is not.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum Status {
+    /// Armed and scanning, with the term count.
+    Armed(usize),
+    /// No file at the resolved path.
+    Absent,
+    /// File exists but could not be read — permissions, a directory, a special
+    /// file, or over the bounded-read cap. **Notified exactly like `Absent`**:
+    /// silent-inert on a permissions error is the same silent-disarm class the
+    /// lenient-config work closed, and the operator cannot tell the difference
+    /// from the outcome alone.
+    Unreadable,
+    /// Read, but did not parse as the expected schema.
+    Malformed(String),
+    /// Parsed, but carries zero terms.
+    ZeroTerms,
+}
+
+impl Status {
+    /// Should SessionStart surface this? Every non-armed state, by design.
+    pub fn needs_notice(&self) -> bool {
+        !matches!(self, Status::Armed(_))
+    }
+}
+
+/// Resolve the term-source path. `CADENCE_REDACTION_TERMS` overrides (the test
+/// seam, and an escape hatch for a non-standard home); otherwise
+/// `$XDG_CONFIG_HOME/cadence/redaction.toml`, else `~/.config/cadence/…`.
+pub(crate) fn terms_path() -> Option<PathBuf> {
+    if let Ok(p) = std::env::var("CADENCE_REDACTION_TERMS")
+        && !p.is_empty()
+    {
+        return Some(PathBuf::from(p));
+    }
+    if let Ok(x) = std::env::var("XDG_CONFIG_HOME")
+        && !x.is_empty()
+    {
+        return Some(PathBuf::from(x).join("cadence").join("redaction.toml"));
+    }
+    std::env::var("HOME")
+        .ok()
+        .filter(|h| !h.is_empty())
+        .map(|h| {
+            PathBuf::from(h)
+                .join(".config")
+                .join("cadence")
+                .join("redaction.toml")
+        })
+}
+
+/// Load the term source, returning both the list and why it is what it is.
+///
+/// Every failure yields an empty list — the guard's own failure is fail-open.
+/// The [`Status`] is what keeps that from being silent.
+pub(crate) fn load() -> (IdentityList, Status) {
+    let Some(path) = terms_path() else {
+        return (IdentityList::default(), Status::Absent);
+    };
+    if !path.exists() {
+        return (IdentityList::default(), Status::Absent);
+    }
+    // Same bounded, regular-file-only reader the body-file path uses: a symlink
+    // to /dev/zero or a multi-GB file must not hang the hook (#157/#194).
+    let Some(raw) = cadence_hooks_core::paths::read_untrusted_config(&path) else {
+        return (IdentityList::default(), Status::Unreadable);
+    };
+    match toml::from_str::<IdentityList>(&raw) {
+        Ok(list) => {
+            if list.is_armed() {
+                let n = list.terms.len();
+                (list, Status::Armed(n))
+            } else {
+                (list, Status::ZeroTerms)
+            }
+        }
+        // The parse error names a line/column but never the file's content —
+        // safe to surface.
+        Err(e) => (
+            IdentityList::default(),
+            Status::Malformed(e.message().to_string()),
+        ),
+    }
+}
+
+/// Build the match regex for one term: case-insensitive, and word-boundary
+/// anchored only on the sides where the term's own edge is a word character
+/// (an unconditional `\b` around a term starting with `.` or `/` would never
+/// match). Multi-word terms match across space, hyphen, and underscore, because
+/// that is how the same name is spelled in prose, in a hostname, and in a slug.
+fn term_regex(term: &str) -> Option<Regex> {
+    let t = term.trim();
+    if t.is_empty() {
+        return None;
+    }
+    let escaped = regex::escape(t);
+    // Re-open the escaped literal spaces into a separator class.
+    let body = escaped.replace("\\ ", "[ _-]").replace(' ', "[ _-]");
+    let starts_word = t
+        .chars()
+        .next()
+        .is_some_and(|c| c.is_alphanumeric() || c == '_');
+    let ends_word = t
+        .chars()
+        .next_back()
+        .is_some_and(|c| c.is_alphanumeric() || c == '_');
+    let pattern = format!(
+        "(?i){}{}{}",
+        if starts_word { r"\b" } else { "" },
+        body,
+        if ends_word { r"\b" } else { "" }
+    );
+    Regex::new(&pattern).ok()
+}
+
+/// Does an allow entry excuse this match?
+///
+/// `path` is a containment test against the scanned surface's file path (absent
+/// for a commit message, so a path-only allow never fires there). `pattern` is
+/// a regex against the full scanned text — the form that expresses "this term,
+/// in this sentence, is the English word."
+fn is_allowed(entry: &AllowEntry, text: &str, file_path: Option<&str>) -> bool {
+    if let Some(p) = entry.path.as_deref().filter(|p| !p.is_empty())
+        && file_path.is_some_and(|fp| fp.contains(p))
+    {
+        return true;
+    }
+    if let Some(pat) = entry.pattern.as_deref().filter(|p| !p.is_empty())
+        && Regex::new(pat).is_ok_and(|re| re.is_match(text))
+    {
+        return true;
+    }
+    false
+}
+
+/// Scan `text` for identity terms.
+///
+/// **Config-blind by signature.** There is no `RedactionConfig` parameter, no
+/// destination tier, no repo allowlist — so no committed file can reach this
+/// function's behavior even by future accident. That is the type-level half of
+/// the same property [`super::ConfigScope::SourceFileOnly`] enforces for the
+/// shaped-tier call sites.
+pub(crate) fn scan_identity(
+    text: &str,
+    list: &IdentityList,
+    file_path: Option<&str>,
+) -> Vec<IdentityHit> {
+    if !list.is_armed() {
+        return Vec::new();
+    }
+    let mut hits: Vec<IdentityHit> = Vec::new();
+    for term in &list.terms {
+        let Some(re) = term_regex(&term.term) else {
+            continue;
+        };
+        // A term-level or global allow excusing this context skips the term.
+        let excused = term
+            .allow
+            .iter()
+            .chain(list.allow.iter())
+            .any(|a| is_allowed(a, text, file_path));
+        if excused {
+            continue;
+        }
+        for m in re.find_iter(text) {
+            hits.push(IdentityHit {
+                id: term.id.clone(),
+                snippet: m.as_str().to_string(),
+                offset: m.start(),
+            });
+        }
+    }
+    hits.sort_by_key(|h| h.offset);
+    hits
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn list_of(terms: &[(&str, &str)]) -> IdentityList {
+        IdentityList {
+            version: Some(1),
+            mode: Mode::Enforce,
+            terms: terms
+                .iter()
+                .map(|(id, t)| IdentityTerm {
+                    id: (*id).to_string(),
+                    term: (*t).to_string(),
+                    class: None,
+                    allow: Vec::new(),
+                })
+                .collect(),
+            allow: Vec::new(),
+        }
+    }
+
+    #[test]
+    fn matches_case_insensitively() {
+        let l = list_of(&[("T1", "acmecorp")]);
+        assert_eq!(scan_identity("We use AcmeCorp here", &l, None).len(), 1);
+    }
+
+    #[test]
+    fn respects_word_boundaries() {
+        let l = list_of(&[("T1", "acme")]);
+        // `acmecorp` must not match the shorter standalone term.
+        assert!(scan_identity("acmecorp tooling", &l, None).is_empty());
+        assert_eq!(scan_identity("the acme tool", &l, None).len(), 1);
+    }
+
+    #[test]
+    fn multiword_matches_across_separators() {
+        let l = list_of(&[("T9", "acme widget")]);
+        for spelling in ["acme widget", "acme-widget", "acme_widget", "Acme Widget"] {
+            assert_eq!(
+                scan_identity(spelling, &l, None).len(),
+                1,
+                "should match: {spelling}"
+            );
+        }
+    }
+
+    #[test]
+    fn hostname_with_dots_matches() {
+        let l = list_of(&[("T5", "ghe.example.com")]);
+        assert_eq!(
+            scan_identity("push to ghe.example.com/org/repo", &l, None).len(),
+            1
+        );
+    }
+
+    #[test]
+    fn empty_list_is_inert() {
+        let l = IdentityList::default();
+        assert!(!l.is_armed());
+        assert!(scan_identity("acmecorp", &l, None).is_empty());
+    }
+
+    #[test]
+    fn mode_defaults_to_enforce() {
+        // The ruled default: shipping disabled "does no good".
+        let parsed: IdentityList = toml::from_str("version = 1\n").expect("parses");
+        assert_eq!(parsed.mode, Mode::Enforce);
+    }
+
+    #[test]
+    fn mode_warn_parses_when_stated() {
+        let parsed: IdentityList = toml::from_str("mode = \"warn\"\n").expect("parses");
+        assert_eq!(parsed.mode, Mode::Warn);
+    }
+
+    #[test]
+    fn pattern_allow_excuses_the_english_collision() {
+        let mut l = list_of(&[("T8", "clarion")]);
+        l.terms[0].allow.push(AllowEntry {
+            path: None,
+            pattern: Some(r"(?i)clarion\s+(call|bell)".to_string()),
+        });
+        assert!(scan_identity("a clarion call to arms", &l, None).is_empty());
+        assert_eq!(scan_identity("the clarion platform", &l, None).len(), 1);
+    }
+
+    #[test]
+    fn path_allow_only_fires_when_a_path_is_present() {
+        let mut l = list_of(&[("T8", "clarion")]);
+        l.terms[0].allow.push(AllowEntry {
+            path: Some("test_fixtures.py".to_string()),
+            pattern: None,
+        });
+        assert!(scan_identity("clarion", &l, Some("a/test_fixtures.py")).is_empty());
+        // A commit message has no path — the allow cannot fire there.
+        assert_eq!(scan_identity("clarion", &l, None).len(), 1);
+    }
+
+    #[test]
+    fn global_allow_applies_to_every_term() {
+        let mut l = list_of(&[("T1", "acmecorp"), ("T2", "widgetco")]);
+        l.allow.push(AllowEntry {
+            path: Some("docs/redaction-tests/".to_string()),
+            pattern: None,
+        });
+        assert!(
+            scan_identity(
+                "acmecorp and widgetco",
+                &l,
+                Some("docs/redaction-tests/fixtures.md")
+            )
+            .is_empty()
+        );
+    }
+
+    #[test]
+    fn malformed_toml_is_fail_open_with_a_named_status() {
+        // Not via load() (which reads the real path) — parse directly.
+        let err = toml::from_str::<IdentityList>("terms = [ this is not toml").unwrap_err();
+        assert!(!err.message().is_empty());
+    }
+
+    #[test]
+    fn status_notices_every_unarmed_state() {
+        assert!(!Status::Armed(3).needs_notice());
+        for s in [
+            Status::Absent,
+            Status::Unreadable,
+            Status::ZeroTerms,
+            Status::Malformed("x".into()),
+        ] {
+            assert!(s.needs_notice(), "{s:?} must notify");
+        }
+    }
+
+    #[test]
+    fn scan_is_config_blind_by_signature() {
+        // A compile-time assertion in spirit: scan_identity's parameters are
+        // (text, list, path). If a RedactionConfig ever becomes reachable here,
+        // this test stops compiling — which is the point.
+        fn assert_signature(f: fn(&str, &IdentityList, Option<&str>) -> Vec<IdentityHit>) -> bool {
+            let _ = f;
+            true
+        }
+        assert!(assert_signature(scan_identity));
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1143,6 +1143,24 @@ impl CheckResult {
             bypass: Some(bypass),
         }
     }
+
+    /// Attach [`BypassProvenance`] to a result that is **not** a plain allow.
+    ///
+    /// [`allow_bypassed`](Self::allow_bypassed) covers the common shape — a
+    /// bypass turns a block into a silent allow. It does not cover a guard with
+    /// more than one severity tier, where a bypass downgrades the hard tier but
+    /// the soft tier still has something to say: dropping to `allow_bypassed`
+    /// would silently discard that message, and returning a bare `nudge` would
+    /// lose the provenance row in `bypasses.jsonl`.
+    ///
+    /// `redact-external-content` is the first such guard: with the identity
+    /// bypass armed and both an identity and a shaped hit present, the honest
+    /// result is a nudge carrying the shaped finding *and* the attribution that
+    /// a bypass suppressed the block.
+    pub fn with_bypass(mut self, bypass: BypassProvenance) -> Self {
+        self.bypass = Some(bypass);
+        self
+    }
 }
 
 /// A hook check that can be run against input.

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -325,28 +325,49 @@
           "plugin": "cadence",
           "event": "PreToolUse",
           "matcher": "Bash",
-          "if": "Bash(*gh pr create*)",
+          "if": "Bash(*gh pr *)",
           "commandHash": "4e29c437b95503c318b77b5befa411c309981ee3d7cacf74f741c39e366873bf"
         },
         {
           "plugin": "cadence",
           "event": "PreToolUse",
           "matcher": "Bash",
-          "if": "Bash(*gh pr edit*)",
+          "if": "Bash(*gh issue *)",
           "commandHash": "4e29c437b95503c318b77b5befa411c309981ee3d7cacf74f741c39e366873bf"
         },
         {
           "plugin": "cadence",
           "event": "PreToolUse",
           "matcher": "Bash",
-          "if": "Bash(*gh issue create*)",
+          "if": "Bash(*gh release *)",
           "commandHash": "4e29c437b95503c318b77b5befa411c309981ee3d7cacf74f741c39e366873bf"
         },
         {
           "plugin": "cadence",
           "event": "PreToolUse",
           "matcher": "Bash",
-          "if": "Bash(*gh issue comment*)",
+          "if": "Bash(*gh gist *)",
+          "commandHash": "4e29c437b95503c318b77b5befa411c309981ee3d7cacf74f741c39e366873bf"
+        },
+        {
+          "plugin": "cadence",
+          "event": "PreToolUse",
+          "matcher": "Bash",
+          "if": "Bash(*gh discussion *)",
+          "commandHash": "4e29c437b95503c318b77b5befa411c309981ee3d7cacf74f741c39e366873bf"
+        },
+        {
+          "plugin": "cadence",
+          "event": "PreToolUse",
+          "matcher": "Bash",
+          "if": "Bash(*tea pr *)",
+          "commandHash": "4e29c437b95503c318b77b5befa411c309981ee3d7cacf74f741c39e366873bf"
+        },
+        {
+          "plugin": "cadence",
+          "event": "PreToolUse",
+          "matcher": "Bash",
+          "if": "Bash(*tea issue *)",
           "commandHash": "4e29c437b95503c318b77b5befa411c309981ee3d7cacf74f741c39e366873bf"
         }
       ]
@@ -411,7 +432,7 @@
       "event": "PreToolUse",
       "name": "redact-external-content",
       "plugin": "cadence",
-      "protected": false,
+      "protected": true,
       "status": "native",
       "applicable": true,
       "evidence": "tests/hook_registration_audit.rs",

--- a/scripts/migrate-redaction-terms.py
+++ b/scripts/migrate-redaction-terms.py
@@ -16,9 +16,12 @@ Three properties this script exists to guarantee:
 2. **It never prints a term.** Progress output is counts and ids only. A
    migration log that echoes the deny-list defeats the deny-list.
 
-3. **It never deletes the source.** The original stays in place until the new
-   file is proven (operator's ruling, 2026-08-03); ``--remove-legacy`` is the
-   separate, deliberate second step.
+3. **It never deletes the source without verifying content.** The original
+   stays in place until the new file is proven (operator ruling, 2026-08-03);
+   ``--remove-legacy`` is a separate, deliberate second step, and it compares
+   the actual term SETS rather than counts — a count check would pass while a
+   hand-edit had changed a term, and this step removes the only other on-disk
+   copy.
 
 Refuses to overwrite an existing redaction.toml — re-running is safe.
 """
@@ -27,6 +30,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import re
 import stat
 import sys
 from pathlib import Path
@@ -115,7 +119,7 @@ def main() -> int:
     ap.add_argument(
         "--remove-legacy",
         action="store_true",
-        help="delete the .txt AFTER verifying the .toml parses to the same term count",
+        help="delete the .txt AFTER verifying the .toml carries the identical term set",
     )
     args = ap.parse_args()
 
@@ -131,19 +135,27 @@ def main() -> int:
             print("OK: legacy file already gone")
             return 0
         legacy_terms, _ = parse_legacy(legacy)
-        # Verify by count, not by content: reading both into memory to diff
-        # would be the one place this script holds every term twice.
+        # Verify by CONTENT, not just count. A count check passes while the
+        # term set differs — a hand-edit between migration and removal that
+        # corrects or swaps a term keeps the count identical — and this step
+        # deletes the only other on-disk copy, so a false pass is unrecoverable
+        # from the filesystem. Compare the actual term sets; report the size of
+        # any mismatch without printing which terms differ.
         body = target.read_text(encoding="utf-8")
-        migrated = body.count("[[terms]]")
-        if migrated != len(legacy_terms):
+        migrated = set(re.findall(r'^\s*term\s*=\s*"((?:[^"\\]|\\.)*)"', body, re.MULTILINE))
+        migrated = {t.replace('\\"', '"').replace("\\\\", "\\") for t in migrated}
+        legacy_set = {t for _, t in legacy_terms}
+        if migrated != legacy_set:
+            only_legacy = len(legacy_set - migrated)
+            only_toml = len(migrated - legacy_set)
             print(
-                f"FAIL: term count differs (legacy {len(legacy_terms)}, toml {migrated}) "
-                "— not removing anything",
+                f"FAIL: term sets differ ({only_legacy} only in legacy, "
+                f"{only_toml} only in toml) — not removing anything",
                 file=sys.stderr,
             )
             return 1
         legacy.unlink()
-        print(f"OK: removed legacy file; {migrated} terms live in redaction.toml")
+        print(f"OK: removed legacy file; {len(migrated)} terms verified in redaction.toml")
         return 0
 
     if not legacy.is_file():

--- a/scripts/migrate-redaction-terms.py
+++ b/scripts/migrate-redaction-terms.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+"""Convert the legacy redaction terms .txt into the structured redaction.toml.
+
+One-time migration for the identity tier (cadence-hooks#561). Reads
+``~/.config/cadence/redaction-terms.txt`` and writes ``redaction.toml`` beside
+it.
+
+Three properties this script exists to guarantee:
+
+1. **Explicit ids.** The legacy format derived a term's "T-code" from its line
+   position, so re-sorting the file silently renumbered every term and left
+   older issues citing codes that had moved. The emitted TOML carries the
+   position-derived code as an authored ``id``, freezing today's numbering as
+   the permanent one.
+
+2. **It never prints a term.** Progress output is counts and ids only. A
+   migration log that echoes the deny-list defeats the deny-list.
+
+3. **It never deletes the source.** The original stays in place until the new
+   file is proven (operator's ruling, 2026-08-03); ``--remove-legacy`` is the
+   separate, deliberate second step.
+
+Refuses to overwrite an existing redaction.toml — re-running is safe.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import stat
+import sys
+from pathlib import Path
+
+# Collisions the 2026-08-03 estate sweep proved real: the term is also an
+# ordinary English word or an unrelated proper noun in a known context. Keyed by
+# the position-derived id. Deliberately a small, reviewed table rather than
+# something inferred from the legacy file's free-prose `# allow:` comments —
+# those are triage notes for humans, and parsing them into enforcement would be
+# guessing at what a sentence meant.
+KNOWN_ALLOWS: dict[str, list[dict[str, str]]] = {
+    "T8": [{"path": "scripts/test_retrofit_plan_store.py"}],
+}
+
+
+def default_config_dir() -> Path:
+    xdg = os.environ.get("XDG_CONFIG_HOME")
+    if xdg:
+        return Path(xdg) / "cadence"
+    return Path.home() / ".config" / "cadence"
+
+
+def toml_escape(s: str) -> str:
+    """Escape for a TOML basic string."""
+    return s.replace("\\", "\\\\").replace('"', '\\"')
+
+
+def parse_legacy(path: Path) -> tuple[list[tuple[str, str]], list[str]]:
+    """Return (terms, notes).
+
+    ``terms`` is [(id, term)] with the id derived from 1-based position among
+    non-comment, non-blank lines — the legacy T-code convention, frozen here.
+    ``notes`` collects the file's comment lines so they can ride along as TOML
+    comments rather than being silently dropped.
+    """
+    terms: list[tuple[str, str]] = []
+    notes: list[str] = []
+    n = 0
+    for raw in path.read_text(encoding="utf-8").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        if line.startswith("#"):
+            notes.append(line.lstrip("#").strip())
+            continue
+        n += 1
+        terms.append((f"T{n}", line))
+    return terms, notes
+
+
+def render(terms: list[tuple[str, str]], notes: list[str]) -> str:
+    out: list[str] = [
+        "# cadence redaction — identity tier term source",
+        "#",
+        "# Migrated from redaction-terms.txt. Ids are AUTHORED and permanent:",
+        "# they were derived from line position once, at migration, and must not",
+        "# be renumbered again — existing issues and the leak ledger cite them.",
+        "# Adding a term means adding a NEW id, never reusing or shifting one.",
+        "#",
+        "# mode: 'enforce' (default) blocks; 'warn' only reports.",
+        "",
+        "version = 1",
+        'mode = "enforce"',
+        "",
+    ]
+    if notes:
+        out.append("# --- notes carried from the legacy file ---")
+        out.extend(f"# {n}" for n in notes)
+        out.append("")
+
+    for tid, term in terms:
+        out.append("[[terms]]")
+        out.append(f'id = "{tid}"')
+        out.append(f'term = "{toml_escape(term)}"')
+        for allow in KNOWN_ALLOWS.get(tid, []):
+            out.append("[[terms.allow]]")
+            for k, v in allow.items():
+                out.append(f'{k} = "{toml_escape(v)}"')
+        out.append("")
+    return "\n".join(out) + "\n"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("--config-dir", type=Path, default=None)
+    ap.add_argument(
+        "--remove-legacy",
+        action="store_true",
+        help="delete the .txt AFTER verifying the .toml parses to the same term count",
+    )
+    args = ap.parse_args()
+
+    cfg = args.config_dir or default_config_dir()
+    legacy = cfg / "redaction-terms.txt"
+    target = cfg / "redaction.toml"
+
+    if args.remove_legacy:
+        if not target.exists():
+            print("FAIL: no redaction.toml to verify against", file=sys.stderr)
+            return 1
+        if not legacy.exists():
+            print("OK: legacy file already gone")
+            return 0
+        legacy_terms, _ = parse_legacy(legacy)
+        # Verify by count, not by content: reading both into memory to diff
+        # would be the one place this script holds every term twice.
+        body = target.read_text(encoding="utf-8")
+        migrated = body.count("[[terms]]")
+        if migrated != len(legacy_terms):
+            print(
+                f"FAIL: term count differs (legacy {len(legacy_terms)}, toml {migrated}) "
+                "— not removing anything",
+                file=sys.stderr,
+            )
+            return 1
+        legacy.unlink()
+        print(f"OK: removed legacy file; {migrated} terms live in redaction.toml")
+        return 0
+
+    if not legacy.is_file():
+        print(f"FAIL: no legacy file at {legacy}", file=sys.stderr)
+        return 1
+    if target.exists():
+        print(
+            f"FAIL: {target} already exists — refusing to overwrite. "
+            "Delete it first if you mean to regenerate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    terms, notes = parse_legacy(legacy)
+    if not terms:
+        print("FAIL: legacy file has no terms", file=sys.stderr)
+        return 1
+
+    # Write 0600 from the start — never a window where the file is world-readable.
+    fd = os.open(target, os.O_WRONLY | os.O_CREAT | os.O_EXCL, stat.S_IRUSR | stat.S_IWUSR)
+    with os.fdopen(fd, "w", encoding="utf-8") as fh:
+        fh.write(render(terms, notes))
+
+    allow_count = sum(len(v) for k, v in KNOWN_ALLOWS.items() if any(t == k for t, _ in terms))
+    print(f"OK: wrote {target} — {len(terms)} terms, {allow_count} allow entr(ies), mode=enforce")
+    print(f"    ids: {', '.join(t for t, _ in terms)}")
+    print("    legacy file left in place; verify, then re-run with --remove-legacy")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,13 @@ use registry::{HOOKS, HookEntry};
 const PROTECTED_GUARDS: &[&str] = &[
     "prevent-secret-leaks",
     "prevent-secret-writes",
+    // Carries the fail-closed identity tier. Protection is per-guard, so this
+    // also strips CADENCE_DISABLE from the same guard's *advisory* tiers —
+    // accepted deliberately (ruled 2026-08-03): the alternative was splitting
+    // one guard in two, and the remaining levers for a noisy nudge are the
+    // per-repo allowlist and originAudience, both config edits. Without this
+    // line, one environment variable silently disarms the leak protection.
+    "redact-external-content",
     "git-safety",
     "guard-push-remote",
     "guard-gh-dangerous",
@@ -216,6 +223,12 @@ enum CadenceCommands {
         /// Scaffold the redaction section of .claude/cadence.json and exit
         #[arg(long)]
         init: bool,
+        /// Report whether the identity tier is armed, and exit. Consumed by the
+        /// cadence plugin's SessionStart: an absent or unreadable term source
+        /// is a silent disarm on the machine you are not looking at, so it has
+        /// to announce itself once per session. Exit 0 armed / 1 unarmed.
+        #[arg(long)]
+        status: bool,
     },
     /// Record that /polish ran on this branch (writes a branch-scoped marker). CLI action.
     RecordPolish {
@@ -963,7 +976,13 @@ fn main() {
                 file,
                 audience,
                 init,
+                status,
             } => {
+                if status {
+                    process::exit(
+                        cadence_hooks_cadence::redact_external_content::run_status().into(),
+                    );
+                }
                 process::exit(
                     cadence_hooks_cadence::redact_external_content::run_scan(file, audience, init)
                         .into(),


### PR DESCRIPTION
Closes #561
Closes #564

The redaction system was calibrated on the wrong axis — loud where consequence was low, silent where it was high. Stages 1–3 and 5 of the re-base fixed the loud half. This is the silent half: the tier that catches what the 2026-08-02 leak-ledger campaign found and redaction did not (102 object-store hits, 41 tracker hits of enterprise identifiers).

## Shape

One guard, two type-separated passes. Identity blocks; the shaped tiers still nudge; the vocabulary class was deleted in Stage 1.

Terms come from `~/.config/cadence/redaction.toml` — outside every repo, which was #561's load-bearing property. Ids are authored and permanent, replacing position-derived codes that drifted the moment the file was re-sorted and left older issues citing numbers that had moved.

## Config-blind by construction, two independent ways

- **Structurally** — a `config_scope` field on the category descriptor, consulted by the two softening call sites (`category_ceiling`, `is_allowlisted`). Deliberately not `if category == "identity"` at N sites: a category added later inherits whichever authority its descriptor declares, including by accident. The principle, for the ADR: *exemption authority follows term-source authority*.
- **By signature** — `scan_identity` takes no `RedactionConfig`, no destination tier, no allowlist. There is no parameter through which a committed file can reach it.

A test asserts a repo that allowlists the term *and* raises every ceiling still blocks.

## Fail directions run opposite, on purpose

The guard's own failure is fail-open: absent, unreadable, malformed, or zero-term source → inert. A guard that hard-fails on a missing config makes every commit impossible on a machine that never had the file. A term match is fail-closed.

The gap between those is the interesting one — a machine where the file was never replicated looks exactly like a clean repo. `redact-scan --status` closes it: an armed guard announces itself when it fires, an unarmed one never does. Present-but-unreadable and zero-term report identically to absent, because from the outcome alone they are indistinguishable and all three mean nothing is being caught.

## Rulings folded in

| Ruling | Why |
|---|---|
| `mode` defaults to **enforce**, not warn | Supersedes the plan's warn-window rollout (operator, 2026-08-03): "Default on — then we'll gather feedback/issues. Does no good if it's disabled." |
| Joins `PROTECTED_GUARDS` | Protection is per-guard, so this also strips `CADENCE_DISABLE` from the same guard's *advisory* tiers. Accepted over splitting one guard in two; remaining levers for a noisy nudge are the allowlist and `originAudience`. Without it, one env var silently disarms the leak protection. |
| Write/Edit runs the identity pass **only** | Shaped tiers on a local edit would nudge every `/Users/…` path written — the false-positive flood that gets a guard turned off. A file write has no audience. |
| Introduced fragments, never `effective_content` | A pre-existing term would otherwise block every unrelated edit *including the one that removes it*. `effective_content`'s `None`-on-unreadable default is also self-locking. |
| `CheckResult::with_bypass` — the one surface change | `allow_bypassed` is Allow-only and message-less, so with the bypass armed and both an identity and a shaped hit present it would silently drop the shaped finding. This keeps the message and the provenance row. |
| Block message names the term verbatim | A block that will not say what tripped it is one the operator cannot act on — they retry, it blocks again, and the guard gets disabled. Transcripts are not the surface this protects. |

## Accepted residual, stated rather than papered over

Coverage is **introduction-time**. Content entering a file outside Write/Edit — `sed -i`, an external editor — can still ride a commit. Accepted under the estate's accidents-not-adversaries threat model; the periodic leak-ledger scan is its detection net, and a native git pre-commit hook (which also sees terminal commits) is the filed v2 route rather than this guard's scope.

Staged-content scanning was considered and rejected at this altitude: `git diff --cached` has no acceptable fail direction on a corrupt index or fresh repo, it violates introduced-only (it would block committing the remediation itself), and it still misses terminal commits.

## Verification

End-to-end against the built binary, each with its control:

| Condition | Exit | Meaning |
|---|---|---|
| Term present, tier armed | 2 | Blocks, naming term and id |
| Clean body, tier armed | 0 | No false positive |
| Term present, tier **unarmed** | 0 | Fail-open holds |
| Term present, armed, `CADENCE_DISABLE` set | **2** | Protection holds — attributable to the `PROTECTED_GUARDS` entry specifically |

Plus 968 tests green (27 new), `clippy --all-targets -D warnings` clean, `fmt --check` clean, full workspace suite green.

## Not in this PR

The cadence-plugin `hooks.json` matcher that routes Write/Edit events here. The code path is dormant until that lands, which keeps the new surface a deliberate second step.

## Migration

`scripts/migrate-redaction-terms.py` converts the legacy file, freezing today's position-derived codes as authored ids. It refuses to overwrite, writes `0600` via `O_EXCL`, never prints a term, and leaves the original in place — `--remove-legacy` is a separate deliberate step after the new file is proven.

Session-Name: cedar-tempo
Session-Id: fd5dc169-945c-417a-8dfa-e626685999ae
Model: claude-opus-5
Harness: claude-code 2.1.220
Machine: cf6e768835c7


---

## Review round (polish panel: security-reviewer + code-reviewer)

Both seats found real defects. Two of them broke guarantees this PR's description made.

### Critical — a committed file *could* disarm the tier

`terms_path()` read `CADENCE_REDACTION_TERMS` and `XDG_CONFIG_HOME` from raw process env. A project's `.claude/settings.json` `env` block reaches hook subprocesses, and this codebase already documents those blocks as attacker-influenceable (`crates/metrics/src/warn_stale.rs` — the reasoning that put `CADENCE_DISABLE` behind `PROTECTED_GUARDS`).

So `{"env": {"CADENCE_REDACTION_TERMS": "/dev/null"}}` in a cloned repo resolved to an absent file, loaded an empty list, and failed open **silently** — a door upstream of both audited softening call sites, which is why auditing those two proved nothing about it. No adversary needed: a repo setting `XDG_CONFIG_HOME` for unrelated reasons disarms the tier by accident.

Fixed: production resolves `$HOME/.config/cadence/redaction.toml` and nothing else; the override survives only as a `#[cfg(test)]` seam. A non-standard config location is now unsupported — accepted, because an escape hatch a committed file can pull is not an escape hatch.

Verified by differential, **with a control**:

| Route to the identical fixture | Exit | Meaning |
|---|---|---|
| Canonical `$HOME/.config/…` path | 2 | Blocks — the real path is honored |
| Only via `CADENCE_REDACTION_TERMS` | 0 | Env ignored |
| Only via `XDG_CONFIG_HOME` | 0 | Env ignored |

Same file content in all three; only the resolution route differs. (The first version of this probe had no working control — its term existed in no loaded file, so every case "passed". Worth stating because a control-free probe of a security fix is exactly the shape that certifies a hole as closed.)

### Important — introduced-only was occurrence-blind

`!old.contains(&snippet)` suppressed *every* match in the new fragment the moment `old` held the term even once. An ordinary rewrite-and-duplicate edit smuggled new instances past the guard. Both seats found this independently. Now compares occurrence counts and reports the surplus; two tests pin both directions.

### Important — the migration's removal check was count-only

`--remove-legacy` compared term *counts* and deletes the only other on-disk copy. A hand-edit between migration and removal that swaps or corrects a term keeps the count identical, so a false pass was unrecoverable from the filesystem. Now compares actual term sets, reporting mismatch sizes without printing which terms differ.

### Self-caught before the panel reported

A mutation test deleted **both** `config_scope` guards and the whole suite stayed green: identity never runs through the category table, so those guards are unreachable and the test asserting "repo config cannot soften identity" was passing on signature blindness alone. The code-reviewer independently reached the same conclusion. Two unit tests now exercise the guards directly — re-running the mutation fails exactly those two — and the field is documented as forward-looking rather than as what protects identity today.

### Also fixed

`scan_is_config_blind_by_signature` asserted nothing at runtime (a changed signature fails compilation, not the test) — replaced with a behavioral assertion. `with_terms` leaked env on panic — now a `Drop` guard. `term_regex`'s first `.replace()` was dead code. `category_ceiling`'s `where 'static: 'a` was unnecessary. Documented why identity dedups findings where the shaped renderer deliberately does not.

### Cleared by review, worth recording

Fail-open/fail-closed split correct and tested; bypass provenance never dropped while a block is suppressed; term text reaches no log surface (`denials.jsonl`, `bypasses.jsonl`, and the migration script all verified); `read_untrusted_config` symlink-safe and bounded, no panic path on malformed input; regex DoS structurally inapplicable (the `regex` crate is linear-time); the `config_scope` refactor behavior-preserving for all four pre-existing categories including offset-dedup order; `toml` feature selection minimal and correct.

Two perf notes accepted rather than fixed: `identity::load()` runs before the tool-type branch, and `scan_identity` recompiles term regexes per call. Both are bounded by a small term list; filed as follow-ups rather than optimized speculatively.

**Now: 972 tests, clippy `-D warnings` clean, fmt clean, workspace green.**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added identity-term scanning for external content, including configurable enforce and warning modes.
  * Added `redact-scan --status` to show whether identity protection is active.
  * Added migration support for converting legacy redaction terms into structured configuration.

* **Bug Fixes**
  * Improved scanning of posts, edits, and file changes to detect newly introduced sensitive terms.
  * Protected external-content redaction from being disabled through standard disable settings.
  * Added safer handling for malformed or unavailable configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->