### PR TITLE
ci: narrow GitHub App token permissions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"

--- a/.github/workflows/auto-tag.yml
+++ b/.github/workflows/auto-tag.yml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate Forge Bellows token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           # client-id, not the deprecated app-id. The action resolves
           # `getInput("client-id") || getInput("app-id")` into one value it
@@ -34,6 +34,7 @@ jobs:
           # token minting dies. Do not narrow this to @v3.0.0.
           client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          permission-contents: write
 
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -197,7 +197,7 @@ jobs:
 
       - name: Generate Forge Bellows token
         id: app-token
-        uses: actions/create-github-app-token@v3
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
         with:
           # client-id, not the deprecated app-id — see auto-tag.yml for why the
           # numeric App ID in RELEASE_APP_ID stays valid under the new key, and
@@ -205,6 +205,7 @@ jobs:
           client-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           repositories: homebrew-tap
+          permission-contents: write
 
       - name: Update Homebrew tap
         env:


### PR DESCRIPTION
## Summary

- Pin both GitHub App token steps to the verified `actions/create-github-app-token` v3.2.0 commit.
- Request only `contents: write` for tag creation and the Homebrew repository dispatch, instead of inheriting the App installation's full permission set.
- Add weekly Dependabot updates for GitHub Actions so pinned action SHAs stay maintainable.

## Validation

- `actionlint` on both changed workflows
- YAML parse and semantic assertions for both workflows and the Dependabot configuration
- Zizmor before/after comparison: the two GitHub App permission findings and two unpinned-action findings are removed, with no new findings
- `cargo fmt --all -- --check`
- Workspace Clippy with warnings denied
- `make report-check`
- `git diff --check`

The next normal version bump remains the end-to-end acceptance event for the secret-backed token mint, tag push, and Homebrew dispatch; no release or tag was manufactured for this PR.

Closes #601
