### PR TITLE
ci: add Rust supply-chain checks

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,54 @@
+name: Security
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "23 7 * * 1"
+
+permissions:
+  contents: read
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_TOOLCHAIN: "1.88.0"
+
+jobs:
+  audit:
+    name: RustSec advisory audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --no-self-update
+
+      - name: Install cargo-audit
+        run: cargo +"$RUST_TOOLCHAIN" install cargo-audit --locked --version 0.22.2
+
+      - name: Audit Rust dependencies
+        run: cargo +"$RUST_TOOLCHAIN" audit
+
+  policy:
+    name: Dependency policy
+    if: github.event_name != 'schedule'
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install pinned Rust toolchain
+        run: rustup toolchain install "$RUST_TOOLCHAIN" --profile minimal --no-self-update
+
+      - name: Install cargo-deny
+        run: cargo +"$RUST_TOOLCHAIN" install cargo-deny --locked --version 0.20.2
+
+      - name: Check dependency policy
+        run: cargo +"$RUST_TOOLCHAIN" deny check bans licenses sources

--- a/deny.toml
+++ b/deny.toml
@@ -1,0 +1,39 @@
+[graph]
+all-features = true
+
+[advisories]
+ignore = []
+
+[licenses]
+allow = [
+  "Apache-2.0",
+  "Apache-2.0 WITH LLVM-exception",
+  "BSD-2-Clause",
+  "MIT",
+  "Unicode-3.0",
+  "Zlib",
+]
+confidence-threshold = 0.8
+include-dev = true
+exceptions = []
+
+[bans]
+multiple-versions = "warn"
+multiple-versions-include-dev = true
+
+# cargo-deny 0.20.2 treats this public workspace's inherited path dependencies
+# as wildcards and cannot exempt only those local paths. Allowing them also
+# leaves future wildcard registry requirements ungated; review those manually.
+wildcards = "allow"
+
+highlight = "all"
+allow = []
+deny = []
+skip = []
+skip-tree = []
+
+[sources]
+unknown-registry = "deny"
+unknown-git = "deny"
+allow-registry = ["https://github.com/rust-lang/crates.io-index"]
+allow-git = []


### PR DESCRIPTION
## Summary

- Add a hard-failing RustSec audit for pushes, pull requests, and a weekly schedule.
- Add cargo-deny policy checks for dependency licenses, sources, and duplicate-version visibility on pushes and pull requests.
- Pin the Rust toolchain, audit tools, and checkout action while keeping workflow permissions read-only.

## Validation

- `cargo audit` 0.22.2 against the current RustSec database
- `cargo deny check bans licenses sources` with cargo-deny 0.20.2
- Negative policy controls for a removed license, an empty registry allowlist, and denied duplicate versions
- `actionlint .github/workflows/security.yml`
- YAML semantic assertions
- Zizmor workflow scan
- `cargo fmt --all -- --check`
- Workspace Clippy with warnings denied
- `make report-check`
- `git diff --check`

## Explicit residuals

- Cargo-deny 0.20.2 cannot narrowly exempt this public workspace's inherited path dependencies, so wildcard requirements remain allowed and must be reviewed manually.
- RustSec currently reports the stale-lock-only `anyhow` RUSTSEC-2026-0190 unsoundness notice as an allowed informational warning; vulnerable dependency findings still fail the audit.

Closes #434
