### PR TITLE
chore: post-wiring housekeeping — pending entries out, cross-plugin sanctions in, codex flip

### DIFF
--- a/config/codex-compatibility.json
+++ b/config/codex-compatibility.json
@@ -68,14 +68,6 @@
       "status": "unavailable",
       "applicable": false,
       "evidence": "Codex does not expose Claude ExitPlanMode approval events"
-    },
-    "nudge-plan-tick": {
-      "applicable": false,
-      "evidence": "registered in the binary but not yet invoked: the cadence PostToolUse:Bash wiring ships in a companion monorepo PR (cameronsjo/cadence-hooks#671 Task 4). Flip to applicable when that wiring merges."
-    },
-    "warn-plan-ready-flip": {
-      "applicable": false,
-      "evidence": "registered in the binary but not yet invoked: the cadence PreToolUse:Bash wiring ships in a companion monorepo PR (cameronsjo/cadence-hooks#671 Task 4). Flip to applicable when that wiring merges."
     }
   },
   "capabilities": [

--- a/crates/core/src/markers.rs
+++ b/crates/core/src/markers.rs
@@ -405,7 +405,9 @@ const DEDUPE_TTL: Duration = Duration::from_secs(30);
 /// PostToolUse hook would collapse two events that shared a payload but
 /// returned different results — response-blind by construction.
 pub const DEDUPE_ELIGIBLE_HOOKS: &[&str] = &[
-    "nudge-polish-before-pr",
+    // nudge-polish-before-pr left this list when cadence#912 consolidated its
+    // overlapping registrations to one coarse if-filter — no fan-out remains
+    // to dedupe (cameronsjo/cadence-hooks#673 hygiene).
     "redact-external-content",
     "warn-overshare",
 ];

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1666,9 +1666,17 @@
       "plugin": "session",
       "protected": false,
       "status": "native",
-      "applicable": false,
-      "evidence": "registered in the binary but not yet invoked: the cadence PostToolUse:Bash wiring ships in a companion monorepo PR (cameronsjo/cadence-hooks#671 Task 4). Flip to applicable when that wiring merges.",
-      "wiring": []
+      "applicable": true,
+      "evidence": "tests/hook_registration_audit.rs",
+      "wiring": [
+        {
+          "plugin": "cadence",
+          "event": "PostToolUse",
+          "matcher": "Bash",
+          "if": "Bash(*git commit*)",
+          "commandHash": "1e75fe857ef769eb6fa6913a4b0182dc76d2b27e5cac73195e7fecc404859eb1"
+        }
+      ]
     },
     {
       "criticality": "workflow",
@@ -1678,9 +1686,24 @@
       "plugin": "session",
       "protected": false,
       "status": "native",
-      "applicable": false,
-      "evidence": "registered in the binary but not yet invoked: the cadence PreToolUse:Bash wiring ships in a companion monorepo PR (cameronsjo/cadence-hooks#671 Task 4). Flip to applicable when that wiring merges.",
-      "wiring": []
+      "applicable": true,
+      "evidence": "tests/hook_registration_audit.rs",
+      "wiring": [
+        {
+          "plugin": "cadence",
+          "event": "PreToolUse",
+          "matcher": "Bash",
+          "if": "Bash(*gh pr ready*)",
+          "commandHash": "da7c944a9132d454f0a28da012aa4c1277da8a72191fe0e06754e01b086b4e3b"
+        },
+        {
+          "plugin": "cadence",
+          "event": "PreToolUse",
+          "matcher": "Bash",
+          "if": "Bash(*gh pr merge*)",
+          "commandHash": "da7c944a9132d454f0a28da012aa4c1277da8a72191fe0e06754e01b086b4e3b"
+        }
+      ]
     }
   ]
 }

--- a/src/dispatch.rs
+++ b/src/dispatch.rs
@@ -675,23 +675,19 @@ mod tests {
     /// The #472 regression fixture: one multi-command Bash call, registered
     /// under overlapping `if:` globs that each match a different segment
     /// (`git commit`, `git push`, `gh pr create`), spawns three processes with
-    /// identical payloads — and must produce exactly ONE emission.
+    /// identical payloads — and must produce exactly ONE emission. The fixture
+    /// hook is `warn-overshare` — a hook still on `DEDUPE_ELIGIBLE_HOOKS` with
+    /// genuinely overlapping registrations (`nudge-polish-before-pr` left the
+    /// list when cadence#912 consolidated its wiring).
     #[test]
     fn dedupe_collapses_a_multi_command_fan_out_to_one_emission() {
         let tmp = tempfile::tempdir().unwrap();
         cadence_hooks_core::test_builders::with_marker_dir(tmp.path(), || {
             let input = fanout_input("git commit -m 'ship it' && git push && gh pr create --fill");
-            let nudge = CheckResult::nudge("polish before opening the PR");
+            let nudge = CheckResult::nudge("possible overshare in the outgoing content");
 
             let emissions = (0..3)
-                .filter(|_| {
-                    claim_emission(
-                        &nudge,
-                        &input,
-                        HookEvent::PreToolUse,
-                        "nudge-polish-before-pr",
-                    )
-                })
+                .filter(|_| claim_emission(&nudge, &input, HookEvent::PreToolUse, "warn-overshare"))
                 .count();
 
             assert_eq!(

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -258,18 +258,7 @@ const PENDING_PLUGIN_GROUPS: &[(&str, &str)] = &[];
 /// binary so the wiring PR has something to point at, and reaching no event
 /// until that PR lands.
 /// (`<plugin> <subcommand>`, tracking_reference)
-const PENDING_WIRING_HOOKS: &[(&str, &str)] = &[
-    (
-        "guardrails inject-gh-write-context",
-        "cameronsjo/cadence#653",
-    ),
-    ("guardrails guard-rm-liveness", "cameronsjo/cadence#760"),
-    ("session nudge-plan-tick", "cameronsjo/cadence-hooks#671"),
-    (
-        "session warn-plan-ready-flip",
-        "cameronsjo/cadence-hooks#671",
-    ),
-];
+const PENDING_WIRING_HOOKS: &[(&str, &str)] = &[];
 
 /// Bash-matcher hooks that intentionally inspect every command (no `if` filter).
 /// These run broad pattern matching internally and can't be narrowed to a single glob.
@@ -300,6 +289,19 @@ const INTENTIONAL_CROSS_PLUGIN_HOOKS: &[(&str, &str, &str)] = &[
         "session persist-plan-approval",
         "must ride the always-on cadence plugin; `session` is its clap namespace",
     ),
+    // Same rationale again: the living-plan guards (cameronsjo/cadence-hooks#675,
+    // wired in cameronsjo/cadence#947) ride the always-on cadence plugin while
+    // `session` owns plan/session state.
+    (
+        "cadence",
+        "session nudge-plan-tick",
+        "must ride the always-on cadence plugin; `session` is its clap namespace",
+    ),
+    (
+        "cadence",
+        "session warn-plan-ready-flip",
+        "must ride the always-on cadence plugin; `session` is its clap namespace",
+    ),
     // Predates the monorepo consolidation (present in canon's manifest at the
     // subtree-add commit f61b5f6), canon is its only registrar anywhere, and it
     // sits in canon's SessionStart block beside `session start` and `session
@@ -328,7 +330,6 @@ const INTENTIONAL_CROSS_PLUGIN_HOOKS: &[(&str, &str, &str)] = &[
 /// developer's working tree, whose freshness varies, so pinning exact
 /// multiplicities would fail on checkout drift rather than on real drift.
 const KNOWN_DUPLICATE_REGISTRATIONS: &[&str] = &[
-    "cadence nudge-polish-before-pr",
     "cadence redact-external-content",
     "cadence warn-overshare",
     "guardrails guard-op-vault-scan",


### PR DESCRIPTION
Follow-through on the living-plan guards wiring ([cadence#947](https://github.com/cameronsjo/cadence/pull/947)) plus the cheap half of #673 (allowlist hygiene; `inject-gh-context` retirement stays on the issue). Report regenerated against cadence main with the wiring; `--check` green. Local cross-sibling audit shows one expected transient (`warn-plan-ready-flip` 2x) until [cadence#954](https://github.com/cameronsjo/cadence/pull/954) merges, and #673's `inject-gh-context` residue.

Session-Name: frost-anchor
Session-Id: 1322f0d3-8e45-49be-b07c-217268925560
Model: claude-fable-5
Harness: claude-code 2.1.227
Machine: cf6e768835c7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enabled native handling for plan-tick and PR-readiness session notifications.
  * Improved hook registration and deduplication behavior.
  * Updated advisory messaging for multi-command notifications.

* **Tests**
  * Expanded audit coverage for session hook wiring.
  * Removed obsolete registration exceptions and updated regression checks.

* **Documentation**
  * Updated compatibility reporting with wiring details and audit evidence.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->