### PR TITLE
chore: release 0.81.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.81.0] - 2026-08-20
+
 ### Added
 
 - **New `cadence warn-changelog-entry` nudge-only check**: fires on the same ship anchors as `warn-docs-update` (`gh pr create`/`ready`/bare `merge`) and flags a shipped branch that touched code but not the `CHANGELOG.md` its repo class owns — a plugin's own `plugins/<name>/CHANGELOG.md` in a monorepo, or the root `CHANGELOG.md` otherwise. Silent in a repo tracking no changelog at all. Opt out via `CADENCE_DISABLE=warn-changelog-entry` (cameronsjo/cadence-hooks#730).

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cadence-hooks-core",
  "glob",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -241,11 +241,11 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.80.0"
+version = "0.81.0"
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.80.0"
+version = "0.81.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-guardrails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.80.0"
+version = "0.81.0"
 edition = "2024"
 license-file = "LICENSE"
 authors = ["Cameron Sjo"]

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "binaryVersion": "0.80.0",
+  "binaryVersion": "0.81.0",
   "minimumCodexVersion": "0.145.0",
   "privacy": {
     "rawHookInputsPersisted": false,


### PR DESCRIPTION
Version bump + CHANGELOG roll-up for v0.81.0. On merge, auto-tag tags the Cargo.toml change and the release workflow builds, attests, and dispatches homebrew.

Rolls in: warn-changelog-entry check (#730), guard-rm case-fold + secret-glob nudge (#732, #344), warn-issue-tracker owner scoping (#727), persist-plan idempotency layers, backtick-parser tail fix, LoopBlock retirement, doctor marker isolation, codex-report partial-wipe guard.

Release-shape precedent: #710 (0.80.0) — same four files, one commit.

Session-Name: three-item-batch-agent-move-gambit-versioning
Session-Id: bc99ac0f-ddad-4038-a0ae-f81ad2798279
Model: claude-fable-5
Harness: claude-code 2.1.234
Machine: cf6e768835c7

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release**
  - Released version 0.81.0, dated August 20, 2026.
  - Updated the documented application and compatibility versions to 0.81.0.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->