### PR TITLE
docs(plans): flip the #690 plan to done; record the #699 escape as a deviation

### DIFF
--- a/docs/plans/2026-08-14-persist-plan-row-idempotency.md
+++ b/docs/plans/2026-08-14-persist-plan-row-idempotency.md
@@ -1,6 +1,6 @@
 ---
-status: in-progress
-next: PR cadence-hooks#693 review + merge (Cameron), then post-merge re-pin verify on sjomba
+status: done
+next: none — shipped in v0.77.0; the session-keying escape was fixed separately as #699 (v0.78.0)
 branch: plan/690-persist-plan-row-idempotency
 approved_in: 7afe614c-d777-40a3-a059-91ba088c0026
 approved_session_id: 7afe614c-d777-40a3-a059-91ba088c0026
@@ -60,7 +60,7 @@ Add a **tier-0 row check** to the late-scan path, and stop inventing directories
   - must-stay-green: `canonical_plans_dir_refuses_a_symlinked_docs_escaping_the_repo`, `run_persist_plan_never_writes_through_a_symlinked_docs_escaping_the_repo` (containment across the variant split)
 - [x] **Gates** — `make ci` (the repo's named gate); if running pieces directly, `cargo test --workspace --no-fail-fast`, `cargo clippy`, `cargo fmt --check`. CHANGELOG entry per repo convention.
 - [x] **Polish + PR** — diff-based review arms (session cwd is the meta-repo; built-in `/polish` arms no-op on worktree diffs), `cadence:redaction` pre-post, PR body: `Fixes #690`, producer tuple (squash-merge repo), public refs only.
-- [ ] **Close the loop** — comment on #690 naming the fix shape + the accepted residual; after merge, verify the re-pin on sjomba and confirm this very session's transcript (which still carries the injected `planContent`) no longer re-persists.
+- [x] **Close the loop** — comment on #690 naming the fix shape + the accepted residual; after merge, verify the re-pin on sjomba and confirm this very session's transcript (which still carries the injected `planContent`) no longer re-persists.
 
 ## Alternatives declined
 
@@ -87,4 +87,5 @@ Solo (single-file Rust change requiring judgment about check ordering; not dispa
 ## Deviations
 
 - Local `make ci` carried three machine-local reds, all attributed off-branch before shipping: `codex_coverage` ×2 (ambient `CADENCE_DISABLE=guard-rm` — green under `env -u`), `hook_registration_audit` (`inject-gh-context` awaits monorepo wiring; CI skips the sibling audit), `doctor_quiet_warnings_print_summary_to_stdout` (fails on pristine `origin/main` on this machine too). GitHub CI: both legs green.
-- Polish security arm raised one Important (advisory, not applied): a *forged* `plan-links.jsonl` row suppresses persists silently — same silent-skip decision the plan's declined-findings section already records; suggested observability record left to Cameron's disposition.
+- Post-ship: the session-keying this plan's panel folded in re-opened the loop at every /clear restart — fixed as #699 (PR #700, v0.78.0): the row now matches body_sha256 + machine digest, no session conjunct. The "eliminated by session-keying" claim in Context was wrong in the field.
+- Polish security arm raised one Important (advisory, filed as #695): a *forged* `plan-links.jsonl` row suppresses persists silently — same silent-skip decision the plan's declined-findings section already records; suggested observability record left to Cameron's disposition.


### PR DESCRIPTION
Index repair: PR #693 merged and v0.77.0/v0.78.0 shipped, but the plan doc on main still read in-progress. Ticks the close-the-loop box, sets status: done, and records the #699 session-keying escape in Deviations.

Session-Name: tidal-anchor
Session-Id: f7964916-08bc-49a1-a75c-f107b3b3001a
Model: claude-fable-5
Harness: claude-code 2.1.232
Machine: cf6e768835c7

🤖 Generated with [Claude Code](https://claude.com/claude-code)