### PR TITLE
fix(ci): skew gate extracts the exact tag's tarball

### DIFF
--- a/.github/workflows/plugin-hooks-skew.yml
+++ b/.github/workflows/plugin-hooks-skew.yml
@@ -39,7 +39,13 @@ jobs:
           # failing every hooks-touching cadence PR in ~5s).
           gh release download "$tag" --repo cameronsjo/cadence-hooks \
             --pattern "*linux-x86_64.tar.gz" --dir /tmp/ch --clobber
-          tar -xzf /tmp/ch/*linux-x86_64.tar.gz -C /tmp/ch
+          # Exact filename, never a glob: /tmp/ch survives between runs on the
+          # self-hosted runner, so after a version rollover TWO tarballs match
+          # *linux-x86_64.tar.gz and tar reads the older one as the archive
+          # with the newer one as a member name ("Not found in archive" —
+          # observed on the first rollover after the --clobber fix, v0.75.1 ->
+          # v0.76.0, 2026-08-12).
+          tar -xzf "/tmp/ch/cadence-hooks-${tag}-linux-x86_64.tar.gz" -C /tmp/ch
           bin="$(find /tmp/ch -type f -name cadence-hooks | head -n1)"
           mkdir -p "$HOME/.local/bin"
           install -m 0755 "$bin" "$HOME/.local/bin/cadence-hooks"


### PR DESCRIPTION
First-rollover bug in the reusable skew gate: `/tmp/ch` survives between runs on the self-hosted runner (the --clobber fix documented that), so after v0.75.1 → v0.76.0 two tarballs match `*linux-x86_64.tar.gz` — tar reads the older as the archive and passes the newer as a member name (`Not found in archive`), failing [cadence#954](https://github.com/cameronsjo/cadence/pull/954)'s doctor job. Extract by exact `cadence-hooks-${tag}-linux-x86_64.tar.gz` instead. Callers bump their SHA pin after this merges.

Session-Name: frost-anchor
Session-Id: 1322f0d3-8e45-49be-b07c-217268925560
Model: claude-fable-5
Harness: claude-code 2.1.227
Machine: cf6e768835c7