### PR TITLE
fix(ci): --no-fail-fast, so one red crate stops hiding every other crate's tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,8 +36,14 @@ jobs:
       - name: Run clippy
         run: cargo clippy --workspace --all-targets -- -D warnings
 
+      # --no-fail-fast: cargo otherwise stops after the first test binary that
+      # fails and never builds the remaining crates', so a red crate silently
+      # takes every other crate's tests out of the run. Measured on the
+      # red-tests branch (#551): the cadence crate failed with 5, aborted, and
+      # cadence-hooks-core's 718 tests never executed — CI reported the 5 as if
+      # it were the whole picture.
       - name: Run tests
-        run: cargo test --workspace
+        run: cargo test --workspace --no-fail-fast
 
       # The checked-in Codex compatibility report is ~1700 generated lines that
       # external consumers read as "what Codex support actually covers", and the

--- a/Makefile
+++ b/Makefile
@@ -20,8 +20,11 @@ release:
 
 .PHONY: test
 ## Run all workspace tests
+# --no-fail-fast is load-bearing: without it cargo stops after the first test
+# binary that fails and never builds the rest, so one red crate hides every
+# other crate's results while the run still looks like a complete answer.
 test:
-	$(CARGO) test --workspace
+	$(CARGO) test --workspace --no-fail-fast
 
 .PHONY: check
 ## Run cargo check (fast compilation check)


### PR DESCRIPTION
`cargo test` stops after the first test binary that fails and never builds the
remaining crates', so one red crate silently removes every other crate's tests
from the run — while the run still reads as a complete answer.

Found while settling a test-count discrepancy on #551. Measured there: the
cadence crate failed with 5, aborted, and `cadence-hooks-core`'s 718 tests never
executed. CI reported "5 failing" and nothing in the output indicated that 718
assertions had gone unasked. The tell was that
`Running unittests ... cadence_hooks_core-*` appears nowhere in the log.

This is the shape where a check is least trustworthy exactly when it matters
most: the moment something is already broken is the moment the rest of the suite
stops being consulted. Independent of #551 — any future red branch hides the
same suite until this changes.

Both call sites, so `make test` and CI agree:

- `Makefile` `test:` target
- `.github/workflows/ci.yml` "Run tests" step

**Verified locally:** `make test` now runs 17 crate test binaries in a single
pass — 4104 tests, 0 failed, exit 0.

---
```text
Session-Name: oaken-sonata
Session-Id: b310fad7-094c-4ef6-9b54-6e6a8cf7e11e
Model: claude-opus-5
Harness: claude-code 2.1.221
Machine: cf6e768835c7
```
