### PR TITLE
chore: release 0.76.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.76.0] - 2026-08-12
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "cadence-hooks-core",
  "glob",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -241,11 +241,11 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.75.1"
+version = "0.76.0"
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.75.1"
+version = "0.76.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-guardrails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.75.1"
+version = "0.76.0"
 edition = "2024"
 license-file = "LICENSE"
 authors = ["Cameron Sjo"]

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "binaryVersion": "0.75.1",
+  "binaryVersion": "0.76.0",
   "minimumCodexVersion": "0.145.0",
   "privacy": {
     "rawHookInputsPersisted": false,


### PR DESCRIPTION
Bundles [#674](https://github.com/cameronsjo/cadence-hooks/pull/674), [#675](https://github.com/cameronsjo/cadence-hooks/pull/675), [#676](https://github.com/cameronsjo/cadence-hooks/pull/676). Version bump + Cargo.lock + codex report regenerated against the plugin workspace + CHANGELOG stamped. The two new guard subcommands stay `applicable: false` until their cadence wiring merges — the doctor CI gate validates wiring against the latest release, so this release precedes the wiring merge ([cadence#947](https://github.com/cameronsjo/cadence/pull/947) waits on it).

Session-Name: frost-anchor
Session-Id: 1322f0d3-8e45-49be-b07c-217268925560
Model: claude-fable-5
Harness: claude-code 2.1.227
Machine: cf6e768835c7