### PR TITLE
docs(guard-rm-liveness): drop stale operator-settings claims from module doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **`guard_rm_liveness`'s module doc dropped a stale claim about the operator's `permissions.allow`/`deny` rows.** It named `Bash(rm:*)` as always in `allow` and `deny` as covering only `/` and `/var/log` — a per-machine, per-date settings snapshot presented as a fixed fact. Reworded to note the blocks drift instead of asserting their current contents.
+
 ## [0.80.0] - 2026-08-16
 
 ### Added

--- a/crates/guardrails/src/guard_rm_liveness.rs
+++ b/crates/guardrails/src/guard_rm_liveness.rs
@@ -7,9 +7,9 @@
 //! `Bash(rm -r:*)`) sat under `guard-rm` as a belt: if the guard did not run,
 //! the settings row still prompted. Those rows were retired because they had no
 //! filesystem awareness — they fired on deletes `guard-rm` had already proven
-//! safe. `Bash(rm:*)` remains in `allow`, and `deny` covers only `/` and
-//! `/var/log`, so with the belt gone a `guard-rm` that silently fails to run
-//! means `rm -rf` executes with no prompt anywhere.
+//! safe. What the operator's `allow`/`deny` blocks contain is a per-machine,
+//! per-date snapshot that drifts, so with the belt gone a `guard-rm` that
+//! silently fails to run can mean `rm -rf` executes with no prompt anywhere.
 //!
 //! That failure is invisible by construction: [`Outcome::Allow`] is a silent
 //! exit 0 and only denials reach `denials.jsonl`, so "guard-rm inspected this


### PR DESCRIPTION
The module doc still asserted `Bash(rm:*)` sits in `allow` and `deny` covers only `/` and `/var/log` — both false since the 2026-08-12 settings change. Replaced with the durable framing: operator allow/deny contents are a per-machine, per-date snapshot that drifts. Doc-comment-only; the liveness mechanism is untouched.

Closes #686

```text
Session-Name: three-item-batch-agent-move-gambit-versioning
Session-Id: bc99ac0f-ddad-4038-a0ae-f81ad2798279
Model: claude-sonnet-5 (impl-686 Stage B; Fable orchestrator)
Harness: claude-code 2.1.234
Machine: cf6e768835c7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that retired permission prompts covered deletes already validated by `guard-rm`.
  * Documented that a silently skipped guard may allow `rm -rf` to run without prompting.
  * Updated the unreleased changelog to note that permission allow/deny blocks can drift across machines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->