### PR TITLE
fix(polish): preserve recorded arm roster

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [Unreleased]
+
+### Fixed
+
+- **`record-polish --arm` now retains previously recorded arms and overrides only names supplied again (#592).** Sequential arm-only recordings merge through the trusted private-marker reader, so a focused rerun no longer erases the rest of the polish roster; roster-less and malformed legacy markers continue to degrade to an empty prior roster.
+
 ## [0.74.0] - 2026-08-06
 
 ### Changed

--- a/crates/cadence/src/record_polish.rs
+++ b/crates/cadence/src/record_polish.rs
@@ -21,10 +21,11 @@
 //! line and exits 0 (ADR-0001).
 
 use cadence_hooks_core::gitstate::GitState;
-use cadence_hooks_core::markers::{polish_marker, write_marker};
+use cadence_hooks_core::markers::{polish_marker, read_polish_record, write_marker};
 use cadence_hooks_core::shell::git_command;
 use cadence_hooks_core::time::utc_timestamp;
 use serde_json::json;
+use std::collections::BTreeMap;
 use std::path::Path;
 
 /// The canonical marker key for a directory: the canonicalized
@@ -134,6 +135,19 @@ fn parse_arms(raw: &[String]) -> Vec<(String, String)> {
         .collect()
 }
 
+/// Merge a trusted prior roster with the incoming delta. Existing names survive;
+/// incoming entries override in argument order, preserving last-value-wins.
+fn merge_arms(
+    existing: Option<&BTreeMap<String, String>>,
+    incoming: Vec<(String, String)>,
+) -> Vec<(String, String)> {
+    let mut merged = existing.cloned().unwrap_or_default();
+    for (name, state) in incoming {
+        merged.insert(name, state);
+    }
+    merged.into_iter().collect()
+}
+
 /// Build the marker payload. Presence is what CP1 gates on; the fields are
 /// stored now so CP2's freshness/scope escalation needs no format change.
 /// The `arms` roster (cadence-hooks#467) is **additive and optional**: absent
@@ -203,7 +217,12 @@ pub fn run_record(
     };
 
     let scope = scope.unwrap_or_else(|| "full".to_string());
-    let arms = parse_arms(&arm);
+    let incoming_arms = parse_arms(&arm);
+    let prior = read_polish_record(&repo_root, &branch);
+    let arms = merge_arms(
+        prior.as_ref().and_then(|record| record.arms.as_ref()),
+        incoming_arms,
+    );
     let content = marker_content(&branch, &head_sha, &scope, &arms);
     let path = polish_marker(&repo_root, &branch);
     match write_marker(&path, &content) {
@@ -239,7 +258,7 @@ mod tests {
     }
 
     #[test]
-    fn marker_content_records_arm_roster_additively() {
+    fn marker_content_serializes_supplied_arm_roster() {
         // #467 RED: the roster rides an additive "arms" object.
         let arms = vec![
             ("security".to_string(), "ran".to_string()),
@@ -334,6 +353,132 @@ mod tests {
             assert_eq!(v["branch"], branch);
             assert_eq!(v["scope"], "code");
             // #467: the roster round-trips through the written marker.
+            assert_eq!(v["arms"]["security"], "ran");
+        });
+    }
+
+    #[test]
+    fn run_record_merges_new_arms_into_existing_roster() {
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/record-polish-merge-test-repo";
+            let branch = "feat/record-polish-merge";
+            let path = polish_marker(repo, branch);
+
+            run_record(
+                Some(repo.into()),
+                Some(branch.into()),
+                Some("full".into()),
+                vec![
+                    "tests=ran".into(),
+                    "security=skipped".into(),
+                    "simplify=ran".into(),
+                ],
+            );
+            run_record(
+                Some(repo.into()),
+                Some(branch.into()),
+                Some("full".into()),
+                vec!["security=ran".into()],
+            );
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert_eq!(v["arms"]["tests"], "ran");
+            assert_eq!(v["arms"]["simplify"], "ran");
+            assert_eq!(v["arms"]["security"], "ran");
+        });
+    }
+
+    #[test]
+    fn run_record_with_no_new_arms_preserves_existing_roster_and_refreshes_scope() {
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/record-polish-no-arm-test-repo";
+            let branch = "feat/record-polish-no-arm";
+            let path = polish_marker(repo, branch);
+
+            run_record(
+                Some(repo.into()),
+                Some(branch.into()),
+                Some("full".into()),
+                vec!["tests=ran".into()],
+            );
+            run_record(
+                Some(repo.into()),
+                Some(branch.into()),
+                Some("docs".into()),
+                vec![],
+            );
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert_eq!(v["arms"]["tests"], "ran");
+            assert_eq!(v["scope"], "docs");
+        });
+    }
+
+    #[test]
+    fn run_record_without_arms_omits_roster_for_new_marker() {
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/record-polish-rosterless-test-repo";
+            let branch = "feat/record-polish-rosterless";
+            let path = polish_marker(repo, branch);
+
+            run_record(
+                Some(repo.into()),
+                Some(branch.into()),
+                Some("full".into()),
+                vec![],
+            );
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert!(v.get("arms").is_none());
+        });
+    }
+
+    #[test]
+    fn run_record_replaces_malformed_prior_marker_with_current_record() {
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/record-polish-malformed-test-repo";
+            let branch = "feat/record-polish-malformed";
+            let path = polish_marker(repo, branch);
+            write_marker(&path, "]]not json").unwrap();
+
+            run_record(
+                Some(repo.into()),
+                Some(branch.into()),
+                Some("code".into()),
+                vec!["security=ran".into()],
+            );
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&content).unwrap();
+            assert_eq!(v["scope"], "code");
+            assert_eq!(v["arms"]["security"], "ran");
+        });
+    }
+
+    #[test]
+    fn run_record_duplicate_incoming_names_keep_last_value() {
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/record-polish-duplicate-test-repo";
+            let branch = "feat/record-polish-duplicate";
+            let path = polish_marker(repo, branch);
+
+            run_record(
+                Some(repo.into()),
+                Some(branch.into()),
+                Some("full".into()),
+                vec!["security=skipped".into(), "security=ran".into()],
+            );
+
+            let content = std::fs::read_to_string(&path).unwrap();
+            let v: serde_json::Value = serde_json::from_str(&content).unwrap();
             assert_eq!(v["arms"]["security"], "ran");
         });
     }

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -272,14 +272,23 @@ impl PolishRecord {
 /// way everything else does: `None` → roster unknown → the presence bool
 /// alone decides, exactly the pre-#467 behavior.
 pub fn read_polish_marker(command: &str, cwd: Option<&str>) -> Option<PolishRecord> {
-    if !marker_dir_is_private() {
-        return None;
-    }
     let cwd = cwd?;
     let dir = parse_work_dir(command, cwd);
     let state = GitState::resolve(Path::new(&dir))?;
     let branch = state.branch?;
-    let path = polish_marker(&state.git_common_dir.to_string_lossy(), &branch);
+    read_polish_record(&state.git_common_dir.to_string_lossy(), &branch)
+}
+
+/// Read a polish record by its already-resolved `(repo_root, branch)` key.
+///
+/// Content is trusted only from the hardened private marker directory. Missing,
+/// unreadable, or malformed markers return `None`; non-string arm values are
+/// filtered from the optional roster instead of failing the whole record.
+pub fn read_polish_record(repo_root: &str, branch: &str) -> Option<PolishRecord> {
+    if !marker_dir_is_private() {
+        return None;
+    }
+    let path = polish_marker(repo_root, branch);
     let content = std::fs::read_to_string(&path).ok()?;
     let v: serde_json::Value = serde_json::from_str(&content).ok()?;
     Some(PolishRecord {
@@ -777,6 +786,56 @@ mod tests {
         // Legacy full/code roster-less markers are UNKNOWN.
         assert_eq!(rec(Some("full"), None).security_ran(), None);
         assert_eq!(rec(None, None).security_ran(), None);
+    }
+
+    #[test]
+    fn read_polish_record_parses_scope_and_filters_non_string_arms() {
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/keyed-polish-record";
+            let branch = "feat/keyed-read";
+            write_marker(
+                &polish_marker(repo, branch),
+                r#"{"scope":"code","arms":{"security":"ran","tests":false}}"#,
+            )
+            .unwrap();
+
+            let rec = read_polish_record(repo, branch).expect("marker reads");
+            assert_eq!(rec.scope.as_deref(), Some("code"));
+            assert_eq!(
+                rec.arms
+                    .as_ref()
+                    .unwrap()
+                    .get("security")
+                    .map(String::as_str),
+                Some("ran")
+            );
+            assert!(!rec.arms.as_ref().unwrap().contains_key("tests"));
+        });
+    }
+
+    #[test]
+    fn read_polish_record_returns_none_for_missing_and_garbage() {
+        let marker_tmp = tempfile::tempdir().unwrap();
+        with_marker_dir(marker_tmp.path(), || {
+            let repo = "/tmp/keyed-polish-record";
+            let branch = "feat/keyed-missing";
+            assert!(read_polish_record(repo, branch).is_none());
+
+            write_marker(&polish_marker(repo, branch), "]]not json").unwrap();
+            assert!(read_polish_record(repo, branch).is_none());
+        });
+    }
+
+    #[test]
+    fn read_polish_record_returns_none_from_degraded_marker_dir() {
+        let tmp = tempfile::tempdir().unwrap();
+        let not_a_dir = tmp.path().join("occupied");
+        std::fs::write(&not_a_dir, "").unwrap();
+        with_marker_dir(&not_a_dir, || {
+            assert!(!marker_dir_is_private(), "precondition: fail-open path");
+            assert!(read_polish_record("/tmp/repo", "feat/degraded").is_none());
+        });
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Preserve existing polish arm results when a later `record-polish --arm` invocation updates only part of the roster.
- Read the prior trusted marker by its resolved repository/branch key, retain string-valued arm entries, and merge incoming entries deterministically with last-value-wins replacement.
- Keep existing behavior for new roster-less markers and malformed prior records, and document the additive update under `[Unreleased]`.

## TDD regression evidence

The regression test records `tests=ran`, `security=skipped`, and `simplify=ran`, then records only `security=ran`. Before the fix, the second write dropped the untouched entries (`tests` read back as `null`); after the fix, `tests` and `simplify` remain while `security` is replaced with `ran`.

Additional coverage exercises no-arm preservation with refreshed scope, new markers without a roster, malformed prior replacement, duplicate incoming names, trusted parsing/filtering, missing or invalid records, and degraded marker-directory refusal.

## Validation

- `cargo test -p cadence-hooks-core markers` — 40 passed
- `cargo test -p cadence-hooks-cadence record_polish` — 15 passed
- `cargo test -p cadence-hooks-core -p cadence-hooks-cadence` — 1,734 tests and 1 doctest passed
- `cargo fmt --all -- --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `make ci` with an empty sibling-audit workspace, matching GitHub CI's no-sibling topology
- `git diff --check`

## Residual caveat

Roster persistence remains an unlocked read-modify-write sequence. Two concurrent recorders for the same repository and branch can read the same prior roster, and the later atomic rename can lose the earlier delta. This change covers the sequential remediation path and intentionally does not add cross-process locking or a new dependency.

Closes #592
