### PR TITLE
chore: release 0.79.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
-## [Unreleased]
+## [0.79.0] - 2026-08-16
 
 ### Added
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "cadence-hooks-core",
  "glob",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -241,11 +241,11 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.78.0"
+version = "0.79.0"
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.78.0"
+version = "0.79.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-guardrails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.78.0"
+version = "0.79.0"
 edition = "2024"
 license-file = "LICENSE"
 authors = ["Cameron Sjo"]

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "binaryVersion": "0.78.0",
+  "binaryVersion": "0.79.0",
   "minimumCodexVersion": "0.145.0",
   "privacy": {
     "rawHookInputsPersisted": false,


### PR DESCRIPTION
Release train for 0.79.0 — checkout-freshness plan's Part B (checkout-staleness line in `session start`), including the sanitize-field security fix from cadence-hooks#698's independent review.

Version bump + regenerated `docs/codex-compatibility-report.json` (explicit `--workspace` from a worktree, verified `--check` clean) + CHANGELOG stamp. `make ci`: fmt/clippy clean, session-crate tests 389 passed; `codex_coverage`/`hook_registration_audit` fail locally for the documented pre-existing/unrelated reasons (sibling-checkout drift, not this branch).