### PR TITLE
fix(redact): exempt the term source from its own identity scan

### DIFF
--- a/crates/cadence/src/redact_external_content.rs
+++ b/crates/cadence/src/redact_external_content.rs
@@ -434,6 +434,15 @@ fn run_edit(input: &HookInput, identity_list: &identity::IdentityList) -> CheckR
         .as_ref()
         .and_then(|ti| ti.file_path.as_deref().or(ti.path.as_deref()));
 
+    // The term source is exempt from its own scan. Without this, adding a term
+    // to the deny-list is "introducing" it and blocks — the file becomes
+    // unmaintainable through the harness, and the block message's own advice
+    // ("add an `allow` entry in the term source") names an edit the guard just
+    // refused. See `identity::is_term_source` for the fail direction.
+    if identity::is_term_source(file_path) {
+        return CheckResult::allow();
+    }
+
     let mut identity_hits: Vec<identity::IdentityHit> = Vec::new();
     for (new, old) in &fragments {
         // Scan only what the edit introduces. A term already present in `old`
@@ -2573,6 +2582,53 @@ term = "acmecorp"
             };
             assert_eq!(RedactExternalContent.run(&input).outcome, Outcome::Allow);
         });
+    }
+
+    #[test]
+    fn the_term_source_is_editable_ie_the_deny_list_stays_maintainable() {
+        // The self-lock this exemption exists to prevent: adding a term to the
+        // deny-list is "introducing" it under the introduced-only rule, so
+        // without the exemption the file cannot be maintained through the
+        // harness at all — and the block message's own advice ("add an allow
+        // entry in the term source") names the edit it just refused.
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("redaction.toml");
+        std::fs::write(&path, FIXTURE).unwrap();
+
+        let _guard = TERMS_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let _cleanup = EnvCleanup(&["CADENCE_REDACTION_TERMS"]);
+        unsafe { std::env::set_var("CADENCE_REDACTION_TERMS", &path) };
+
+        let edit = |target: &str| HookInput {
+            tool_name: Some("Edit".into()),
+            tool_input: Some(cadence_hooks_core::ToolInput {
+                file_path: Some(target.into()),
+                old_string: Some("version = 1".into()),
+                new_string: Some("version = 1\n[[terms]]\nid = \"T9\"\nterm = \"acmecorp\"".into()),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        assert_eq!(
+            RedactExternalContent
+                .run(&edit(path.to_str().unwrap()))
+                .outcome,
+            Outcome::Allow,
+            "adding a term to the deny-list itself must be possible"
+        );
+
+        // The control that keeps the exemption honest: the identical content
+        // written to any OTHER path still blocks. Without this, an exemption
+        // that matched everything would look just as green.
+        let other = dir.path().join("notes.md");
+        assert_eq!(
+            RedactExternalContent
+                .run(&edit(other.to_str().unwrap()))
+                .outcome,
+            Outcome::Block,
+            "the exemption must be the term source alone, not any file"
+        );
     }
 
     #[test]

--- a/crates/cadence/src/redact_external_content/identity.rs
+++ b/crates/cadence/src/redact_external_content/identity.rs
@@ -183,6 +183,49 @@ pub(crate) fn terms_path() -> Option<PathBuf> {
         })
 }
 
+/// Is this edit targeting the term source itself?
+///
+/// # Why this exemption has to exist
+///
+/// The term source contains every term, so writing a term into it is, by the
+/// introduced-only rule, "introducing" one — and the tier blocks. That makes
+/// the deny-list **unmaintainable through the harness**: adding a term is
+/// exactly the edit the guard refuses. Worse, the block message tells the
+/// operator to add an `allow` entry *in the term source*, which is the edit it
+/// just blocked. A perfectly circular instruction.
+///
+/// Writing terms into the deny-list is definitionally legitimate — it is what
+/// the file is for. Same reasoning that makes the removal edit possible: a
+/// guard that cannot be maintained gets bypassed or disabled, and then it
+/// protects nothing.
+///
+/// # Fail direction
+///
+/// Defaults to **false** (scan) whenever the answer is not certain. A false
+/// positive here would exempt an arbitrary file from the identity scan, which
+/// is the far worse error — so an unresolvable path is scanned, not skipped.
+/// Both the literal and canonicalized comparisons are tried, because the file
+/// may not exist yet (the first write that creates it) and because `HOME` is
+/// often a symlink.
+pub(crate) fn is_term_source(file_path: Option<&str>) -> bool {
+    let Some(fp) = file_path.filter(|p| !p.is_empty()) else {
+        return false;
+    };
+    let Some(terms) = terms_path() else {
+        return false;
+    };
+    let target = std::path::Path::new(fp);
+    if target == terms {
+        return true;
+    }
+    // Canonicalize both when the paths exist — resolves symlinked HOME and the
+    // /tmp vs /private/tmp split. Any failure falls through to `false`.
+    match (target.canonicalize(), terms.canonicalize()) {
+        (Ok(a), Ok(b)) => a == b,
+        _ => false,
+    }
+}
+
 /// Load the term source, returning both the list and why it is what it is.
 ///
 /// Every failure yields an empty list — the guard's own failure is fail-open.


### PR DESCRIPTION
fix(redact): exempt the term source from its own identity scan

Probing the Write/Edit wiring before arming it (cadence#772) surfaced a
self-lock: the deny-list becomes unmaintainable through the harness the moment
that matcher lands.

The term source contains every term, so writing a term INTO it is "introducing"
one under the introduced-only rule, and the tier blocks. Adding a term to the
deny-list -- the file's entire purpose -- was exactly the edit the guard
refused. Verified against the built binary: exit 2.

The circularity is the tell. The block message says to "add an `allow` entry
beside it in the term source," which is the edit it just blocked. An instruction
the guard forbids you from following is not an escape hatch.

Fix: `run_edit` returns allow when the edit targets the term source. Same
reasoning that already makes the removal edit possible -- a guard that cannot be
maintained gets bypassed or disabled, and then it protects nothing.

Fail direction is deliberate: `is_term_source` defaults to FALSE (scan) whenever
the answer is not certain, because a false positive would exempt an arbitrary
file from the identity scan, which is the far worse error. Literal comparison
first (the file may not exist yet -- the write that creates it), canonicalized
comparison second (HOME is often a symlink); any resolution failure falls
through to scanning.

Verified end-to-end with a control, since an exemption that matched everything
would look just as green as a correct one:
  - term added to the deny-list file        -> exit 0
  - IDENTICAL content written to any other  -> exit 2

973 tests, clippy -D warnings clean, fmt clean, codex report fresh.

Found by probing cadence#772 (the Write/Edit wiring) before merging it, not after. That PR is blocked on this one: arming the matcher without this fix makes the deny-list unmaintainable through the harness.