### PR TITLE
fix(core): close two secret-guard bypasses shipped in 0.75.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.75.1] - 2026-08-08
+
 ### Fixed
 
 - **Two shell-parser secret bypasses the #551 quote-migration left open, both live in 0.75.0 (#551 follow-up).** `substitution_bodies`' outer loop tracked quotes with ANSI-C-blind `in_single`/`in_double` bools, so a `$'a\'b'` string before a command substitution desynced the scan and every later `$(…)`/`` `…` `` — e.g. `echo $'a\'b' $(cat .env)` — was hidden from `prevent-secret-leaks` while bash executed the read (proven with a marker file). The outer loop now drives the shared `scan_quote_syntax` state machine, the same reader `split_segments`/`tokenize` use. Separately, `redirect_targets` (the append-inclusive parser feeding `prevent-secret-writes`) lost the escaped-whitespace branch its `clobber_redirect_targets` sibling kept, so `>> my\ dir/.env` truncated the target at the escaped space and the append to a real `.env` inside a space-bearing directory reached no guard; the branch is restored so the two redirect parsers agree on where a filename ends. Regression tests pin the executed read/write blocking, the escaped-backtick-prose and single-quoted-literal negatives, and parser-level parity with the quoted spellings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Two shell-parser secret bypasses the #551 quote-migration left open, both live in 0.75.0 (#551 follow-up).** `substitution_bodies`' outer loop tracked quotes with ANSI-C-blind `in_single`/`in_double` bools, so a `$'a\'b'` string before a command substitution desynced the scan and every later `$(…)`/`` `…` `` — e.g. `echo $'a\'b' $(cat .env)` — was hidden from `prevent-secret-leaks` while bash executed the read (proven with a marker file). The outer loop now drives the shared `scan_quote_syntax` state machine, the same reader `split_segments`/`tokenize` use. Separately, `redirect_targets` (the append-inclusive parser feeding `prevent-secret-writes`) lost the escaped-whitespace branch its `clobber_redirect_targets` sibling kept, so `>> my\ dir/.env` truncated the target at the escaped space and the append to a real `.env` inside a space-bearing directory reached no guard; the branch is restored so the two redirect parsers agree on where a filename ends. Regression tests pin the executed read/write blocking, the escaped-backtick-prose and single-quoted-literal negatives, and parser-level parity with the quoted spellings.
+
 ## [0.75.0] - 2026-08-08
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "cadence-hooks-core",
  "glob",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -241,11 +241,11 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.75.0"
+version = "0.75.1"
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.75.0"
+version = "0.75.1"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-guardrails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.75.0"
+version = "0.75.1"
 edition = "2024"
 license-file = "LICENSE"
 authors = ["Cameron Sjo"]

--- a/crates/cadence/src/prevent_secret_leaks.rs
+++ b/crates/cadence/src/prevent_secret_leaks.rs
@@ -1051,6 +1051,33 @@ mod tests {
     }
 
     #[test]
+    fn ansi_c_escaped_quote_does_not_hide_substitution_read() {
+        // #551 outer loop: an ANSI-C `$'a\'b'` string before a `$(…)`
+        // substitution desynced the quote-blind outer scan in
+        // `substitution_bodies`, so `cat .env` never became a segment and
+        // reached no guard — while bash executed it (proven with a marker
+        // file). The `echo` head is metadata-safe, so the substitution body was
+        // the only path to the read.
+        let result = SecretLeaksGuard.run(&make_bash_input(r"echo $'a\'b' $(cat .env)"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn ansi_c_escaped_quote_does_not_hide_backtick_read() {
+        // Same desync via the backtick substitution arm.
+        let result = SecretLeaksGuard.run(&make_bash_input(r"echo $'a\'b' `cat .env`"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn ansi_c_escaped_quote_benign_command_still_allowed() {
+        // Control: the same ANSI-C string with no secret read stays allowed —
+        // the fix surfaces the hidden substitution, it does not over-block.
+        let result = SecretLeaksGuard.run(&make_bash_input(r"echo $'a\'b' hello"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Allow);
+    }
+
+    #[test]
     fn verb_fold_cannot_widen_this_guards_exemption() {
         // This file is the ONE consumer of `core::shell::command_word` whose
         // lookup is an EXEMPTION (`METADATA_SAFE_COMMANDS`), where matching

--- a/crates/cadence/src/prevent_secret_writes.rs
+++ b/crates/cadence/src/prevent_secret_writes.rs
@@ -1235,4 +1235,37 @@ mod tests {
             "ANSI-C escaped quote bypassed append redirect"
         );
     }
+
+    // --- #551: escaped-whitespace in a redirect target path ---
+    // `redirect_targets` (the append-inclusive parser feeding this guard) lost
+    // the escaped-whitespace branch its sibling `clobber_redirect_targets`
+    // kept, so `>> my\ dir/.env` truncated the target at the escaped space
+    // (`my\`). The append to a real `.env` inside a space-bearing directory
+    // then named a non-secret target and reached no guard, while the quoted
+    // spelling `>> "my dir/.env"` blocked. The shell writes `my dir/.env`
+    // (final component `.env`), proven with a marker file.
+
+    #[test]
+    fn escaped_space_in_dir_path_clobber_blocked() {
+        assert!(bash_targets_env_file(r"echo TOKEN > my\ dir/.env"));
+    }
+
+    #[test]
+    fn escaped_space_in_dir_path_append_blocked() {
+        assert!(bash_targets_env_file(r"echo TOKEN >> my\ dir/.env"));
+    }
+
+    #[test]
+    fn escaped_space_secret_write_blocks_via_run() {
+        let result = SecretWritesGuard.run(&make_bash_input(r"echo TOKEN >> my\ dir/.env"));
+        assert_eq!(result.outcome, cadence_hooks_core::Outcome::Block);
+    }
+
+    #[test]
+    fn quoted_space_in_dir_path_still_blocked() {
+        // Control: the quoted spelling always resolved correctly, so the
+        // assertions above are evidence about the escape branch, not the
+        // parser generally.
+        assert!(bash_targets_env_file(r#"echo TOKEN > "my dir/.env""#));
+    }
 }

--- a/crates/core/src/shell.rs
+++ b/crates/core/src/shell.rs
@@ -2332,6 +2332,21 @@ pub fn redirect_targets(segment: &str) -> Vec<String> {
                         i = next;
                         continue;
                     }
+                    // A backslash-escaped whitespace char is part of the
+                    // filename, not a token terminator — consume the backslash
+                    // and keep the escaped char. Without this,
+                    // `>> my\ dir/.env` truncated the target at the escaped
+                    // space (`my\`), so the append to a real `.env` inside a
+                    // space-bearing directory reached no guard — while the
+                    // quoted spelling `>> "my dir/.env"` blocked correctly. The
+                    // sibling [`clobber_redirect_targets`] already carried this
+                    // branch; the two redirect parsers must not disagree on
+                    // where a filename ends (cameronsjo/cadence-hooks#551).
+                    if tc == '\\' && i + 1 < chars.len() && chars[i + 1].is_whitespace() {
+                        target.push(chars[i + 1]);
+                        i += 2;
+                        continue;
+                    }
                     if tc.is_whitespace() || matches!(tc, '>' | '<' | '|' | ';' | '&') {
                         break;
                     }
@@ -2525,33 +2540,38 @@ fn substitution_bodies(segment: &str) -> Vec<String> {
     let chars: Vec<char> = segment.chars().collect();
     let mut bodies = Vec::new();
     let mut i = 0;
-    let mut in_single = false;
-    let mut in_double = false;
+    let mut quote: Option<Quote> = None;
     while i < chars.len() {
+        // Single quotes and ANSI-C `$'…'` strings suppress substitution; double
+        // quotes do not. While inside a suppressing run, `$(`/backtick are
+        // literal text — advance the shared quote state machine past them. The
+        // former hand-rolled `in_single`/`in_double` bools had no ANSI-C mode,
+        // so `$'a\'b'` read the escaped `\'` as a close and the real `'` as a
+        // reopen: every later `$(…)` fell inside a phantom single-quote and
+        // reached no guard, while bash executed it (cameronsjo/cadence-hooks#551
+        // outer loop). `scan_quote_syntax` is the same reader `split_segments`
+        // and `tokenize` use, so the three cannot drift on where a quoted run
+        // ends.
+        if matches!(quote, Some(Quote::Single | Quote::AnsiC))
+            && let Some(next) = scan_quote_syntax(&chars, i, &mut quote)
+        {
+            i = next;
+            continue;
+        }
         let c = chars[i];
-        if c == '\\' && !in_single {
+        // A backslash escapes the next character in executed context (unquoted
+        // or inside double quotes), so `\$(`, an escaped backtick, and `\"` open
+        // no substitution and close no quote. Handled before the `$(`/backtick
+        // detection so an escaped opener is never read as one — this is what
+        // keeps `"use \`cat .env\` carefully"` inert. `scan_quote_syntax`'s
+        // Double mode escapes only `"`/`\`, so it cannot carry this case alone.
+        if c == '\\' {
             i += 2;
             continue;
         }
-        if in_single {
-            if c == '\'' {
-                in_single = false;
-            }
-            i += 1;
-            continue;
-        }
-        if c == '\'' && !in_double {
-            in_single = true;
-            i += 1;
-            continue;
-        }
-        if c == '"' {
-            in_double = !in_double;
-            i += 1;
-            continue;
-        }
         // `$(` … `)` with paren-depth AND quote tracking. `$(< file)` keeps
-        // its `<`.
+        // its `<`. Reached in executed context only — unquoted or inside double
+        // quotes, both of which run the substitution.
         if c == '$' && chars.get(i + 1) == Some(&'(') {
             if let Some((body, end)) = scan_substitution_body(&chars, i + 2, true) {
                 if !body.trim().is_empty() {
@@ -2600,6 +2620,14 @@ fn substitution_bodies(segment: &str) -> Vec<String> {
                 bodies.push(body);
             }
             i = j + 1;
+            continue;
+        }
+        // Not a substitution: let the state machine open a quote, close the
+        // current double quote, or consume an outside-quotes escape; otherwise
+        // step one char. Inside double quotes this keeps `$(`/backtick
+        // detection live while still tracking the closing `"`.
+        if let Some(next) = scan_quote_syntax(&chars, i, &mut quote) {
+            i = next;
             continue;
         }
         i += 1;
@@ -5330,6 +5358,62 @@ mod tests {
         assert!(
             targets.iter().any(|t| t == ".env"),
             "ANSI-C escaped quote hid the append redirect: {targets:?}"
+        );
+    }
+
+    #[test]
+    fn redirect_targets_escaped_whitespace_in_path_kept() {
+        // #551: `redirect_targets` lost the escaped-whitespace branch its
+        // sibling `clobber_redirect_targets` carries, so a backslash-escaped
+        // space in the target path truncated the filename (`my\`) instead of
+        // continuing through it. The append to `.env` inside a space-bearing
+        // directory then named a non-secret target and reached no guard, while
+        // the quoted spelling was parsed correctly.
+        assert_eq!(
+            redirect_targets(r"echo TOKEN >> my\ dir/.env"),
+            vec!["my dir/.env"]
+        );
+        assert_eq!(
+            redirect_targets(r"echo TOKEN > my\ dir/.env"),
+            vec!["my dir/.env"]
+        );
+        // The two redirect parsers must agree on where the filename ends.
+        assert_eq!(
+            clobber_redirect_targets(r"echo TOKEN > my\ dir/.env"),
+            vec!["my dir/.env"]
+        );
+        // Control: the quoted spelling always resolved correctly, so this is
+        // evidence about the escape branch, not the parser generally.
+        assert_eq!(
+            redirect_targets(r#"echo TOKEN >> "my dir/.env""#),
+            vec!["my dir/.env"]
+        );
+    }
+
+    #[test]
+    fn substitution_bodies_ansi_c_escaped_quote_does_not_hide_later_substitution() {
+        // #551 outer loop: the hand-rolled `in_single`/`in_double` bools had no
+        // ANSI-C mode, so `$'a\'b'` read the escaped `\'` as a close and the
+        // real `'` as a reopen — every later `$(…)` fell inside a phantom
+        // single-quote and was never surfaced as a body, while bash executed
+        // it. The shared `scan_quote_syntax` state machine tracks `$'…'`.
+        assert!(
+            substitution_bodies(r"echo $'a\'b' $(cat .env)")
+                .iter()
+                .any(|b| b.contains("cat .env")),
+            "ANSI-C escaped quote hid the substitution body"
+        );
+        assert!(
+            substitution_bodies(r"echo $'a\'b' `cat .env`")
+                .iter()
+                .any(|b| b.contains("cat .env")),
+            "ANSI-C escaped quote hid the backtick body"
+        );
+        // Control: an ANSI-C string genuinely containing a `$(` is literal and
+        // must NOT be surfaced — the fix suppresses inside single/ANSI-C runs.
+        assert!(
+            substitution_bodies(r"echo $'literal $(cat .env)'").is_empty(),
+            "a `$(` inside a single-quoted ANSI-C run must stay literal"
         );
     }
 

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "binaryVersion": "0.75.0",
+  "binaryVersion": "0.75.1",
   "minimumCodexVersion": "0.145.0",
   "privacy": {
     "rawHookInputsPersisted": false,


### PR DESCRIPTION
## What

Fast-follow to #551 / v0.75.0. Two shell-parser guard misses that **shipped in 0.75.0** are live secret bypasses — each reproduced against the freshly-built 0.75.0 binary (guard ALLOW while bash actually reads/writes the secret), then fixed. Both are **new mechanisms**, distinct from the four follow-ups filed off #551 (#652/#653/#654/#655).

### Miss 1 — secret read hidden (`prevent-secret-leaks`)

`substitution_bodies`' **outer** loop tracked quotes with ANSI-C-blind `in_single`/`in_double` bools. #551 migrated the inner `$(…)` scan to the shared `Quote` state machine but left the outer loop deciding executed-context on those bools — so an earlier `$'a\'b'` desynced it and hid every later `$(…)` / backtick substitution.

- `echo $'a\'b' $(cat .env)` → **ALLOW (exit 0)** pre-fix, bash prints `.env` to stdout (marker-proven) → **DENY** post-fix.

Fixed by driving the outer loop with the shared `scan_quote_syntax`, plus an explicit executed-context backslash-escape skip so an escaped backtick in double-quoted prose still opens nothing.

### Miss 2 — secret write hidden (`prevent-secret-writes`)

`redirect_targets` (the append-inclusive parser) lacked the escaped-whitespace branch its `clobber_redirect_targets` sibling carries, so a secret `.env` inside a space-bearing directory truncated the target.

- `echo TOKEN >> my\ dir/.env` → **ALLOW (exit 0)** pre-fix, bash writes `my dir/.env` → **DENY** post-fix.

(The original reviewer's `>> My\ .env` is a parser bug but not a security miss — `My .env`'s final component isn't a secret.)

## Verification

- Both fixed payloads DENY, benign controls ALLOW — reproduced independently against the built binary.
- `cargo test -p cadence-hooks-core -p cadence-hooks-cadence` → 990 + 769 pass, 0 fail. 9 regression tests added.
- `cargo clippy --workspace --all-targets -- -D warnings` clean; `cargo fmt` applied.
- Releases 0.75.1 (fast-follow; the live guard is the Homebrew-PATH binary).

```
Session-Name: pr-slates-2026-08-08
Session-Id: d7cca765-6b18-4f59-a720-06996dd637b1
Model: claude-fable-5
Harness: claude-code 2.1.226
Machine: cf6e768835c7
```
