### PR TITLE
fix(guard-rm): protections outrank the temp carve-out; an empty substitution no longer downgrades Block

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`guard-rm` no longer treats a protected target as unresolvable because an empty substitution was appended (#541).** `$()`, `$( )`, and an empty backtick pair expand to nothing in every shell, so `rm -rf ~/Documents$()` names exactly `~/Documents` — but the operand reached the classifier still carrying a `$` and downgraded a contractual Block to an Ask, a downgrade bought with two characters. Empty substitutions are now removed before any other parsing touches the segment, which also covers the two shapes the shell layer mangled: a trailing `$()` whose `)` the group-wrapper trim consumed, and `$( )` split across two tokens. Only *lexically* empty bodies are removed — `$(cat f)` and `${EMPTY}` keep their Ask verbatim, and an operand that was all empty substitution still asks rather than falling through to the working directory's verdict.
+- **A `$TMPDIR` that is the home directory, or an ancestor of it, is no longer honored as a temp root (#569).** Pointing `$TMPDIR` at `$HOME` reclassified every path under home as disposable scratch, making `rm -rf ~/Documents` a silent allow. The value is now refused across `guard-rm`, `enforce-worktree`, and the shared path classifier — component-wise, and under either spelling: a `$TMPDIR` that only *resolves* to home is rejected too, closing a symlinked `$TMPDIR` and a `$TMPDIR` differing from `$HOME` only in case on a case-insensitive volume. Real temp roots are unaffected, including macOS `/var/folders` and the Windows per-user temp directory that legitimately lives *under* the profile directory.
+- **An explicit `.git` now outranks `guard-rm`'s temp carve-out (#576).** A repository checked out under `/tmp` is still a repository, so `rm -rf /tmp/repo` blocks instead of allowing on the strength of its location alone. cadence's own managed scratch keeps its allow: a `.claude/worktrees/` checkout is disposable by construction, including when it lives under a temp root.
+
 ## [0.75.0] - 2026-08-08
 
 ### Added

--- a/crates/core/src/git_fixtures.rs
+++ b/crates/core/src/git_fixtures.rs
@@ -101,6 +101,7 @@ pub(crate) fn resolve_scratch_dir(root: &Path, tag: &str) -> PathBuf {
         std::env::var("TMPDIR").ok().as_deref(),
         override_root.as_deref(),
         xdg_cache_home().as_deref(),
+        Some(&crate::paths::user_home_lossy_or_default()),
     )
 }
 
@@ -138,13 +139,14 @@ fn resolve_scratch_dir_with(
     tmpdir: Option<&str>,
     override_root: Option<&Path>,
     xdg_cache_home: Option<&Path>,
+    home: Option<&str>,
 ) -> PathBuf {
     // `$TMPDIR` is invariant for the process — canonicalize once (a real
     // `realpath` syscall chain) and reuse it across all three candidates,
     // rather than re-canonicalizing per candidate inside `escapes_carveout`
     // (cadence-hooks#403 code review: the relocation path this function
     // exists for is precisely the one that was paying that cost 2-3x).
-    let tmpdir_canonical = crate::worktree::canonicalize_tmpdir(tmpdir);
+    let tmpdir_canonical = crate::worktree::canonicalize_tmpdir(tmpdir, home);
     let suffix = format!("{tag}-{}", std::process::id());
     let candidate = |base: &Path| base.join(&suffix);
     // Canonicalize `dir` (or its nearest existing ancestor — the `{tag}-{pid}`
@@ -162,7 +164,12 @@ fn resolve_scratch_dir_with(
     let escapes_carveout = |dir: &Path| {
         let resolved = canonicalize_nearest_existing(dir);
         !is_claude_managed_dir(&resolved)
-            && !path_under_temp_root_with_canonical(&resolved, tmpdir, tmpdir_canonical.as_deref())
+            && !path_under_temp_root_with_canonical(
+                &resolved,
+                tmpdir,
+                tmpdir_canonical.as_deref(),
+                home,
+            )
     };
 
     let default_dir = candidate(root);
@@ -523,7 +530,7 @@ mod tests {
     #[test]
     fn resolve_uses_the_default_when_it_escapes_the_carveout() {
         let root = Path::new("/Users/dev/checkout/target/scratch");
-        let dir = resolve_scratch_dir_with(root, "basic", None, None, None);
+        let dir = resolve_scratch_dir_with(root, "basic", None, None, None, None);
         assert_eq!(dir, root.join(format!("basic-{}", std::process::id())));
     }
 
@@ -536,6 +543,7 @@ mod tests {
             Some(&tmpdir),
             Some(Path::new("/Users/dev/.cache/cadence-hooks/test-scratch")),
             Some(Path::new("/Users/dev/.cache/should-not-be-used")),
+            None,
         );
         assert!(
             dir.starts_with("/Users/dev/.cache/cadence-hooks/test-scratch"),
@@ -553,6 +561,7 @@ mod tests {
             Some(&tmpdir),
             None,
             Some(Path::new("/Users/dev/.cache")),
+            None,
         );
         assert!(dir.starts_with("/Users/dev/.cache/cadence-hooks/test-scratch"));
     }
@@ -565,6 +574,7 @@ mod tests {
             None,
             None,
             Some(Path::new("/Users/dev/.cache")),
+            None,
         );
         // `!is_claude_managed_dir(&dir)` alone would pass for ANY non-`.claude`
         // result, including a wrong branch that happened to land somewhere
@@ -590,6 +600,7 @@ mod tests {
             Some(&tmpdir),
             None,
             None,
+            None,
         );
     }
 
@@ -603,6 +614,7 @@ mod tests {
             "tag",
             Some(&tmpdir),
             Some(&bad_override),
+            None,
             None,
         );
     }
@@ -623,6 +635,7 @@ mod tests {
             Some(&tmpdir),
             None,
             Some(&carved_out_xdg_cache_home),
+            None,
         );
     }
 
@@ -661,7 +674,7 @@ mod tests {
 
         // Sanity: the literal path does NOT lexically look like a carve-out.
         assert!(
-            !path_under_temp_root(&symlink_root.join("tag-x"), None),
+            !path_under_temp_root(&symlink_root.join("tag-x"), None, None),
             "test setup: the symlink's literal path must not itself start with /tmp"
         );
 
@@ -671,6 +684,7 @@ mod tests {
             None,
             None,
             Some(Path::new("/Users/dev/.cache")),
+            None,
         );
         assert!(
             dir.starts_with("/Users/dev/.cache/cadence-hooks/test-scratch"),

--- a/crates/core/src/pathclass.rs
+++ b/crates/core/src/pathclass.rs
@@ -162,7 +162,7 @@ pub fn classify(
     // ancestor (a worktree under `.claude`, a repo in `/tmp`) resolves to its
     // allow-class before git-root can match. This ordering is load-bearing and
     // locked by `claude_scratch_wins_over_git_root_probe`.
-    if path_under_temp_root(Path::new(&norm), ctx.tmpdir) {
+    if path_under_temp_root(Path::new(&norm), ctx.tmpdir, Some(ctx.home)) {
         return PathClass::Temp;
     }
     if under_claude_scratch(&norm) {
@@ -242,7 +242,14 @@ pub const CLAUDE_SCRATCH_DIRS: &[&str] = &["worktrees", "intros"];
 /// (`.claude/worktrees`) is excluded — deleting it takes every worktree at once,
 /// which is not the single-disposable-item case. Mirrors the `.claude` dir's own
 /// exclusion one level down.
-fn under_claude_scratch(norm: &str) -> bool {
+///
+/// Public because [`classify`] tests `Temp` FIRST, so a scratch path that also
+/// lives under a temp root reports [`PathClass::Temp`] and the scratch fact is
+/// unreachable from the returned class. `guardrails::guard_rm` needs that fact
+/// to keep worktree cleanup allowed while blocking a plain repo under `/tmp`
+/// (cadence-hooks#576), and asking here is cheaper and safer than reordering a
+/// precedence three tests already lock.
+pub fn under_claude_scratch(norm: &str) -> bool {
     let segs: Vec<&str> = norm.split('/').filter(|s| !s.is_empty()).collect();
     let Some(pos) = segs.iter().position(|s| *s == ".claude") else {
         return false;

--- a/crates/core/src/worktree.rs
+++ b/crates/core/src/worktree.rs
@@ -582,7 +582,7 @@ mod tests {
     /// comparison, is what settles it.
     #[test]
     #[cfg(unix)]
-    fn tmpdir_symlinked_to_home_is_not_a_temp_root() {
+    fn symlinked_tmpdir_covering_home_is_not_a_temp_root() {
         let scratch = scratch("tmpdir-symlink-home");
         let home = scratch.path().join("home");
         let link = scratch.path().join("tmpdir-link");
@@ -599,6 +599,46 @@ mod tests {
         assert!(
             !is_temp_root(&link.join("Documents"), Some(link_str), Some(home_str)),
             "a $TMPDIR that resolves to home must not earn the temp carve-out"
+        );
+    }
+
+    /// A `$TMPDIR` differing from home only in CASE, on a case-insensitive
+    /// volume — macOS's default, and a shipped target. `Path::starts_with` is
+    /// byte-exact, so the literal comparison declines to call it covering, and
+    /// the raw prefix test then matches every operand spelled the same way:
+    /// `TMPDIR=/users/dev` against `HOME=/Users/dev` handed the whole home tree
+    /// the temp carve-out. Resolution is what closes it — `canonicalize`
+    /// returns the volume's real casing, so both spellings converge.
+    ///
+    /// The volume, not the platform, is the question: case-insensitive mounts
+    /// exist on Linux and case-sensitive APFS volumes exist on macOS, so this
+    /// probes the actual filesystem and self-skips where the two spellings
+    /// genuinely name different directories and there is nothing to reject.
+    #[test]
+    fn case_differing_tmpdir_covering_home_is_not_a_temp_root() {
+        let scratch = scratch("tmpdir-case-home");
+        let home = scratch.path().join("home");
+        std::fs::create_dir_all(home.join("Documents")).unwrap();
+
+        let shouted = scratch.path().join("HOME");
+        if !shouted.is_dir() {
+            println!("skipped: case-sensitive volume, the two spellings are different directories");
+            return;
+        }
+
+        let home_str = home.to_str().unwrap();
+        let shouted_str = shouted.to_str().unwrap();
+        // Sanity: byte-exact comparison really does decline here, so a
+        // literal-only check would have granted the carve-out.
+        assert!(!Path::new(home_str).starts_with(shouted_str));
+
+        assert!(
+            !is_temp_root(
+                &shouted.join("Documents"),
+                Some(shouted_str),
+                Some(home_str)
+            ),
+            "a $TMPDIR naming home in different case must not earn the temp carve-out"
         );
     }
 

--- a/crates/core/src/worktree.rs
+++ b/crates/core/src/worktree.rs
@@ -132,9 +132,10 @@ pub(crate) fn git_dir_is_common_dir(git_dir: &Path, repo_root: &Path) -> bool {
 }
 
 /// Pure-ish: does `path` live under a temp root? `tmpdir` is the `$TMPDIR`
-/// value, when set. True for `/tmp`, `/private/tmp`, and `$TMPDIR` (with the
-/// canonicalized form too, for macOS's `/var/folders` vs `/private/var`
-/// split). The one non-pure step is a `canonicalize` of the `$TMPDIR` value.
+/// value, when set, and `home` the user's home directory, when resolvable.
+/// True for `/tmp`, `/private/tmp`, and `$TMPDIR` (with the canonicalized form
+/// too, for macOS's `/var/folders` vs `/private/var` split). The one non-pure
+/// step is a `canonicalize` of the `$TMPDIR` value.
 ///
 /// This is the generic predicate behind [`is_temp_root`]; `guardrails::guard_rm`
 /// reuses it to classify an `rm` target path (cadence-hooks#261), while
@@ -142,9 +143,55 @@ pub(crate) fn git_dir_is_common_dir(git_dir: &Path, repo_root: &Path) -> bool {
 /// carve-out. Canonicalizes `tmpdir` on every call — fine for a single check,
 /// but see [`path_under_temp_root_with_canonical`] when a caller checks
 /// several candidate paths against the same `$TMPDIR` in one pass.
-pub fn path_under_temp_root(path: &Path, tmpdir: Option<&str>) -> bool {
-    let canonical = canonicalize_tmpdir(tmpdir);
-    path_under_temp_root_with_canonical(path, tmpdir, canonical.as_deref())
+pub fn path_under_temp_root(path: &Path, tmpdir: Option<&str>, home: Option<&str>) -> bool {
+    let canonical = canonicalize_tmpdir(tmpdir, home);
+    path_under_temp_root_with_canonical(path, tmpdir, canonical.as_deref(), home)
+}
+
+/// True when `tmpdir` IS the home directory or an ancestor of it — under
+/// **either** spelling, the literal one or the resolved one.
+///
+/// A `$TMPDIR` that wide reclassifies every path under home as disposable, and
+/// the consumers of this predicate read "disposable" as ALLOW — with
+/// `TMPDIR=$HOME`, `rm -rf ~/Documents` was a silent allow (cadence-hooks#569).
+/// A temp root that swallows the user's whole working life is not a temp root,
+/// so it is rejected outright rather than trusted.
+///
+/// **Both spellings, because the literal one is what the prefix test uses.**
+/// `path_under_temp_root_with_canonical` matches an operand against the RAW
+/// `$TMPDIR` string, so an operand spelled the same way as a symlinked or
+/// case-differing `$TMPDIR` matches it — and a lexical-only check calls that
+/// value acceptable, because it compares unequal to home while naming the same
+/// directory. Two spellings survived a literal-only check: `TMPDIR=/scratch`
+/// where `/scratch -> $HOME`, and `TMPDIR=/users/dev` against `HOME=/Users/dev`
+/// on a case-insensitive volume (macOS's default, and a shipped target). Both
+/// are the exact failure class #569 exists to close.
+///
+/// Component-wise via [`Path::starts_with`], so `/Users/devon` does not swallow
+/// a home at `/Users/devon-old`. An unset or empty `home` disables the rule:
+/// nothing to protect means nothing to reject, and the alternative — treating
+/// an unresolvable home as "reject everything" — would disable the temp
+/// carve-out wholesale. A resolution failure on either side likewise declines
+/// to reject: an unreadable path is this predicate's blind spot, not evidence.
+///
+/// Costs up to two `realpath` chains, and only on the path where the cheap
+/// comparison already said no — the common case for a normal `$TMPDIR`. Paid
+/// deliberately: the callers are hooks that already spawn `git` or stat `.git`,
+/// and the alternative is a hole in the one branch that grants the carve-out.
+fn tmpdir_covers_home(tmpdir: &Path, home: Option<&str>) -> bool {
+    let Some(home) = home.map(str::trim).filter(|h| !h.is_empty()) else {
+        return false;
+    };
+    if Path::new(home).starts_with(tmpdir) {
+        return true;
+    }
+    match (
+        std::fs::canonicalize(tmpdir),
+        std::fs::canonicalize(Path::new(home)),
+    ) {
+        (Ok(resolved_tmpdir), Ok(resolved_home)) => resolved_home.starts_with(&resolved_tmpdir),
+        _ => false,
+    }
 }
 
 /// `$TMPDIR`, canonicalized once — factored out of [`path_under_temp_root`]
@@ -153,11 +200,25 @@ pub fn path_under_temp_root(path: &Path, tmpdir: Option<&str>) -> bool {
 /// fallback chain, cadence-hooks#403 code review) can canonicalize once and
 /// reuse it, instead of re-running a real `realpath` syscall chain per
 /// candidate.
-pub(crate) fn canonicalize_tmpdir(tmpdir: Option<&str>) -> Option<PathBuf> {
+///
+/// Returns `None` for a `$TMPDIR` that covers `home` — [`usable_tmpdir`] has
+/// already rejected it under both spellings, so no further check is owed here.
+pub(crate) fn canonicalize_tmpdir(tmpdir: Option<&str>, home: Option<&str>) -> Option<PathBuf> {
+    usable_tmpdir(tmpdir, home).and_then(|t| std::fs::canonicalize(t).ok())
+}
+
+/// `$TMPDIR`, trimmed, when the value is usable as a temp root at all:
+/// non-empty, not the filesystem root, and not covering `home`.
+///
+/// One definition rather than a repeated filter chain, because both callers
+/// below decide the same security question and a divergence between them would
+/// be a hole in exactly one of the two paths. This is the single veto for the
+/// whole `via_env` branch — gating only the branch's canonical comparand left
+/// its raw one, the one that actually fires, unguarded.
+fn usable_tmpdir<'a>(tmpdir: Option<&'a str>, home: Option<&str>) -> Option<&'a str> {
     tmpdir
         .map(str::trim)
-        .filter(|t| !t.is_empty() && *t != "/")
-        .and_then(|t| std::fs::canonicalize(t).ok())
+        .filter(|t| !t.is_empty() && *t != "/" && !tmpdir_covers_home(Path::new(t), home))
 }
 
 /// Same check as [`path_under_temp_root`], but takes an already-canonicalized
@@ -167,20 +228,18 @@ pub(crate) fn path_under_temp_root_with_canonical(
     path: &Path,
     tmpdir: Option<&str>,
     tmpdir_canonical: Option<&Path>,
+    home: Option<&str>,
 ) -> bool {
     let fixed = path.starts_with("/tmp") || path.starts_with("/private/tmp");
-    let via_env = tmpdir
-        .map(str::trim)
-        .filter(|t| !t.is_empty() && *t != "/")
-        .is_some_and(|t| {
-            // `path` (a repo root from `git rev-parse --show-toplevel`, or a
-            // resolved `rm` target) may be canonicalized (`/private/var/…` on
-            // macOS) while `$TMPDIR` is not (`/var/folders/…`) — compare
-            // against the canonicalized tmpdir too, or the match never fires
-            // on macOS.
-            path.starts_with(t)
-                || tmpdir_canonical.is_some_and(|c| c != Path::new("/") && path.starts_with(c))
-        });
+    let via_env = usable_tmpdir(tmpdir, home).is_some_and(|t| {
+        // `path` (a repo root from `git rev-parse --show-toplevel`, or a
+        // resolved `rm` target) may be canonicalized (`/private/var/…` on
+        // macOS) while `$TMPDIR` is not (`/var/folders/…`) — compare
+        // against the canonicalized tmpdir too, or the match never fires
+        // on macOS.
+        path.starts_with(t)
+            || tmpdir_canonical.is_some_and(|c| c != Path::new("/") && path.starts_with(c))
+    });
     fixed || via_env
 }
 
@@ -188,8 +247,8 @@ pub(crate) fn path_under_temp_root_with_canonical(
 /// enforcing worktree discipline on them would only produce noise. Delegates
 /// to [`path_under_temp_root`] — kept as a named alias for the enforce-worktree
 /// carve-out's readability.
-pub fn is_temp_root(repo_root: &Path, tmpdir: Option<&str>) -> bool {
-    path_under_temp_root(repo_root, tmpdir)
+pub fn is_temp_root(repo_root: &Path, tmpdir: Option<&str>, home: Option<&str>) -> bool {
+    path_under_temp_root(repo_root, tmpdir, home)
 }
 
 /// Lexically normalize `dir`'s components — resolving `.` and `..` without
@@ -338,7 +397,12 @@ pub fn would_block_here(dir: &Path) -> bool {
     };
     let repo_root_path = Path::new(&repo_root);
     let is_primary = is_primary_checkout(&repo_root);
-    let temp_root = is_temp_root(repo_root_path, std::env::var("TMPDIR").ok().as_deref());
+    let home = crate::paths::user_home_lossy_or_default();
+    let temp_root = is_temp_root(
+        repo_root_path,
+        std::env::var("TMPDIR").ok().as_deref(),
+        Some(&home),
+    );
     let snoozed = is_snoozed_now(repo_root_path);
     let allow_main_env = is_truthy(std::env::var("CADENCE_ALLOW_MAIN").ok().as_deref());
     let repo_declared = is_primary
@@ -466,13 +530,100 @@ mod tests {
 
     #[test]
     fn tmp_roots_are_temp() {
-        assert!(is_temp_root(Path::new("/tmp/scratch-repo"), None));
-        assert!(is_temp_root(Path::new("/private/tmp/fixture"), None));
+        assert!(is_temp_root(Path::new("/tmp/scratch-repo"), None, None));
+        assert!(is_temp_root(Path::new("/private/tmp/fixture"), None, None));
     }
 
     #[test]
     fn home_repo_is_not_temp() {
-        assert!(!is_temp_root(Path::new("/Users/dev/Projects/repo"), None));
+        assert!(!is_temp_root(
+            Path::new("/Users/dev/Projects/repo"),
+            None,
+            None
+        ));
+    }
+
+    // --- #569: a `$TMPDIR` that swallows home is not a temp root ---
+
+    /// `TMPDIR=$HOME` reclassified the entire home directory as disposable,
+    /// and the ALLOW consumers read that literally: `rm -rf ~/Documents` was a
+    /// silent allow. The value is refused rather than trusted.
+    #[test]
+    fn tmpdir_equal_to_home_is_not_a_temp_root() {
+        assert!(!is_temp_root(
+            Path::new("/Users/dev/Documents"),
+            Some("/Users/dev"),
+            Some("/Users/dev")
+        ));
+    }
+
+    /// One level up is worse, not better — `/Users` covers every home on the
+    /// machine.
+    #[test]
+    fn tmpdir_ancestor_of_home_is_not_a_temp_root() {
+        assert!(!is_temp_root(
+            Path::new("/Users/dev/Documents"),
+            Some("/Users"),
+            Some("/Users/dev")
+        ));
+        // Component-wise: a sibling home with a shared string prefix is not
+        // covered, so the rejection stays as narrow as it should be.
+        assert!(is_temp_root(
+            Path::new("/Users/dev-old/scratch"),
+            Some("/Users/dev-old"),
+            Some("/Users/dev")
+        ));
+    }
+
+    /// A `$TMPDIR` that only *resolves* to home — the literal strings compare
+    /// unequal, so a lexical-only check granted the carve-out and the raw
+    /// prefix test then matched every operand spelled through the symlink.
+    /// Uses real directories: the whole point is that resolution, not string
+    /// comparison, is what settles it.
+    #[test]
+    #[cfg(unix)]
+    fn tmpdir_symlinked_to_home_is_not_a_temp_root() {
+        let scratch = scratch("tmpdir-symlink-home");
+        let home = scratch.path().join("home");
+        let link = scratch.path().join("tmpdir-link");
+        std::fs::create_dir_all(home.join("Documents")).unwrap();
+        let _ = std::fs::remove_file(&link);
+        std::os::unix::fs::symlink(&home, &link).unwrap();
+
+        let home_str = home.to_str().unwrap();
+        let link_str = link.to_str().unwrap();
+        // Sanity: the two spellings really are lexically unrelated, so a
+        // lexical-only check would have granted the carve-out here.
+        assert!(!Path::new(home_str).starts_with(link_str));
+
+        assert!(
+            !is_temp_root(&link.join("Documents"), Some(link_str), Some(home_str)),
+            "a $TMPDIR that resolves to home must not earn the temp carve-out"
+        );
+    }
+
+    /// The real macOS `$TMPDIR` is nowhere near home and keeps working.
+    #[test]
+    fn macos_var_folders_tmpdir_still_honored() {
+        assert!(is_temp_root(
+            Path::new("/var/folders/xy/T/repo"),
+            Some("/var/folders/xy/T"),
+            Some("/Users/dev")
+        ));
+    }
+
+    /// Windows puts the per-user temp dir UNDER the profile directory, which
+    /// is why the rule rejects only an ancestor-or-equal of home and not
+    /// "anything under home" — the latter would kill the carve-out on Windows
+    /// outright.
+    #[test]
+    fn windows_appdata_temp_under_home_still_honored() {
+        let tmp = "C:/Users/dev/AppData/Local/Temp";
+        assert!(is_temp_root(
+            Path::new("C:/Users/dev/AppData/Local/Temp/repo"),
+            Some(tmp),
+            Some("C:/Users/dev")
+        ));
     }
 
     // --- is_claude_managed_dir / is_plan_doc_dir ---

--- a/crates/guardrails/src/enforce_worktree.rs
+++ b/crates/guardrails/src/enforce_worktree.rs
@@ -188,6 +188,10 @@ struct EnvConfig {
     kill_switch: bool,
     /// `$TMPDIR`, for the scratch-repo exemption.
     tmpdir: Option<String>,
+    /// The user's home directory, so a `$TMPDIR` that swallows it is refused
+    /// the scratch exemption rather than exempting the whole checkout tree
+    /// (cadence-hooks#569).
+    home: String,
 }
 
 impl EnvConfig {
@@ -197,6 +201,7 @@ impl EnvConfig {
             allow_main: truthy("CADENCE_ALLOW_MAIN"),
             kill_switch: truthy("CADENCE_NO_ENFORCE_WORKTREE"),
             tmpdir: std::env::var("TMPDIR").ok(),
+            home: cadence_hooks_core::paths::user_home_lossy_or_default(),
         }
     }
 }
@@ -1339,7 +1344,11 @@ fn assess_dir(
     };
     let common_dir = PathBuf::from(common_dir);
     let is_primary = is_primary_checkout(&repo_root);
-    let temp_root = is_temp_root(Path::new(&repo_root), cfg.tmpdir.as_deref());
+    let temp_root = is_temp_root(
+        Path::new(&repo_root),
+        cfg.tmpdir.as_deref(),
+        Some(&cfg.home),
+    );
     let snoozed = cadence_hooks_core::worktree::is_snoozed_in_common_dir(&common_dir);
     let repo_declared = is_primary && !cfg.allow_main && repo_allow.is_allowed(&repo_root);
     let allowed_main = cfg.allow_main || repo_declared;
@@ -1733,11 +1742,17 @@ mod tests {
         Scratch::new(&scratch_root(), tag)
     }
 
+    /// An empty `home` disables the #569 swallowed-home rule, which is what
+    /// keeps these cases testing what they were written to test. Read a pass
+    /// here as evidence about the exemption under test and nothing else — the
+    /// rule itself is covered where it lives, in `core::worktree`'s
+    /// `tmpdir_*_home_is_not_a_temp_root` tests.
     fn cfg(allow_main: bool, kill_switch: bool) -> EnvConfig {
         EnvConfig {
             allow_main,
             kill_switch,
             tmpdir: None,
+            home: String::new(),
         }
     }
 
@@ -1810,36 +1825,43 @@ mod tests {
 
     #[test]
     fn tmp_roots_are_temp() {
-        assert!(is_temp_root(Path::new("/tmp/scratch-repo"), None));
-        assert!(is_temp_root(Path::new("/private/tmp/fixture"), None));
+        assert!(is_temp_root(Path::new("/tmp/scratch-repo"), None, None));
+        assert!(is_temp_root(Path::new("/private/tmp/fixture"), None, None));
     }
 
     #[test]
     fn tmpdir_env_root_is_temp() {
         assert!(is_temp_root(
             Path::new("/var/folders/xy/T/repo"),
-            Some("/var/folders/xy/T")
+            Some("/var/folders/xy/T"),
+            None
         ));
     }
 
     #[test]
     fn home_repo_is_not_temp() {
-        assert!(!is_temp_root(Path::new("/Users/dev/Projects/repo"), None));
+        assert!(!is_temp_root(
+            Path::new("/Users/dev/Projects/repo"),
+            None,
+            None
+        ));
         // A degenerate `$TMPDIR=/` must not exempt everything.
         assert!(!is_temp_root(
             Path::new("/Users/dev/Projects/repo"),
-            Some("/")
+            Some("/"),
+            None
         ));
         assert!(!is_temp_root(
             Path::new("/Users/dev/Projects/repo"),
-            Some("")
+            Some(""),
+            None
         ));
     }
 
     #[test]
     fn temp_lookalike_is_not_temp() {
         // Path-component boundary: /tmpfoo is not under /tmp.
-        assert!(!is_temp_root(Path::new("/tmpfoo/repo"), None));
+        assert!(!is_temp_root(Path::new("/tmpfoo/repo"), None, None));
     }
 
     #[test]
@@ -1856,7 +1878,7 @@ mod tests {
         std::fs::create_dir_all(&real).unwrap();
         std::os::unix::fs::symlink(&real, &link).unwrap();
         let repo_root = std::fs::canonicalize(&real).unwrap().join("repo");
-        assert!(is_temp_root(&repo_root, Some(link.to_str().unwrap())));
+        assert!(is_temp_root(&repo_root, Some(link.to_str().unwrap()), None));
     }
 
     // --- git_commit_targets (pure parsing) ---

--- a/crates/guardrails/src/guard_rm.rs
+++ b/crates/guardrails/src/guard_rm.rs
@@ -404,6 +404,14 @@ fn collect_targets(
     let mut dir_known = cwd_known;
 
     for (segment, _next_op) in split_segments_with_ops(script) {
+        // Drop empty substitutions BEFORE any other parsing touches the
+        // segment. `strip_group_wrappers` trims trailing `)` unconditionally,
+        // so a segment ending in `$()` reached the tokenizer as a dangling
+        // `$(` — and `tokenize` splits `$( )` into two words the shell joins
+        // into one. Either way the operand arrived carrying a `$`, and
+        // `resolve_target` answered ASK for a target whose contract is BLOCK
+        // (cadence-hooks#541).
+        let segment = strip_empty_substitutions(&segment);
         let segment = strip_group_wrappers(&segment);
         let tokens = tokenize(segment);
         let argv = skip_transparent_prefixes(&tokens);
@@ -707,6 +715,17 @@ fn resolve_target(
     single_file: bool,
     caller_dereferences: bool,
 ) -> TargetToken {
+    // An EMPTY operand is not a target. `rm -rf ''` deletes nothing — the shell
+    // errors on it — and an operand left empty by `strip_empty_substitutions`
+    // was entirely an empty expansion. Neither means "the current directory",
+    // but both reach the `literal.is_empty()` bare-cwd reading below and would
+    // carry the effective directory's verdict, which from a temp cwd is a
+    // silent ALLOW. The genuine bare-cwd spellings — `*` and a literal `.` —
+    // arrive non-empty and reach that reading through `glob_literal_prefix`,
+    // so they are unaffected.
+    if operand.is_empty() {
+        return TargetToken::Unresolvable;
+    }
     // Unexpanded variable / command substitution — can't prove anything. This
     // guard (with the `..` checks below) runs AHEAD of glob detection, so an
     // unresolvable operand never masquerades as a clean file-scoped sweep.
@@ -803,6 +822,94 @@ fn resolve_target(
     }
 }
 
+/// Remove every **lexically empty** substitution from `segment`: `$()`, `$( )`,
+/// and a backtick pair enclosing nothing but whitespace.
+///
+/// An empty body expands to the empty string in every shell, so `~/Documents$()`
+/// deletes exactly `~/Documents`. Without this, the operand reached
+/// [`resolve_target`] still carrying a `$`, which answered ASK for a target
+/// whose contract is BLOCK — a downgrade bought by appending two characters
+/// (cadence-hooks#541).
+///
+/// Deleting the span reproduces what the shell does, joining included:
+/// `a$( )b` is one word `ab` there too, because field splitting applies to the
+/// (empty) expansion, not to the literal text around it.
+///
+/// **Lexically** empty is the whole rule. `$(cat f)` and `${EMPTY}` are left
+/// verbatim so they keep their `Unresolvable` verdict: resolving those would
+/// mean modelling what a command prints or what a variable holds, which this
+/// parser cannot know. Only ASCII whitespace counts as an empty body — the same
+/// characters the shell's own word splitting treats as blank.
+///
+/// Stripping can never *create* a resolvable operand out of a real
+/// substitution: only a complete empty pair is removed, delimiters included, so
+/// any surviving substitution keeps the `$` or backtick that routes it to
+/// `Unresolvable`. It removes only `$`, `(`, `)`, backticks, and whitespace, so
+/// it cannot synthesize a `/`, cannot erase a `..`, and cannot move a target
+/// into a temp root or out of a `.git` component.
+///
+/// **Quote-blind, deliberately.** This scans the raw segment with no quote
+/// state, while the shell keeps `$()` as literal filename characters inside
+/// `'…'` or after a backslash. The divergence runs strict — the guard sees a
+/// SHORTER name, which lands in the same or a more protected class
+/// (`rm -rf ~/'$()'` reads as `~/` → Block) — with one narrow exception: a
+/// shortened name can end in a transient-scratch suffix the real one does not,
+/// so `rm ~/'notes.tmp$()'` reads as `~/notes.tmp` and allows. Accepted rather
+/// than fixed: the operand has to be a hand-typed file literally named
+/// `notes.tmp$()`, and threading quote state in here would duplicate
+/// `core::shell`'s tokenizer for that one case.
+fn strip_empty_substitutions(segment: &str) -> Cow<'_, str> {
+    let mut out: Option<String> = None;
+    // Bytes already flushed into `out`, and where the next delimiter hunt
+    // starts — they diverge because a non-empty body is scanned past, not copied.
+    let mut copied = 0;
+    let mut scan = 0;
+    while let Some(rel) = segment[scan..].find(['$', '`']) {
+        let at = scan + rel;
+        if let Some(len) = empty_substitution_len(&segment[at..]) {
+            let buf = out.get_or_insert_with(|| String::with_capacity(segment.len()));
+            buf.push_str(&segment[copied..at]);
+            copied = at + len;
+            scan = copied;
+        } else {
+            scan = at + 1;
+        }
+    }
+    match out {
+        Some(mut buf) => {
+            buf.push_str(&segment[copied..]);
+            Cow::Owned(buf)
+        }
+        None => Cow::Borrowed(segment),
+    }
+}
+
+/// Byte length of the empty substitution starting at the head of `s`, if one
+/// starts there: `$(` + ASCII whitespace + `)`, or a backtick pair around the
+/// same. `None` for anything else, including a non-empty body — a
+/// conservative answer, because `None` means the operand stays unresolvable.
+fn empty_substitution_len(s: &str) -> Option<usize> {
+    let (open_len, closer) = if s.starts_with("$(") {
+        (2usize, ')')
+    } else if s.starts_with('`') {
+        (1usize, '`')
+    } else {
+        return None;
+    };
+    let body = &s[open_len..];
+    // `trim_start_matches` returns a suffix OF `body`, so the length difference
+    // is exactly that suffix's byte offset — always in range and always on a
+    // char boundary, however the operand is spelled. The slice below cannot
+    // panic on hostile input.
+    let blank = body.len()
+        - body
+            .trim_start_matches(|c: char| c.is_ascii_whitespace())
+            .len();
+    body[blank..]
+        .starts_with(closer)
+        .then_some(open_len + blank + closer.len_utf8())
+}
+
 /// True when `operand`'s final path segment is a glob that scopes to files
 /// *within* a directory rather than naming the directory itself: it contains a
 /// glob metachar (`*`/`?`/`[`), does NOT start with `.` (so `.*` — which matches
@@ -874,6 +981,23 @@ fn classify_path(path: &str, ctx: &RmContext, is_git_root: &dyn Fn(&str) -> bool
         tmpdir: ctx.tmpdir,
     };
     let shared = pathclass::classify(&norm, &pc_ctx, is_git_root);
+
+    // #576: `Temp` is a claim about where the target LIVES; a `.git` is an
+    // explicit protection the user put there. A repo checked out under `/tmp`
+    // is still a repo — the location claim loses to the marker, so the temp
+    // ALLOW does not apply and the git-repo BLOCK stands.
+    //
+    // `.claude` scratch stays ABOVE this rule: a `.claude/worktrees/` checkout
+    // is cadence's own managed scratch and its `.git` is exactly why cleanup
+    // must stay allowed. The predicate is asked directly rather than read off
+    // `shared`, because `pathclass::classify` tests temp BEFORE claude-scratch
+    // — a worktree that lives under `/tmp` arrives here reported as `Temp`.
+    if shared == PathClass::Temp
+        && !pathclass::under_claude_scratch(&norm)
+        && (has_git_component(&norm) || is_git_root(&norm))
+    {
+        return TargetClass::GitRepo;
+    }
 
     // ALLOW rules first — the shared classifier owns Temp and ClaudeScratch.
     match shared {
@@ -1582,6 +1706,70 @@ mod tests {
         assert_eq!(out, Outcome::Allow);
     }
 
+    // --- #569: a `$TMPDIR` that swallows home cannot disarm the home block ---
+
+    /// The end-to-end shape of the defect: point `$TMPDIR` at home and every
+    /// home child read as disposable temp. The protection now outlives the
+    /// widened root.
+    #[test]
+    fn home_child_blocks_under_a_widened_tmpdir() {
+        let home = home();
+        let ctx = RmContext {
+            home: &home,
+            vault: Some(VAULT),
+            tmpdir: Some(&home),
+        };
+        let out = judge_rm("rm -rf ~/Documents", "/home", &ctx, &|_| false, &|_| false).outcome;
+        assert_eq!(out, Outcome::Block);
+    }
+
+    // --- #576: an explicit protection outranks the temp carve-out ---
+
+    /// A repo checked out under `/tmp` is still a repo — the `.git` the user
+    /// put there outranks the claim that the location makes it disposable.
+    #[test]
+    fn git_repo_under_temp_blocks() {
+        assert_eq!(
+            judge_with("rm -rf /tmp/repo", "/home", &["/tmp/repo"]),
+            Outcome::Block
+        );
+    }
+
+    /// The carve-out itself is untouched: plain temp scratch with no `.git`
+    /// anywhere still allows.
+    #[test]
+    fn plain_temp_scratch_still_allows() {
+        assert_eq!(
+            judge_with("rm -rf /tmp/scratch", "/home", &[]),
+            Outcome::Allow
+        );
+    }
+
+    /// cadence's own managed scratch keeps its ALLOW even under a temp root,
+    /// where `pathclass::classify` reports it as `Temp` rather than
+    /// `ClaudeScratch` — the case a `shared != ClaudeScratch` guard would miss.
+    #[test]
+    fn claude_worktree_under_temp_still_allows() {
+        assert_eq!(
+            judge_with(
+                "rm -rf /tmp/x/.claude/worktrees/y",
+                "/home",
+                &["/tmp/x/.claude/worktrees/y"]
+            ),
+            Outcome::Allow
+        );
+    }
+
+    /// The literal-`.git`-component half of the git-root fact, which needs no
+    /// filesystem probe at all.
+    #[test]
+    fn dot_git_component_under_temp_blocks() {
+        assert_eq!(
+            judge_with("rm -rf /tmp/repo/.git", "/home", &[]),
+            Outcome::Block
+        );
+    }
+
     #[test]
     fn session_intro_allows() {
         assert_eq!(
@@ -1937,6 +2125,101 @@ mod tests {
     #[test]
     fn command_substitution_target_asks() {
         assert_eq!(judge("rm -rf $(mktemp -d)", "/home"), Outcome::Ask);
+    }
+
+    // --- #541: an empty substitution must not downgrade a protected target ---
+
+    /// `$()` and an empty backtick pair expand to nothing, so the operand still
+    /// names the protected home child — appending them was a free Block→Ask
+    /// downgrade.
+    #[test]
+    fn empty_substitution_suffix_still_blocks() {
+        for command in [
+            "rm -rf ~/Documents$()",
+            "rm -rf ~/Documents$( )",
+            "rm -rf ~/Documents``",
+            "rm -rf ~/Documents` `",
+            "rm -rf ~/$()Documents",
+        ] {
+            assert_eq!(
+                judge(command, "/private/tmp"),
+                Outcome::Block,
+                "an empty substitution expands to nothing: {command}"
+            );
+        }
+    }
+
+    /// The narrowness of the rule: a body with content resolves to a value this
+    /// parser cannot know, so it keeps its Ask verbatim.
+    #[test]
+    fn unknown_substitution_suffix_still_asks() {
+        assert_eq!(
+            judge("rm -rf ~/`cat which_dir`", "/private/tmp"),
+            Outcome::Ask
+        );
+        assert_eq!(judge("rm -rf $(mktemp -d)", "/private/tmp"), Outcome::Ask);
+    }
+
+    /// A variable is not a substitution — `${EMPTY}` names a value, and
+    /// modelling variable contents is out of scope.
+    #[test]
+    fn variable_suffix_still_asks() {
+        assert_eq!(
+            judge("rm -rf ~/Documents${EMPTY}", "/private/tmp"),
+            Outcome::Ask
+        );
+    }
+
+    /// The rail: an operand that is ALL empty substitution leaves the recursive
+    /// delete with no readable operand, which asks. It must NOT read as a bare
+    /// cwd reference and carry the effective directory's verdict.
+    #[test]
+    fn substitution_stripping_to_nothing_is_unresolvable() {
+        // `/private/tmp` is a temp root, so a cwd fall-through would ALLOW.
+        assert_eq!(judge("rm -rf $()", "/private/tmp"), Outcome::Ask);
+        assert_eq!(judge("rm -rf ``", "/private/tmp"), Outcome::Ask);
+    }
+
+    /// A QUOTED `$()` is a literal filename to the shell, not an expansion —
+    /// stripping it leaves an empty operand, which must not read as a bare cwd
+    /// reference and inherit the working directory's verdict. `/private/tmp`
+    /// is a temp root, so that fall-through would have been a silent ALLOW.
+    #[test]
+    fn an_operand_left_empty_by_stripping_is_unresolvable() {
+        for command in [
+            "rm -rf '$()'",
+            "rm -rf \"$()\"",
+            "rm -rf ''",
+            "rm -rf ``",
+            "rm -rf $()",
+        ] {
+            assert_eq!(
+                judge(command, "/private/tmp"),
+                Outcome::Ask,
+                "an empty operand names no target: {command}"
+            );
+        }
+    }
+
+    /// The genuine bare-cwd spellings still resolve to the effective directory
+    /// — they arrive non-empty and empty out via `glob_literal_prefix`, which
+    /// the empty-operand rail deliberately sits ahead of.
+    #[test]
+    fn bare_cwd_globs_still_carry_the_directorys_verdict() {
+        assert_eq!(judge("rm -rf *", "/private/tmp"), Outcome::Allow);
+        assert_eq!(judge("rm -rf .", "/private/tmp"), Outcome::Allow);
+        assert_eq!(
+            judge("cd ~/Documents && rm -rf *", "/private/tmp"),
+            Outcome::Block
+        );
+    }
+
+    /// `guard_rm_liveness`'s command-substitution probe asserts Ask by
+    /// contract — a stripping rule that widened past empty bodies would fire a
+    /// false nudge every SessionStart.
+    #[test]
+    fn liveness_probe_contract_holds() {
+        assert_eq!(judge("rm -rf $(printf %s x)", "/private/tmp"), Outcome::Ask);
     }
 
     #[test]

--- a/crates/guardrails/src/guard_rm_liveness.rs
+++ b/crates/guardrails/src/guard_rm_liveness.rs
@@ -41,12 +41,11 @@
 //! # What it deliberately does NOT probe
 //!
 //! **The git-repo Block path.** Unlike the home case, it needs a real `.git` on
-//! disk, and every writable fixture location is wrong: under the temp root the
-//! Temp classification is evaluated *first* and pre-empts the git-repo check
-//! (verified — `rm -rf /tmp/<dir-with-.git>` is a silent Allow), so a tempdir
-//! fixture would assert Block, get Allow, and nudge falsely every session. The
-//! alternative — writing a fixture outside the temp roots at every SessionStart
-//! — is a worse hazard than the gap it would close.
+//! disk, and none of the four probes may write one. A tempdir fixture is now
+//! classifiable — since #576 an explicit `.git` outranks the temp carve-out, so
+//! `rm -rf /tmp/<dir-with-.git>` Blocks rather than allowing — but creating and
+//! removing a repo at every SessionStart is a worse hazard than the gap it would
+//! close, and a fixture outside the temp roots is worse still.
 //!
 //! # What it structurally CANNOT see
 //!
@@ -130,14 +129,14 @@ const HOME_PROBE_BASENAME: &str = "cadence-guard-rm-liveness-probe";
 /// same as a real one. (The git-repo Block case is *not* reachable; see the
 /// module header.)
 ///
-/// It is also the probe that catches the widest real degradation. `guard-rm`
-/// resolves its temp roots partly from `$TMPDIR`, and a `$TMPDIR` pointing at a
-/// directory that contains real work silently converts that whole subtree to
-/// "disposable": with `TMPDIR` set to the home directory, `rm -rf ~/Documents`
-/// is a **silent Allow** (verified). The three probes above all still pass in
-/// that state, because none of their operands falls under the widened root —
-/// so without this one the check would report healthy while home protection was
-/// gone. Filed separately as a `guard-rm` defect; this probe is the detection.
+/// It is also the probe that catches the widest real degradation: home
+/// protection failing while the other three probes still pass, because none of
+/// their operands falls under home. The instance it was written for — a
+/// `$TMPDIR` pointing at the home directory, which converted that whole subtree
+/// to "disposable" and made `rm -rf ~/Documents` a silent Allow — is fixed at
+/// the source (cadence-hooks#569: a `$TMPDIR` that is home, or an ancestor of
+/// it, is refused the temp carve-out). The probe stays because the failure
+/// *class* is what it watches, not that one instance.
 ///
 /// Returns `None` when the home directory cannot be resolved, so the probe is
 /// skipped rather than failed — an unresolvable home is this check's own blind
@@ -330,13 +329,17 @@ mod tests {
     }
 
     #[test]
-    fn widened_tmpdir_that_swallows_home_is_caught() {
-        // The finding this probe exists for. guard-rm resolves temp roots partly
-        // from $TMPDIR; pointing TMPDIR at the home directory reclassifies that
-        // whole subtree as disposable, and `rm -rf ~/<anything>` becomes a
-        // silent Allow. The other three probes all still pass in that state —
-        // none of their operands falls under the widened root — so this asserts
-        // the check as a whole goes loud, not merely that one probe flips.
+    fn widened_tmpdir_no_longer_disarms_the_home_block() {
+        // This probe was added to DETECT the #569 degradation: guard-rm resolved
+        // its temp roots partly from $TMPDIR, so pointing TMPDIR at the home
+        // directory reclassified that whole subtree as disposable and
+        // `rm -rf ~/<anything>` became a silent Allow. #569 fixed it at the
+        // source — a $TMPDIR that is home, or an ancestor of it, is refused the
+        // temp carve-out — so the check is now correctly SILENT in that state.
+        //
+        // The probe itself is not obsolete: it still fails loudly if home
+        // protection regresses by any other route. This test pins the fix; the
+        // probe covers the rest.
         let home = std::env::var("HOME").or_else(|_| std::env::var("USERPROFILE"));
         let Ok(home) = home else {
             return; // no resolvable home on this platform; the probe self-skips
@@ -351,12 +354,8 @@ mod tests {
                 let result = GuardRmLiveness.run(&make_session("s1", "startup"));
                 assert_eq!(
                     result.outcome,
-                    Outcome::Nudge,
-                    "a TMPDIR that swallows $HOME must not read as healthy"
-                );
-                assert!(
-                    result.message.unwrap().contains("home directory"),
-                    "the nudge must name the home-directory probe as the diverging one"
+                    Outcome::Allow,
+                    "a TMPDIR that swallows $HOME no longer degrades guard-rm (#569)"
                 );
             },
         );


### PR DESCRIPTION
Three guard-rm verdict-widening fixes, one PR — every change moves verdicts toward Block, never toward Allow.

- **#541** — a lexically-empty substitution (`$()`, empty backticks) no longer downgrades Block to Ask: `strip_empty_substitutions` removes provably-empty bodies before classification, with rails (stripping-to-empty stays Unresolvable; non-empty bodies keep their Ask verbatim). `${EMPTY}` and `` `true` `` deliberately stay Ask — resolving them means modeling variable/command values, the widening class that was rejected three times on #428.
- **#569** — a `$TMPDIR` that equals or covers `$HOME` no longer grants the temp carve-out. The covers-home veto gates the whole `via_env` branch on both the raw and canonicalized values (security review caught the raw-branch gap: a symlinked `TMPDIR=/scratch -> $HOME` or case-differing `/users/dev` on APFS previously still swallowed home). Shared-predicate blast radius is in the safe direction (more blocks in enforce-worktree; fixture relocation covered by the suite).
- **#576** — a git repo under a temp root now Blocks: explicit protection outranks the location claim, guard-locally (pathclass precedence untouched); `.claude/worktrees/` disposability still wins. The stale liveness doc-comments describing the old ordering are corrected in the same diff.

Security review ran on the diff (independent adversarial pass): one Important finding (the raw-branch veto gap above) — fixed in `be0ec14`; the `.GIT` case-fold nit filed separately as cameronsjo/cadence-hooks#657. No Cargo.toml bump — the 0.76.0 chore PR ships after the batch.

Known machine-local reds excluded from the gate (fail identically at clean origin/main): pending_wiring_hooks_are_still_unwired, all_binary_subcommands_are_registered.

Closes cameronsjo/cadence-hooks#576
Closes cameronsjo/cadence-hooks#569
Closes cameronsjo/cadence-hooks#541

Session-Name: tidal-ballad
Session-Id: 6bff6f72-e4d7-4e6f-9e7a-8df28d520b1f
Model: claude-fable-5
Harness: claude-code 2.1.226
Machine: cf6e768835c7
