### PR TITLE
chore: bump version to 0.72.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.72.1] - 2026-08-04
+
+### Fixed
+
+- **`replicate-redaction-terms.sh` mislabeled an out-of-date binary as a corrupt terms file (#587).** The verify step inferred "too old" from an exit code, assuming an unrecognized `--status` exits clap's 2 — but `cadence-hooks` intercepts unknown subcommands itself, with its own message and its own code, so the too-old case fell through to the alarming branch. A live M5 run reported "terms written but binary reports NOT ARMED" and pointed the operator at a perfectly good file. The check now compares `--version` against the first release carrying the identity tier, which is deterministic and says the useful thing. Two related holes closed alongside it: the already-armed early exit trusted a `[[terms]]` header count, which proves a header exists rather than that the file parses — so the one path a re-run exists for was the one that skipped verification — and a greater-than-zero term count accepted a one-line garbage paste or a fetch cut mid-entry.
+- **The 1Password fetch was CSV-quoting the terms file, and every check the script had was blind to it (#588).** `op item get --fields label=notesPlain` returns a multi-line value with a literal double quote prepended and appended. One character, two failures: on the legacy text format the leading quote stopped the first comment line from starting with `#`, so a prose fragment counted as a term and displaced a real one — a machine came up with 19 terms against the source's 18 and reported ARMED; on TOML it breaks parsing outright with `invalid basic string` and the tier is inert. Both read as a corrupt terms file. The fetch now uses `--format json`, which returns the value unquoted. The script also **parses** the written file rather than only counting lines in it — header count, term-value count, floor, and truncation were all line-counting checks, and every one of them passed on a document that failed to parse on line 1. Counting proves shape, not validity. `tomllib` is 3.11+, so its absence warns instead of silently skipping the validation.
+
 ## [0.72.0] - 2026-08-04
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,8 +12,19 @@ Rust workspace (8 crates) compiling to a single `cadence-hooks` binary. Dispatch
 ## Release (fully automated — do NOT create tags or edit the tap formula manually)
 
 1. `make bump VERSION=X.Y.Z` (updates Cargo.toml), then `cargo check` to refresh Cargo.lock
-2. Commit both files, push to main
-3. `auto-tag.yml` creates the `vX.Y.Z` tag → `release.yml` builds 4 platform binaries, publishes the GitHub Release, and sends a `repository_dispatch` that updates `cameronsjo/homebrew-tap`'s formula
+2. `make report` to regenerate `docs/codex-compatibility-report.json` — **not optional, and read the warning below before running it**
+3. Commit all three files (plus the CHANGELOG stamp), push to main
+4. `auto-tag.yml` creates the `vX.Y.Z` tag → `release.yml` builds 4 platform binaries, publishes the GitHub Release, and sends a `repository_dispatch` that updates `cameronsjo/homebrew-tap`'s formula
+
+**Step 2 is the one that keeps getting skipped, and it is CI-gated.** The report embeds `binaryVersion`, which `scripts/generate-codex-report.py --check` compares as exact text against the freshly-built binary's `manifest --format json` — so a Cargo.toml-only bump turns `make report-check` red on the ubuntu leg. It went stale at 0.70.1 and left `report-check` red on `main` from the 0.71.0 bump onward; 0.72.0 and 0.72.1 both had to touch four files for this reason.
+
+**`make report` from a worktree silently empties every wiring array (#566).** The generator's `--workspace` defaults to the repo's *parent* directory and globs plugin wiring from `<workspace>/cadence/plugins/*/hooks/hooks.json`. From `.claude/worktrees/<name>/` that parent resolves to a directory with no plugin checkout, so all 67 wiring arrays render `[]` and get written with no warning. Pass the real workspace explicitly:
+
+```bash
+python3 scripts/generate-codex-report.py --workspace <path-to-plugin-workspace-root>
+```
+
+Two more traps on that flag. `--check` **cannot catch this** — with no sibling checkout it takes a documented exemption path and compares everything-but-wiring, so it passes either way (that is also why CI can never verify wiring). And pointing it at a plugin checkout parked on a feature branch rewrites wiring to match *that branch*; generate against a synthetic workspace built from the plugin repo's `origin/main` (`git -C <plugin-repo> archive origin/main plugins | tar -x -C <tmp>/cadence`) when the local checkout has moved. Verify with a strict `--check --workspace <same>`, which does compare wiring.
 
 Manual tagging or formula edits race the automation. Post-release: `brew update && brew upgrade cadence-hooks`, verify `cadence-hooks --version`.
 
@@ -24,7 +35,7 @@ Manual tagging or formula edits race the automation. Post-release: `brew update 
 
 A stale baseline in either direction fails open (ADR-0001) — it never blocks, just under- or (if hand-typed wrong) over-nudges.
 
-**From a Claude session the bump commit to main is blocked by this repo's own `enforce-worktree` guard** (a primary-checkout `git commit`), unless the session happens to carry `CADENCE_ALLOW_MAIN` in its env. Do the bump in a worktree and push its tip to main: `git worktree add .claude/worktrees/release-X -b release/X origin/main`, then `make bump` + `cargo check` + stamp the CHANGELOG (`## [Unreleased]` → `## [X] - DATE`) **in the worktree**, `git commit`, then `git push origin release/X:main` (fast-forward → triggers auto-tag). `git rebase` is also guard-blocked (git-safety hook), so reshape commits with `reset`, not rebase. Note `release.yml` builds and publishes even when `ci.yml` is red (it doesn't gate on the test suite) — verify the release via the tag/Release workflow/tap formula, not the CI check.
+**From a Claude session the bump commit to main is blocked by this repo's own `enforce-worktree` guard** (a primary-checkout `git commit`), unless the session happens to carry `CADENCE_ALLOW_MAIN` in its env. Do the bump in a worktree and push its tip to main: `git worktree add .claude/worktrees/release-X -b release/X origin/main`, then `make bump` + `cargo check` + the explicit-`--workspace` report regeneration from step 2 above (the worktree is exactly where the wiring-emptying trap fires) + stamp the CHANGELOG (`## [Unreleased]` → `## [X] - DATE`) **in the worktree**, `git commit`, then `git push origin release/X:main` (fast-forward → triggers auto-tag). `git rebase` is also guard-blocked (git-safety hook), so reshape commits with `reset`, not rebase. Note `release.yml` builds and publishes even when `ci.yml` is red (it doesn't gate on the test suite) — verify the release via the tag/Release workflow/tap formula, not the CI check.
 
 **Check `git log --oneline -5` on main for bump commits before choosing the next version number.** Parallel Claude sessions release from this repo too — a 0.15.1 shipped mid-session while another session was building what became 0.15.2. The race only surfaced because the bump commit failed loudly; don't rely on that.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -204,7 +204,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "cadence-hooks-core",
  "glob",
@@ -217,7 +217,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -230,7 +230,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -240,11 +240,11 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.72.0"
+version = "0.72.1"
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -257,7 +257,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -265,7 +265,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -275,7 +275,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.72.0"
+version = "0.72.1"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-guardrails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.72.0"
+version = "0.72.1"
 edition = "2024"
 license-file = "LICENSE"
 authors = ["Cameron Sjo"]

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "binaryVersion": "0.72.0",
+  "binaryVersion": "0.72.1",
   "minimumCodexVersion": "0.145.0",
   "privacy": {
     "rawHookInputsPersisted": false,
@@ -437,6 +437,13 @@
       "applicable": true,
       "evidence": "tests/hook_registration_audit.rs",
       "wiring": [
+        {
+          "plugin": "cadence",
+          "event": "PreToolUse",
+          "matcher": "Write|Edit|mcp__.*(write|edit|create|update|delete|remove|move|rename).*",
+          "if": null,
+          "commandHash": "a5ab5b4c692e07b821b489edac41c35f8c7f3f9d04e171b7f9efa6d65a72f5fa"
+        },
         {
           "plugin": "cadence",
           "event": "PreToolUse",


### PR DESCRIPTION
Patch release for the two `scripts/` fixes already on `main` past the `v0.72.0` tag. Neither changes binary behavior.

- #587 — version-gate the verify step instead of inferring "too old" from an exit code, and stop trusting the script's own term count
- #588 — read the 1Password note as JSON, and parse the TOML before believing its term count

## Why four files, not one

`Cargo.toml` alone goes red. `make report-check` on the ubuntu leg builds the binary and compares its `manifest --format json` `binaryVersion` against the committed `docs/codex-compatibility-report.json` as exact text, so the bump stales that file. Same reason the 0.72.0 bump commit touched the same set.

## How the report was regenerated

Not with a bare `make report`. The generator's `--workspace` defaults to the repo's parent directory, and it globs plugin wiring from `<workspace>/cadence/plugins/*/hooks/hooks.json`. Two ways that misfires here:

- From a worktree the parent resolves to a directory with no plugin checkout, so all 67 wiring arrays render empty and get written to disk with no warning. Measured: `hooks=67 empty_wiring=67` on the default, `empty_wiring=2` on an explicit workspace.
- The local plugin checkout is parked on a feature branch well behind its own `main`, so pointing at it would have rewritten wiring to match a stale branch.

So the report was generated against a synthetic workspace built from the plugin repo's `origin/main`. Beyond the version line the diff is one added entry — the plugin's `PreToolUse` `Write|Edit` hook for the identity tier, which landed after the 0.72.0 report was generated.

Note that `report-check` cannot verify wiring on CI at all: with no plugin checkout beside the repo it takes the documented exemption path and compares everything-but-wiring. Wiring here was verified separately with a strict `--check` against the synthetic workspace, which does compare it.

## Verification

- `make ci` — exit 0. 4104 tests passed, 0 failed. fmt-check, clippy `-D warnings`, and `report-check` all clean.
- Strict `generate-codex-report.py --check --workspace <synthetic>` — exit 0, wiring compared rather than exempted.
- `MIN_BINARY` in `replicate-redaction-terms.sh` stays `0.72.0` on purpose: it names the first release carrying the identity tier, not the current release, and its `sort -V` comparison already admits 0.72.1.

## Follow-up (not in this PR)

The plugin repo's `platform-baseline.json` records `cadence_hooks.current_version` and feeds a session-start advisory. It needs its own bump to 0.72.1 after this releases, as it got for 0.72.0.

Session-Name: oaken-sonata
Session-Id: b310fad7-094c-4ef6-9b54-6e6a8cf7e11e
Model: claude-opus-5
Harness: claude-code 2.1.221
Machine: cf6e768835c7
