### PR TITLE
fix(core): normalize Codex apply-patch objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Fixed
 
+- **Codex `apply_patch` hook payloads now normalize both object-wrapped patch-body forms (#639).** The official Codex 0.146.0 `tool_input.command` envelope and the adapter-emitted `tool_input.input` envelope now reach per-target security guards instead of failing closed as if the patch body were missing. Raw-string `tool_input`, top-level `input`, and already-normalized `tool_input.patch` compatibility remain intact; conflicting recognized bodies and malformed or missing bodies fail closed without echoing patch content.
 - **`record-polish --arm` now retains previously recorded arms and overrides only names supplied again (#592).** Sequential arm-only recordings merge through the trusted private-marker reader, so a focused rerun no longer erases the rest of the polish roster; roster-less and malformed legacy markers continue to degrade to an empty prior roster.
 
 ## [0.74.0] - 2026-08-06

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -464,6 +464,35 @@ where
     Ok(value.and_then(|v| serde_json::from_value(v).ok()))
 }
 
+/// Resolve every supported `apply_patch` body envelope without letting one
+/// recognized field shadow another. `patch` is the already-normalized internal
+/// form; retaining it here preserves existing compatibility while subjecting it
+/// to the same conflict check as external harness envelopes.
+fn resolve_apply_patch_body(value: &serde_json::Value) -> Result<Option<&str>, &'static str> {
+    let tool_input = value.get("tool_input");
+    let candidates = [
+        tool_input.and_then(serde_json::Value::as_str),
+        tool_input
+            .and_then(|input| input.get("command"))
+            .and_then(serde_json::Value::as_str),
+        tool_input
+            .and_then(|input| input.get("input"))
+            .and_then(serde_json::Value::as_str),
+        tool_input
+            .and_then(|input| input.get("patch"))
+            .and_then(serde_json::Value::as_str),
+        value.get("input").and_then(serde_json::Value::as_str),
+    ];
+    let mut candidates = candidates.into_iter().flatten();
+    let Some(first) = candidates.next() else {
+        return Ok(None);
+    };
+    if candidates.any(|candidate| candidate != first) {
+        return Err("apply_patch payload contains conflicting patch bodies");
+    }
+    Ok(Some(first))
+}
+
 impl HookInput {
     /// Read and parse hook input from stdin.
     pub fn from_stdin() -> Result<Self, String> {
@@ -492,10 +521,8 @@ impl HookInput {
             .unwrap_or_default()
             .to_string();
         if tool_name == "apply_patch" {
-            let patch = value
-                .get("tool_input")
-                .and_then(serde_json::Value::as_str)
-                .or_else(|| value.get("input").and_then(serde_json::Value::as_str))
+            let patch = resolve_apply_patch_body(&value)
+                .map_err(str::to_string)?
                 .map(str::to_string);
             if let Some(patch) = patch {
                 value["tool_input"] = serde_json::json!({"patch": patch});
@@ -1780,6 +1807,111 @@ mod tests {
                 .collect::<Vec<_>>(),
             [Some("Write"), Some("Edit"), Some("Write"), Some("Edit")]
         );
+    }
+
+    #[test]
+    fn codex_patch_command_object_expands_target() {
+        let input = HookInput::from_json(
+            r#"{"tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n*** Add File: command.txt\n+ok\n*** End Patch"}}"#,
+        )
+        .unwrap();
+        let targets = input.normalized_inputs().unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].file_path().as_deref(), Some("command.txt"));
+        assert_eq!(targets[0].content(), Some("ok"));
+    }
+
+    #[test]
+    fn codex_patch_input_object_expands_target() {
+        let input = HookInput::from_json(
+            r#"{"tool_name":"apply_patch","tool_input":{"input":"*** Begin Patch\n*** Add File: input.txt\n+ok\n*** End Patch"}}"#,
+        )
+        .unwrap();
+        let targets = input.normalized_inputs().unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].file_path().as_deref(), Some("input.txt"));
+        assert_eq!(targets[0].content(), Some("ok"));
+    }
+
+    #[test]
+    fn codex_patch_top_level_input_expands_target() {
+        let input = HookInput::from_json(
+            r#"{"tool_name":"apply_patch","input":"*** Begin Patch\n*** Add File: top-level.txt\n+ok\n*** End Patch"}"#,
+        )
+        .unwrap();
+        let targets = input.normalized_inputs().unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].file_path().as_deref(), Some("top-level.txt"));
+        assert_eq!(targets[0].content(), Some("ok"));
+    }
+
+    #[test]
+    fn codex_patch_normalized_patch_field_expands_target() {
+        let input = HookInput::from_json(
+            r#"{"tool_name":"apply_patch","tool_input":{"patch":"*** Begin Patch\n*** Add File: normalized.txt\n+ok\n*** End Patch"}}"#,
+        )
+        .unwrap();
+        let targets = input.normalized_inputs().unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].file_path().as_deref(), Some("normalized.txt"));
+        assert_eq!(targets[0].content(), Some("ok"));
+    }
+
+    #[test]
+    fn codex_patch_identical_duplicate_bodies_expand_target() {
+        let patch = "*** Begin Patch\n*** Add File: duplicate.txt\n+ok\n*** End Patch";
+        let payload = serde_json::json!({
+            "tool_name": "apply_patch",
+            "tool_input": {"command": patch, "input": patch, "patch": patch},
+            "input": patch,
+        });
+        let input = HookInput::from_json(&payload.to_string()).unwrap();
+        let targets = input.normalized_inputs().unwrap();
+        assert_eq!(targets.len(), 1);
+        assert_eq!(targets[0].file_path().as_deref(), Some("duplicate.txt"));
+        assert_eq!(targets[0].content(), Some("ok"));
+    }
+
+    #[test]
+    fn codex_patch_conflicting_bodies_fail_without_echoing_them() {
+        let benign = "*** Begin Patch\n*** Add File: benign.txt\n+ok\n*** End Patch";
+        let secret = "*** Begin Patch\n*** Add File: secret.env\n+TOP_SECRET\n*** End Patch";
+        let payloads = [
+            serde_json::json!({
+                "tool_name": "apply_patch",
+                "tool_input": {"command": benign, "input": secret},
+            }),
+            serde_json::json!({
+                "tool_name": "apply_patch",
+                "tool_input": {"command": benign},
+                "input": secret,
+            }),
+            serde_json::json!({
+                "tool_name": "apply_patch",
+                "tool_input": {"command": benign, "patch": secret},
+            }),
+        ];
+        for payload in payloads {
+            let error = HookInput::from_json(&payload.to_string()).unwrap_err();
+            assert!(error.contains("conflicting patch bodies"), "{error}");
+            assert!(!error.contains("benign.txt"), "{error}");
+            assert!(!error.contains("secret.env"), "{error}");
+            assert!(!error.contains("TOP_SECRET"), "{error}");
+        }
+    }
+
+    #[test]
+    fn malformed_object_wrapped_patch_diagnostic_does_not_echo_body() {
+        for field in ["command", "input"] {
+            let payload = serde_json::json!({
+                "tool_name": "apply_patch",
+                "tool_input": {field: "*** Begin Patch\nTOP_SECRET\n*** End Patch"},
+            });
+            let input = HookInput::from_json(&payload.to_string()).unwrap();
+            let error = input.normalized_inputs().unwrap_err();
+            assert!(error.contains("schema rejected"), "{field}: {error}");
+            assert!(!error.contains("TOP_SECRET"), "{field}: {error}");
+        }
     }
 
     #[test]

--- a/tests/codex_coverage.rs
+++ b/tests/codex_coverage.rs
@@ -372,7 +372,7 @@ fn patch_add_file_carrying_a_secret_is_blocked() {
     let payload = serde_json::json!({
         "tool_name": "apply_patch",
         "cwd": "/private/tmp",
-        "tool_input": patch,
+        "tool_input": {"command": patch},
     })
     .to_string();
     let (code, stderr) = run_hook(
@@ -381,6 +381,10 @@ fn patch_add_file_carrying_a_secret_is_blocked() {
         &payload,
     );
     assert_eq!(code, Some(2), "a patched-in secret must block: {stderr}");
+    assert!(
+        !stderr.contains("targets could not be enumerated"),
+        "the guard, not patch normalization, must decide the block: {stderr}"
+    );
 
     // Control: the same guard on the same content through a plain Write. If
     // this did not block, the assertion above would prove nothing about the
@@ -393,6 +397,66 @@ fn patch_add_file_carrying_a_secret_is_blocked() {
     .to_string();
     let (code, _) = run_hook(&["cadence", "prevent-secret-writes"], &[], &write);
     assert_eq!(code, Some(2), "control: the plain Write must block too");
+}
+
+#[test]
+fn adapter_wrapped_benign_patch_reaches_security_critical_guard() {
+    let patch = "*** Begin Patch\n*** Add File: harmless.txt\n+ok\n*** End Patch";
+    let payload = serde_json::json!({
+        "tool_name": "apply_patch",
+        "cwd": "/private/tmp",
+        "tool_input": {"input": patch},
+    })
+    .to_string();
+    let (code, stderr) = run_hook(
+        &["cadence", "prevent-secret-writes"],
+        &[("CADENCE_HARNESS", "codex")],
+        &payload,
+    );
+    assert_eq!(
+        code,
+        Some(0),
+        "a benign patch must reach the guard: {stderr}"
+    );
+    assert!(
+        stderr.is_empty(),
+        "a benign patch must stay silent: {stderr}"
+    );
+}
+
+#[test]
+fn conflicting_patch_bodies_fail_closed_without_echoing_them() {
+    let benign = "*** Begin Patch\n*** Add File: benign.txt\n+ok\n*** End Patch";
+    let secret = "*** Begin Patch\n*** Add File: secret.env\n+AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n*** End Patch";
+    let payloads = [
+        serde_json::json!({
+            "tool_name": "apply_patch",
+            "cwd": "/private/tmp",
+            "tool_input": {"command": benign, "input": secret},
+        }),
+        serde_json::json!({
+            "tool_name": "apply_patch",
+            "cwd": "/private/tmp",
+            "tool_input": {"command": benign},
+            "input": secret,
+        }),
+    ];
+    for payload in payloads {
+        let (code, stderr) = run_hook(
+            &["cadence", "prevent-secret-writes"],
+            &[("CADENCE_HARNESS", "codex")],
+            &payload.to_string(),
+        );
+        assert_eq!(code, Some(2), "conflicting patch bodies must block");
+        assert!(
+            stderr.contains("apply_patch payload contains conflicting patch bodies")
+                && stderr.contains("security-critical hook input could not be parsed"),
+            "the security-critical parse failure must explain the block: {stderr}"
+        );
+        assert!(!stderr.contains("benign.txt"), "{stderr}");
+        assert!(!stderr.contains("secret.env"), "{stderr}");
+        assert!(!stderr.contains("AKIAIOSFODNN7EXAMPLE"), "{stderr}");
+    }
 }
 
 /// `guard-dotfiles` sees a patch target: an `apply_patch` writing a managed

--- a/tests/fixtures/harness/codex.jsonl
+++ b/tests/fixtures/harness/codex.jsonl
@@ -1,6 +1,6 @@
 {"route":"shell","payload":{"hook_event_name":"PreToolUse","tool_name":"shell","tool_input":{"cmd":"git status"}}}
 {"route":"unified-exec","payload":{"hook_event_name":"PreToolUse","tool_name":"exec_command","tool_input":{"cmd":"pwd"}}}
-{"route":"apply-patch","payload":{"hook_event_name":"PreToolUse","tool_name":"apply_patch","tool_input":"*** Begin Patch\n*** Add File: notes.md\n+ok\n*** End Patch"}}
+{"route":"apply-patch","payload":{"hook_event_name":"PreToolUse","tool_name":"apply_patch","tool_input":{"command":"*** Begin Patch\n*** Add File: notes.md\n+ok\n*** End Patch"}}}
 {"route":"mcp-functions","payload":{"hook_event_name":"PreToolUse","tool_name":"mcp__filesystem__read_file","tool_input":{"path":"README.md"}}}
 {"route":"mcp-filesystem-write","payload":{"hook_event_name":"PreToolUse","tool_name":"mcp__filesystem__write_file","tool_input":{"path":"notes.md","content":"ok"}}}
 {"route":"subagents","payload":{"hook_event_name":"PreToolUse","tool_name":"spawn_agent","tool_input":{"subagent_type":"reviewer"}}}


### PR DESCRIPTION
## Summary

- Accept the official Codex 0.146.0 tool_input.command envelope and the adapter tool_input.input envelope while preserving raw-string, normalized patch, and top-level input compatibility.
- Reject differing recognized patch bodies before parsing so one envelope cannot shadow another; identical duplicates remain valid.
- Keep malformed, missing, and conflicting payloads fail-closed with static diagnostics that never echo patch content.

## Regression evidence

Before this fix, object-wrapped apply-patch calls were rejected as missing their body. The regression suite now verifies target and content normalization for every supported envelope, rejects conflicting bodies without leaking either value, and proves secret-bearing patches reach the security guard rather than false-passing through a parser error.

## Validation

- Core apply-patch tests: 8 passed
- Core library tests: 763 passed
- Codex coverage tests: 16 passed
- cargo fmt --all -- --check
- cargo clippy --workspace --all-targets -- -D warnings
- make report-check
- git diff --check

Closes #639