### PR TITLE
chore(ci): bump create-github-app-token to v3 and use client-id

### DIFF
--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -22,9 +22,15 @@ jobs:
     steps:
       - name: Generate Forge Bellows token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          # client-id, not the deprecated app-id. The action resolves
+          # `getInput("client-id") || getInput("app-id")` into one value it
+          # hands to createAppAuth as appId, so the numeric App ID in
+          # RELEASE_APP_ID stays valid — a rename, not a credential change.
+          # The rename REQUIRES v3: v2 has no client-id input at all
+          # (its app-id is required), so renaming on v2 breaks the job.
+          client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -28,8 +28,10 @@ jobs:
           # `getInput("client-id") || getInput("app-id")` into one value it
           # hands to createAppAuth as appId, so the numeric App ID in
           # RELEASE_APP_ID stays valid — a rename, not a credential change.
-          # The rename REQUIRES v3: v2 has no client-id input at all
-          # (its app-id is required), so renaming on v2 breaks the job.
+          # The rename REQUIRES v3.1.0+, which is where client-id landed.
+          # Neither v2 nor v3.0.0 declares it, and both mark app-id required,
+          # so on either one client-id is ignored, app-id resolves empty, and
+          # token minting dies. Do not narrow this to @v3.0.0.
           client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -201,7 +201,7 @@ jobs:
         with:
           # client-id, not the deprecated app-id — see auto-tag.yml for why the
           # numeric App ID in RELEASE_APP_ID stays valid under the new key, and
-          # why the rename requires v3 rather than v2.
+          # why the rename requires v3.1.0+ (not v2, and not v3.0.0).
           client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           repositories: homebrew-tap

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,9 +197,12 @@ jobs:
 
       - name: Generate Forge Bellows token
         id: app-token
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          # client-id, not the deprecated app-id — see auto-tag.yml for why the
+          # numeric App ID in RELEASE_APP_ID stays valid under the new key, and
+          # why the rename requires v3 rather than v2.
+          client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           repositories: homebrew-tap
 


### PR DESCRIPTION
`actions/create-github-app-token` deprecated the `app-id` input in favor of
`client-id`. Both workflows here were pinned to `@v2`.

## Why the bump is required, not incidental

`@v2` predates `client-id` entirely — it declares only `app-id`, and declares it
`required: true`:

```yaml
inputs:
  app-id:
    description: "GitHub App ID"
    required: true
```

with `main.js` reading `const appId = core.getInput("app-id")`. So renaming the
key on `@v2` would break token minting for **both** auto-tag and the tap update.
The bump has to land first.

## Why the value is unchanged

On `@v3` the action resolves both inputs into one
([`main.js:21`](https://github.com/actions/create-github-app-token/blob/main/main.js#L21)):

```js
const clientId = core.getInput("client-id") || core.getInput("app-id");
```

and passes it to `createAppAuth({ appId: clientId, ... })`. The numeric App ID
already in `RELEASE_APP_ID` stays valid under the new key — no new variable, no
rotation, no change to the GitHub App.

## Why v3's breaking changes don't bite

- **Actions Runner ≥ 2.327.1** — required only for *self-hosted* runners. Both
  jobs run on `ubuntu-latest` (`auto-tag.yml:21`, `release.yml:110`).
- **Proxy handling now needs `NODE_USE_ENV_PROXY`** — neither workflow uses a
  proxy.

## Verification

Both files parse, and each `app-token` step resolves to `@v3` with `client-id`
and no `app-id`:

```
auto-tag.yml -> actions/create-github-app-token@v3 ['client-id', 'private-key']
release.yml  -> actions/create-github-app-token@v3 ['client-id', 'private-key', 'repositories']
```

No residual `app-id:` or `@v2` anywhere under `.github/workflows/`.

Exercised end to end only on the next version bump, since both steps sit on the
release path. No `Cargo.toml` change here, so this does not auto-tag.

No CHANGELOG bullet: CI-only changes don't carry one in this repo (cff0f17,
c8d1c13).

Session-Name: amber-bellows
Session-Id: 8120ec6d-f5f8-4f4f-b918-03b53b48cad2
Model: claude-opus-5
Harness: claude-code 2.1.222
Machine: cf6e768835c7
