### PR TITLE
feat(session): nudge when the approved plan carries no settled Panel: line

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **The plan-persistence nudge now flags an approved plan carrying no settled `Panel:` line (#623).** Both persistence triggers (`persist-plan`, UserPromptSubmit; `persist-plan-approval`, PostToolUse:ExitPlanMode) already hold the normalized plan body; they now scan it for the plan template's settled `Panel:` stanza — `Panel: <seats> ran — <counts>` or the absence assertion `Panel: none — <reason>`, anchored at line start, first match in document order deciding (the `Driver:` stamp's discipline, so a quoted example later in the body can neither satisfy nor contradict the stanza) — and when neither form is present (absent, `pending`-shaped, or a `## Panel review` heading with no settled line) append one static sentence to the existing nudge: run the plan-review panel before implementing, fold findings, or write the absence line. Post-approval, pre-implementation detection by design — a rejection emits no hook event, so the template layer (cameronsjo/cadence#849) covers approval-time visibility. Artifact-anchored (the marker survives the approve-and-clear session boundary that killed session-scoped markers, cameronsjo/cadence#578), nudge-only (no trust root needed, unlike the gate cameronsjo/cadence#392 rejected), and the sentence is a static string — committed plan content is untrusted input and is never echoed. No new registration, no hooks.json change.
+
 ## [0.72.1] - 2026-08-04
 
 ### Fixed

--- a/crates/session/src/persist_plan.rs
+++ b/crates/session/src/persist_plan.rs
@@ -279,6 +279,7 @@ pub fn run_persist_plan(
         &machine_digest,
         &repo_root,
         approved_label,
+        panel_line_settled(&body),
     )
 }
 
@@ -378,6 +379,7 @@ pub fn run_persist_plan_approval(
         &machine_digest,
         &repo_root,
         &own_name,
+        panel_line_settled(&body),
     )
 }
 
@@ -983,6 +985,49 @@ fn render_document(f: &FrontmatterFields, body: &str) -> String {
     format!("{}\n\n{body}\n", render_frontmatter(f))
 }
 
+/// The one static sentence appended to the persistence nudge when the
+/// approved plan carries no settled `Panel:` line (cameronsjo/cadence-hooks#623).
+/// Static by design: committed plan content is untrusted input, so the nudge
+/// never echoes any of it — detection is artifact-anchored (the line lives in
+/// the plan document, surviving the approve-and-clear session boundary that
+/// killed session-scoped markers, cameronsjo/cadence#578) and warn-tier only
+/// (a nudge needs no trust root, unlike the gate cameronsjo/cadence#392
+/// rejected).
+const PANEL_GATE_NUDGE: &str = "panel gate: this plan carries no settled Panel: line — run the \
+     plan-review panel before implementing, fold findings, or write \"Panel: none — <reason>\" \
+     (cadence:attune → plan-review-panel).";
+
+/// True when the plan body carries a settled `Panel:` line — anchored at line
+/// start, in exactly one of the plan template's two settled forms:
+///
+/// - `Panel: <seats> ran — <counts…>` (a panel ran; both sides non-empty)
+/// - `Panel: none — <reason>` (the absence assertion; non-empty reason)
+///
+/// Anything else — no `Panel:` line at all, a `Panel: pending…` placeholder,
+/// or a `## Panel review` heading with no settled line — is unsettled. The
+/// line-start anchor plus the required `Panel: ` prefix means a `## Panel`
+/// heading can never false-match.
+///
+/// **First match in document order decides** — the `Driver:` stamp's
+/// discipline (plan-pipeline-conventions §4/§5): the plan template's `## Panel`
+/// stanza precedes the task body, so the stanza's own line is judged, and a
+/// quoted `Panel: … ran — …` example later in the body can neither satisfy
+/// the gate (the accidental-forgery hole a whole-body `any()` scan would
+/// open) nor contradict the stanza. Detection only; the caller appends the
+/// static [`PANEL_GATE_NUDGE`], never any matched text.
+fn panel_line_settled(body: &str) -> bool {
+    let Some(rest) = body.lines().find_map(|line| line.strip_prefix("Panel: ")) else {
+        return false;
+    };
+    if let Some(reason) = rest.strip_prefix("none — ") {
+        return !reason.trim().is_empty();
+    }
+    if let Some((seats, tail)) = rest.split_once(" ran — ") {
+        return !seats.trim().is_empty() && !tail.trim().is_empty();
+    }
+    false
+}
+
 /// The shared tail both triggers converge on once each has resolved its own
 /// body/session/approval fields: claim a target, append the linkage row,
 /// render the nudge. Never overwrites anything (see [`claim_target`]).
@@ -999,6 +1044,7 @@ fn persist_and_nudge(
     machine_digest: &str,
     repo_root: &Path,
     approved_label: &str,
+    panel_settled: bool,
 ) -> CheckResult {
     let path = match claim_target(plans_dir, stem, session_id, body_hash, document) {
         Claim::Wrote(path) | Claim::AlreadyPersisted(path) => path,
@@ -1025,11 +1071,16 @@ fn persist_and_nudge(
         body_hash,
     ));
 
-    CheckResult::nudge(format!(
+    let mut nudge = format!(
         "Approved plan persisted to {} (approved in {approved_label}). Verify placement, then \
          commit it (explicit-path git add) before implementation.",
         path.display()
-    ))
+    );
+    if !panel_settled {
+        nudge.push(' ');
+        nudge.push_str(PANEL_GATE_NUDGE);
+    }
+    CheckResult::nudge(nudge)
 }
 
 // ---------------------------------------------------------------------------
@@ -2262,6 +2313,117 @@ mod tests {
         assert!(!links.contains("test-host"));
         assert!(!links.contains("\"host\""));
         assert!(!links.contains("\"repo\""));
+    }
+
+    #[test]
+    fn panel_line_settled_accepts_both_settled_forms_only() {
+        // Settled: the ran form and the absence assertion.
+        assert!(panel_line_settled(
+            "# T\n\nPanel: plan-reviewer ×2 ran — 3 findings, 2 folded in, 1 declined\n\nbody"
+        ));
+        assert!(panel_line_settled(
+            "# T\n\nPanel: none — raw-draft bypass per operator ask\n"
+        ));
+        // Unsettled: absent, pending-shaped, empty reason/counts, heading-only.
+        assert!(!panel_line_settled("# T\n\nno panel line at all\n"));
+        assert!(!panel_line_settled(
+            "# T\n\nPanel: pending — seats not yet run\n"
+        ));
+        assert!(!panel_line_settled("# T\n\nPanel: none — \n"));
+        assert!(!panel_line_settled("# T\n\nPanel:  ran — 3 findings\n"));
+        assert!(!panel_line_settled(
+            "# T\n\n## Panel review — findings declined\n\n- none declined\n"
+        ));
+        // Anchored at line start: an indented or mid-line mention never matches.
+        assert!(!panel_line_settled("# T\n\n  Panel: x ran — y\n"));
+        assert!(!panel_line_settled(
+            "# T\n\nsee Panel: x ran — y for details\n"
+        ));
+        // First match in document order decides (the Driver: stamp's
+        // discipline): a settled-looking quoted example AFTER an unsettled
+        // stanza line never satisfies the gate…
+        assert!(!panel_line_settled(
+            "# T\n\nPanel: pending — seats queued\n\nExample: write\nPanel: x ran — 1 finding\n"
+        ));
+        // …and a later unsettled mention never contradicts a settled stanza.
+        assert!(panel_line_settled(
+            "# T\n\nPanel: reviewer ran — 2 findings, 2 folded in, 0 declined\n\n\
+             Quoted form:\nPanel: pending — never do this\n"
+        ));
+    }
+
+    #[test]
+    fn end_to_end_approval_unpaneled_plan_appends_static_panel_sentence() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+
+        // `pending`-shaped line: present but unsettled — the nudge must fire,
+        // and must never echo the plan's own text (untrusted input).
+        let plan = "# Fix the Widget\n\nPanel: pending — awaiting seat dispatch\n\nDo the thing.";
+        let input = exit_plan_mode_post_tool_use(
+            "sid",
+            plan,
+            &cwd,
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            Some(false),
+        );
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let msg = r.message.unwrap();
+        assert!(
+            msg.contains(PANEL_GATE_NUDGE),
+            "unsettled Panel: line must append the static panel sentence: {msg}"
+        );
+        assert!(
+            !msg.contains("awaiting seat dispatch"),
+            "the nudge must never echo plan text: {msg}"
+        );
+    }
+
+    #[test]
+    fn end_to_end_approval_settled_panel_line_gets_no_panel_sentence() {
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+
+        let plan = "# Fix the Widget\n\n\
+                    Panel: plan-reviewer ×2 ran — 3 findings, 2 folded in, 1 declined\n\n\
+                    Do the thing.";
+        let input = exit_plan_mode_post_tool_use(
+            "sid",
+            plan,
+            &cwd,
+            &tmp.path().join("t.jsonl").to_string_lossy(),
+            Some(false),
+        );
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let msg = r.message.unwrap();
+        assert!(
+            !msg.contains("panel gate:"),
+            "a settled Panel: line must not trigger the panel sentence: {msg}"
+        );
+        // The absence assertion is equally settled.
+        let plan_none = "# Fix the Sprocket\n\nPanel: none — raw-draft bypass per ask\n\nBody.";
+        let input = exit_plan_mode_post_tool_use(
+            "sid2",
+            plan_none,
+            &cwd,
+            &tmp.path().join("t2.jsonl").to_string_lossy(),
+            Some(false),
+        );
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge);
+        assert!(!r.message.unwrap().contains("panel gate:"));
     }
 
     #[test]

--- a/crates/session/src/persist_plan.rs
+++ b/crates/session/src/persist_plan.rs
@@ -279,7 +279,7 @@ pub fn run_persist_plan(
         &machine_digest,
         &repo_root,
         approved_label,
-        panel_line_settled(&body),
+        &body,
     )
 }
 
@@ -379,7 +379,7 @@ pub fn run_persist_plan_approval(
         &machine_digest,
         &repo_root,
         &own_name,
-        panel_line_settled(&body),
+        &body,
     )
 }
 
@@ -1003,6 +1003,12 @@ const PANEL_GATE_NUDGE: &str = "panel gate: this plan carries no settled Panel: 
 /// - `Panel: <seats> ran — <counts…>` (a panel ran; both sides non-empty)
 /// - `Panel: none — <reason>` (the absence assertion; non-empty reason)
 ///
+/// The separator tolerates what a human actually types: em dash (the
+/// template's canonical form), en dash, `--`, or a plain hyphen — a
+/// hand-written `Panel: none - reason` states the settled fact unambiguously,
+/// and hardcoding U+2014 would fire a false nudge on it (code review of this
+/// change).
+///
 /// Anything else — no `Panel:` line at all, a `Panel: pending…` placeholder,
 /// or a `## Panel review` heading with no settled line — is unsettled. The
 /// line-start anchor plus the required `Panel: ` prefix means a `## Panel`
@@ -1013,17 +1019,43 @@ const PANEL_GATE_NUDGE: &str = "panel gate: this plan carries no settled Panel: 
 /// stanza precedes the task body, so the stanza's own line is judged, and a
 /// quoted `Panel: … ran — …` example later in the body can neither satisfy
 /// the gate (the accidental-forgery hole a whole-body `any()` scan would
-/// open) nor contradict the stanza. Detection only; the caller appends the
-/// static [`PANEL_GATE_NUDGE`], never any matched text.
+/// open) nor contradict the stanza. Lines inside fenced code blocks
+/// (``` / ~~~ toggles, indentation-tolerant) and block quotes (`>`) are
+/// skipped before the first-match rule applies — a fenced or quoted example
+/// in a plan with no stanza at all must not mint a settled verdict (security
+/// review of this change; same class as the quoted-example hole above). The
+/// fence tracker is deliberately naive — it toggles without matching fence
+/// lengths — which errs toward skipping ambiguous lines: on a malformed
+/// document the failure mode is a spurious nudge (fail-loud), never a
+/// suppressed one. Detection only; the caller appends the static
+/// [`PANEL_GATE_NUDGE`], never any matched text.
 fn panel_line_settled(body: &str) -> bool {
-    let Some(rest) = body.lines().find_map(|line| line.strip_prefix("Panel: ")) else {
+    let mut in_fence = false;
+    let Some(rest) = body.lines().find_map(|line| {
+        let trimmed = line.trim_start();
+        if trimmed.starts_with("```") || trimmed.starts_with("~~~") {
+            in_fence = !in_fence;
+            return None;
+        }
+        if in_fence || line.starts_with('>') {
+            return None;
+        }
+        line.strip_prefix("Panel: ")
+    }) else {
         return false;
     };
-    if let Some(reason) = rest.strip_prefix("none — ") {
-        return !reason.trim().is_empty();
+    // Dash tolerance: `--` must be tried before `-` or the second hyphen
+    // leaks into the text it precedes.
+    fn strip_dash(s: &str) -> Option<&str> {
+        let s = s.trim_start();
+        ["—", "–", "--", "-"].iter().find_map(|d| s.strip_prefix(d))
     }
-    if let Some((seats, tail)) = rest.split_once(" ran — ") {
-        return !seats.trim().is_empty() && !tail.trim().is_empty();
+    if let Some(after_none) = rest.strip_prefix("none") {
+        return strip_dash(after_none).is_some_and(|reason| !reason.trim().is_empty());
+    }
+    if let Some((seats, tail)) = rest.split_once(" ran ") {
+        return !seats.trim().is_empty()
+            && strip_dash(tail).is_some_and(|counts| !counts.trim().is_empty());
     }
     false
 }
@@ -1044,7 +1076,7 @@ fn persist_and_nudge(
     machine_digest: &str,
     repo_root: &Path,
     approved_label: &str,
-    panel_settled: bool,
+    plan_body: &str,
 ) -> CheckResult {
     let path = match claim_target(plans_dir, stem, session_id, body_hash, document) {
         Claim::Wrote(path) | Claim::AlreadyPersisted(path) => path,
@@ -1076,7 +1108,10 @@ fn persist_and_nudge(
          commit it (explicit-path git add) before implementation.",
         path.display()
     );
-    if !panel_settled {
+    // Evaluated only after the claim succeeded: the persistence write must
+    // never depend on the detector — a future panic here eats one nudge's
+    // sentence, never the persist (security review of this change).
+    if !panel_line_settled(plan_body) {
         nudge.push(' ');
         nudge.push_str(PANEL_GATE_NUDGE);
     }
@@ -2350,6 +2385,75 @@ mod tests {
             "# T\n\nPanel: reviewer ran — 2 findings, 2 folded in, 0 declined\n\n\
              Quoted form:\nPanel: pending — never do this\n"
         ));
+        // Dash tolerance: a hand-typed hyphen, double hyphen, or en dash
+        // states the settled fact as unambiguously as the template's em dash.
+        assert!(panel_line_settled(
+            "# T\n\nPanel: none - raw-draft bypass\n"
+        ));
+        assert!(panel_line_settled(
+            "# T\n\nPanel: 2 reviewers ran - 3 findings, all folded in\n"
+        ));
+        assert!(panel_line_settled(
+            "# T\n\nPanel: none -- operator bypass\n"
+        ));
+        assert!(panel_line_settled(
+            "# T\n\nPanel: reviewer ran – 1 finding\n"
+        ));
+        // …but the dash is still required, and an empty ran-tail is unsettled.
+        assert!(!panel_line_settled("# T\n\nPanel: none reason given\n"));
+        assert!(!panel_line_settled("# T\n\nPanel: x ran — \n"));
+        assert!(!panel_line_settled("# T\n\nPanel: x ran 3 findings\n"));
+        // Fenced and block-quoted examples never mint a settled verdict for a
+        // plan with no stanza at all (security review of this change).
+        assert!(!panel_line_settled(
+            "# Add a Panel: stanza\n\n```markdown\nPanel: reviewer ran — 3 findings\n```\n\n\
+             Approach: …\n"
+        ));
+        assert!(!panel_line_settled(
+            "# T\n\n> Panel: reviewer ran — 3 findings\n\nbody\n"
+        ));
+        // A real stanza after a closed fence still settles.
+        assert!(panel_line_settled(
+            "# T\n\n```\nexample\n```\n\nPanel: reviewer ran — 1 finding, folded\n"
+        ));
+    }
+
+    #[test]
+    fn end_to_end_prompt_path_unpaneled_plan_appends_static_panel_sentence() {
+        // The UserPromptSubmit trigger extracts its body differently
+        // (PLAN_PREFIX strip vs the ExitPlanMode tool response), so the
+        // sentence wiring is asserted on this path too, both directions.
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+
+        let prompt = "Implement the following plan:\n\n# Fix the Widget\n\nDo the thing.";
+        let input = make_user_prompt_submit(
+            "child-session-id",
+            prompt,
+            &cwd,
+            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
+        );
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge);
+        assert!(r.message.unwrap().contains(PANEL_GATE_NUDGE));
+
+        let prompt_settled = "Implement the following plan:\n\n# Fix the Sprocket\n\n\
+                              Panel: reviewer ran — 1 finding, folded\n\nDo the thing.";
+        let input = make_user_prompt_submit(
+            "child-session-id",
+            prompt_settled,
+            &cwd,
+            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
+        );
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge);
+        assert!(!r.message.unwrap().contains("panel gate:"));
     }
 
     #[test]

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -861,7 +861,15 @@
       "status": "native",
       "applicable": false,
       "evidence": "registered in the binary but not yet invoked: the cadence-guardrails SessionStart wiring ships in a companion monorepo PR. Flip to applicable when that wiring merges.",
-      "wiring": []
+      "wiring": [
+        {
+          "plugin": "cadence-guardrails",
+          "event": "SessionStart",
+          "matcher": "*",
+          "if": null,
+          "commandHash": "015e644cb4ac3720d4f018aef441a66094578157a6bfe827b898e80dc03e763f"
+        }
+      ]
     },
     {
       "criticality": "security-critical",
@@ -1696,7 +1704,7 @@
     },
     {
       "criticality": "workflow",
-      "description": "Persist an approved plan whose post-approval turn was wiped (UserPromptSubmit)",
+      "description": "Persist an approved plan whose post-approval turn was wiped, nudging when it carries no settled Panel: line (UserPromptSubmit)",
       "event": "UserPromptSubmit",
       "name": "persist-plan",
       "plugin": "session",
@@ -1716,7 +1724,7 @@
     },
     {
       "criticality": "workflow",
-      "description": "Persist an approved plan on same-session approval (PostToolUse:ExitPlanMode)",
+      "description": "Persist an approved plan on same-session approval, nudging when it carries no settled Panel: line (PostToolUse:ExitPlanMode)",
       "event": "PostToolUse",
       "name": "persist-plan-approval",
       "plugin": "session",

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -419,13 +419,13 @@ pub const HOOKS: &[HookEntry] = &[
     },
     HookEntry {
         name: "persist-plan",
-        description: "Persist an approved plan whose post-approval turn was wiped (UserPromptSubmit)",
+        description: "Persist an approved plan whose post-approval turn was wiped, nudging when it carries no settled Panel: line (UserPromptSubmit)",
         plugin: "session",
         event: Some(HookEvent::UserPromptSubmit),
     },
     HookEntry {
         name: "persist-plan-approval",
-        description: "Persist an approved plan on same-session approval (PostToolUse:ExitPlanMode)",
+        description: "Persist an approved plan on same-session approval, nudging when it carries no settled Panel: line (PostToolUse:ExitPlanMode)",
         plugin: "session",
         event: Some(HookEvent::PostToolUse),
     },


### PR DESCRIPTION
Closes #623.

Both plan-persistence triggers (`persist-plan`, UserPromptSubmit; `persist-plan-approval`, PostToolUse:ExitPlanMode) already hold the normalized plan body. They now scan it for the plan template's settled `Panel:` stanza — `Panel: <seats> ran — <counts>` or the absence assertion `Panel: none — <reason>` — anchored at line start, **first match in document order** deciding (the `Driver:` stamp's discipline, so a quoted example later in the body can neither satisfy nor contradict the stanza). When no settled line is present (absent, `pending`-shaped, or a heading with no line), one static sentence is appended to the existing persistence nudge telling the session to run the plan-review panel before implementing, fold findings, or write the absence line.

Design constraints honored:

- **Nudge, never a block** (warn tier, ADR-0001); every uncertainty degrades to silent allow.
- **Static string only** — committed plan content is untrusted input and is never echoed into the nudge (tested).
- **Artifact-anchored** — the marker is the line in the plan document, surviving the approve-and-clear session boundary (cameronsjo/cadence#578's objection to session-scoped markers).
- **No new plumbing** — rides `persist_and_nudge`, the shared tail both triggers converge on; no new registration, no wiring change.
- **Honest framing** — post-approval, pre-implementation detection; a rejection emits no hook event, so approval-time visibility belongs to the template layer (cameronsjo/cadence#849, PR cameronsjo/cadence#850).

Tests: detector unit tests (both settled forms, pending/absent/heading-only/indented/mid-line negatives, first-match ordering both directions) plus end-to-end approval-path assertions that the sentence appends on an unsettled plan, never echoes plan text, and stays absent on a settled line. `cargo test -p cadence-hooks-session` 85/85; workspace green except the pre-existing `hook_registration_audit` sibling-checkout drift (reproduces identically on an untouched main checkout — unrelated); clippy `-D warnings` clean; fmt clean.

Session-Name: steady-lantern
Session-Id: 1bd323e5-10e8-42e3-a879-63e4236b3353
Model: claude-fable-5
Harness: claude-code 2.1.223
Machine: cf6e768835c7
