### PR TITLE
fix(session): persist-plan-approval merges plan frontmatter + CADENCE_NO_PERSIST_PLAN; remove the persist-plan UPS arm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,16 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Removed
 
+- **`session persist-plan` (the UserPromptSubmit re-scan arm) and `CADENCE_PERSIST_PLAN_FORCE`.** It re-fired every prompt holding the RAW approved plan text, which is stale the moment a plan starts living — so it wrote raw duplicate siblings (cameronsjo/cadence-hooks#703, #724, #729), stamped a second frontmatter block over a ticked plan (#738), and wrote into primary checkouts (#739); three rounds of on-disk recognition heuristics could not track a document that drifts away from every hash by design. `session persist-plan-approval` (PostToolUse:ExitPlanMode) is the sole writer now; when no approval-time persist happened (the approve-and-clear path), the cadence rules' copy rule is the fallback. The `plan-skips.jsonl` stream dies with the arm. Unwired first in cameronsjo/cadence#1025.
+
+### Fixed
+
+- **`session persist-plan-approval` merges into a plan's own leading frontmatter instead of stacking a second block on top (cameronsjo/cadence-hooks#738).** A template-authored plan already opens with `status:`/`next:`/`branch:`; the hook used to prepend its own `---` block, so SessionStart and outro read the hook's `status: "in-flight"` / `branch:` forever. The written file now carries ONE block — the plan's lines byte-for-byte, then the hook-owned provenance keys, with `status`/`updated`/`branch` suppressed when the plan's block already declares them. Plan content stays untrusted: the only interpretation is the existing fence scan plus a column-0 `key:` read.
+
+### Added
+
+- **`CADENCE_NO_PERSIST_PLAN` opts out of `session persist-plan-approval` (cameronsjo/cadence-hooks#692).** Any non-empty value, from the process environment or the repo's `.claude/settings.local.json` / `.claude/settings.json` `env` block (the `CADENCE_ALLOW_MAIN` precedent), skips the persist entirely — no file, no `plan-links.jsonl` row, exit 0. Advisory tier. The four plan guards and the SessionStart plan scanner are not covered by this flag.
+
 - **`guardrails warn-subagent-concurrency` and its `CADENCE_MAX_CONCURRENT_SUBAGENTS` cap.** The nudge guessed at an observed server-side throttle; Claude Code now documents the real caps (`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` = 20 concurrent, 200 spawns per session), so the guard was dead weight. The `cadence-guardrails` wiring left first (cameronsjo/cadence, `chore/remove-warn-subagent-concurrency`); `run-cadence-hooks.sh` fails open on the unknown subcommand for any binary/plugin skew in between.
 
 ## [0.81.0] - 2026-08-20

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -87,9 +87,7 @@ impl HookEvent {
                 r#"{"tool_name":"Edit","tool_input":{"file_path":"src/main.rs"},"tool_response":{"stdout":"ok"}}"#
             }
             HookEvent::SessionStart => r#"{"session_id":"test","source":"startup"}"#,
-            // Exercises the persist-plan prefix gate — a prompt shaped like the
-            // approve-and-clear re-injection (see `session persist-plan`).
-            HookEvent::UserPromptSubmit => r#"{"prompt":"Implement the following plan:\n\ntest"}"#,
+            HookEvent::UserPromptSubmit => r#"{"prompt":"test prompt"}"#,
         }
     }
 }
@@ -3044,15 +3042,10 @@ mod tests {
     }
 
     #[test]
-    fn user_prompt_submit_sample_exercises_the_persist_plan_prefix_gate() {
+    fn user_prompt_submit_sample_carries_a_prompt() {
         let input: HookInput =
             serde_json::from_str(HookEvent::UserPromptSubmit.sample_payload()).unwrap();
-        assert!(
-            input
-                .prompt()
-                .is_some_and(|p| p.starts_with("Implement the following plan:")),
-            "sample should exercise the persist-plan prefix gate"
-        );
+        assert!(input.prompt().is_some_and(|p| !p.is_empty()));
     }
 
     #[test]

--- a/crates/core/src/time.rs
+++ b/crates/core/src/time.rs
@@ -26,7 +26,7 @@ pub fn utc_timestamp() -> String {
 /// Current LOCAL calendar date, `%Y-%m-%d` (e.g. `2026-07-20`).
 ///
 /// Distinct from [`utc_timestamp`]: filenames that carry a date (e.g. the
-/// `docs/plans/YYYY-MM-DD-<slug>.md` convention `session persist-plan` writes
+/// `docs/plans/YYYY-MM-DD-<slug>.md` convention `session persist-plan-approval` writes
 /// into) use the author's local calendar day, matching every hand-authored
 /// plan file — a UTC-derived date would occasionally be a day off from what
 /// the session experienced. `Zoned::now()` resolves the system time zone,

--- a/crates/metrics/src/lib.rs
+++ b/crates/metrics/src/lib.rs
@@ -57,7 +57,7 @@ pub mod warn_stale;
 /// The metrics root directory (`CADENCE_METRICS_DIR`, else
 /// `<config_dir>/metrics`) — the single source of truth every stream's
 /// writer resolves against. Re-exported so a JSONL append living outside
-/// this crate (e.g. `session persist-plan`'s `plan-links.jsonl`) reuses the
+/// this crate (e.g. `session persist-plan-approval`'s `plan-links.jsonl`) reuses the
 /// resolution instead of re-deriving it.
 pub use common::metrics_dir;
 

--- a/crates/session/src/lib.rs
+++ b/crates/session/src/lib.rs
@@ -30,7 +30,6 @@
 //! | `end`               | SessionEnd   | [`end`]         |
 //! | `backstop-record`   | SessionEnd   | [`backstop`]    |
 //! | `backstop-warn`     | SessionStart | [`backstop`]    |
-//! | `persist-plan`      | UserPromptSubmit | [`persist_plan`] |
 //! | `persist-plan-approval` | PostToolUse | [`persist_plan`] |
 
 /// Outro "no loose ends" backstop: SessionEnd records loose ends, SessionStart warns (#123).

--- a/crates/session/src/persist_plan.rs
+++ b/crates/session/src/persist_plan.rs
@@ -267,11 +267,15 @@ pub fn run_persist_plan_approval(
 }
 
 /// Has this repo or session opted out of the persist (cadence-hooks#692)?
-/// `CADENCE_NO_PERSIST_PLAN` with any non-empty value, read from the process
-/// environment first and then from the repo's `.claude/settings.local.json` /
-/// `.claude/settings.json` `env` block — the same two sources and the same
-/// untrusted-config reader `CADENCE_ALLOW_MAIN` uses. Advisory tier: no
-/// `PROTECTED_GUARDS` treatment, no audit row on the skip.
+/// `CADENCE_NO_PERSIST_PLAN` with any non-empty value — the `CADENCE_NO_*`
+/// family's convention (`CADENCE_NO_OUTRO_BACKSTOP`, `CADENCE_NO_FEEDBACK_FOOTER`),
+/// so `"0"`/`"false"` DO opt out; unset or empty to re-enable — read from the
+/// process environment first and then from the repo's
+/// `.claude/settings.local.json` / `.claude/settings.json` `env` block, the
+/// same two sources and the same untrusted-config reader `CADENCE_ALLOW_MAIN`
+/// uses. Advisory tier: no `PROTECTED_GUARDS` treatment, no audit row on the
+/// skip — the flag is the operator's own choice about an advisory write, not
+/// a bypass of a block.
 fn persist_plan_opted_out(repo_root: &Path) -> bool {
     std::env::var("CADENCE_NO_PERSIST_PLAN").is_ok_and(|v| !v.is_empty())
         || cadence_hooks_core::config::repo_env_flag(repo_root, "CADENCE_NO_PERSIST_PLAN")
@@ -816,24 +820,40 @@ fn hook_frontmatter_lines(f: &FrontmatterFields, plan_keys: &[&str]) -> Vec<Stri
     lines
 }
 
-/// The top-level keys a plan's own frontmatter block declares — the bare
-/// `key` of every `key:` line at column 0. Byte-level, deliberately: the
-/// block is untrusted plan content, and this is the ONLY interpretation
-/// [`render_document`] makes of it (which hook defaults to suppress). Nested
-/// or indented keys, comments, and anything that is not `ident:` at column 0
-/// are ignored.
+/// The frontmatter keys this hook owns: the persist's provenance, which a
+/// plan's own block must never be able to pre-empt. [`render_document`] drops
+/// any plan line declaring one of these (and emits its own lines FIRST), so
+/// a first-match line reader (`file_matches_body`, `plan_scan`) and a
+/// last-wins YAML parser agree on the provenance of the written file.
+const HOOK_OWNED_KEYS: [&str; 8] = [
+    "body_sha256",
+    "session",
+    "session_id",
+    "model",
+    "harness",
+    "machine",
+    "approved_in",
+    "approved_session_id",
+];
+
+/// The bare `key` of a `key:` line at column 0, or `None` for anything else
+/// (an indented/nested key, a comment, a continuation line, prose). Byte-level,
+/// deliberately: a plan's frontmatter block is untrusted content, and this is
+/// the ONLY interpretation [`render_document`] makes of it — which hook
+/// defaults to suppress, and which plan lines to drop as hook-owned.
+fn plan_line_key(line: &str) -> Option<&str> {
+    let (key, _) = line.split_once(':')?;
+    (!key.is_empty()
+        && key
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-'))
+    .then_some(key)
+}
+
+/// The top-level keys a plan's own frontmatter block declares — see
+/// [`plan_line_key`] for what counts.
 fn plan_frontmatter_keys(block: &str) -> Vec<&str> {
-    block
-        .lines()
-        .filter_map(|line| {
-            let (key, _) = line.split_once(':')?;
-            (!key.is_empty()
-                && key
-                    .bytes()
-                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-'))
-            .then_some(key)
-        })
-        .collect()
+    block.lines().filter_map(plan_line_key).collect()
 }
 
 /// The full document written to disk, trailing-newline terminated.
@@ -841,14 +861,24 @@ fn plan_frontmatter_keys(block: &str) -> Vec<&str> {
 /// A body with no leading frontmatter gets the hook's block, a blank line,
 /// then the body. A body that already OPENS with its own `---` block (a plan
 /// authored from the template carries `status:`/`next:`/`branch:` from birth)
-/// gets ONE merged block (cadence-hooks#738): the plan's own lines copied
-/// byte-for-byte first — untrusted content, never parsed beyond
-/// [`frontmatter_extent`]'s fence scan and [`plan_frontmatter_keys`]'s
-/// column-0 key read — then the hook-owned lines, with `status`/`updated`/
-/// `branch` suppressed when the plan's block already declares them; the body
-/// resumes after the plan's closing fence. Stacking a second block on top
-/// left SessionStart/outro reading the hook's `status: "in-flight"` /
-/// `branch:` forever, however far the plan had moved on.
+/// gets ONE merged block (cadence-hooks#738): the hook-owned lines FIRST —
+/// with `status`/`updated`/`branch` suppressed when the plan's block already
+/// declares them — then the plan's own lines copied byte-for-byte, minus any
+/// line declaring a [`HOOK_OWNED_KEYS`] key; the body resumes after the
+/// plan's closing fence. Stacking a second block on top left SessionStart/
+/// outro reading the hook's `status: "in-flight"` / `branch:` forever,
+/// however far the plan had moved on.
+///
+/// The plan block is untrusted content. It is never parsed beyond
+/// [`frontmatter_extent`]'s fence scan and [`plan_line_key`]'s column-0 key
+/// read; hook-first ordering plus the hook-owned-key drop is what keeps a
+/// plan from pre-empting the provenance keys (a plan declaring its own
+/// `body_sha256:`/`approved_session_id:` would otherwise win a first-match
+/// read), and from swallowing them into a malformed scalar of its own (an
+/// unterminated quote or a `...` document-end marker on a plan line can only
+/// damage what FOLLOWS it — now only the plan's own lines). Lines are
+/// re-joined with `\n`, so a CRLF-authored block comes out LF (`str::lines`
+/// strips the `\r`) — deliberate, the rest of the file is LF too.
 fn render_document(f: &FrontmatterFields, body: &str) -> String {
     let Some((start, end, body_start)) = frontmatter_extent(body) else {
         return format!("{}\n\n{body}\n", render_frontmatter(f));
@@ -856,8 +886,13 @@ fn render_document(f: &FrontmatterFields, body: &str) -> String {
     let plan_block = &body[start..end];
     let plan_keys = plan_frontmatter_keys(plan_block);
     let mut lines = vec!["---".to_string()];
-    lines.extend(plan_block.lines().map(str::to_string));
     lines.extend(hook_frontmatter_lines(f, &plan_keys));
+    lines.extend(
+        plan_block
+            .lines()
+            .filter(|line| !plan_line_key(line).is_some_and(|k| HOOK_OWNED_KEYS.contains(&k)))
+            .map(str::to_string),
+    );
     lines.push("---".to_string());
     let rest = body[body_start..].trim_start_matches(['\r', '\n']);
     format!("{}\n\n{rest}\n", lines.join("\n"))
@@ -2083,22 +2118,22 @@ mod tests {
             1,
             "exactly one closing fence (one block), got:\n{doc}"
         );
-        assert!(doc.starts_with("---\nstatus: done\nnext: \"ship it\"\nbranch: feat/x\n"));
-        // The plan's status/branch win: the hook's defaults are suppressed.
-        assert_eq!(
-            doc.matches("\nstatus:").count() + usize::from(doc.starts_with("---\nstatus:")),
-            1
-        );
+        // Hook-owned lines first (`updated` was absent from the plan's block,
+        // so the hook supplies it; `status`/`branch` are the plan's), then the
+        // plan's own lines verbatim, then the one closing fence.
+        assert!(doc.starts_with("---\nupdated: \"2026-07-25\"\nbody_sha256: \"hash\"\n"));
+        assert!(doc.contains("\nsession_id: \"own-sid\"\n"));
+        assert_eq!(doc.matches("\nstatus:").count(), 1, "{doc}");
         assert!(!doc.contains("status: \"in-flight\""));
         assert_eq!(doc.matches("\nbranch:").count(), 1);
-        // `updated` was absent from the plan's block, so the hook supplies it.
-        assert!(doc.contains("\nupdated: \"2026-07-25\"\n"));
-        assert!(doc.contains("\nbody_sha256: \"hash\"\n"));
-        assert!(doc.contains("\nsession_id: \"own-sid\"\n"));
         let (frontmatter, rest) = doc
             .split_once("---\n\n")
             .expect("closing fence + blank line");
-        assert!(frontmatter.ends_with("\nmachine: \"digest\"\n"));
+        assert!(
+            frontmatter.ends_with(
+                "\nmachine: \"digest\"\nstatus: done\nnext: \"ship it\"\nbranch: feat/x\n"
+            )
+        );
         assert_eq!(rest, "# Title\n\nbody text\n");
     }
 
@@ -2117,6 +2152,44 @@ mod tests {
         assert_eq!(doc.matches("\nstatus: \"in-flight\"\n").count(), 1);
         assert_eq!(doc.matches("\n---\n").count(), 1);
         assert!(doc.ends_with("---\n\nbody\n"));
+    }
+
+    #[test]
+    fn render_document_merge_drops_plan_lines_that_claim_hook_owned_keys() {
+        // A plan block declaring the hook's provenance keys must not be able
+        // to forge them: its lines are dropped, the hook's come first, and
+        // each hook-owned key appears exactly once with the hook's value.
+        let fields = base_fields("real-hash", "real-digest");
+        let body = "---\nbody_sha256: \"forged\"\nsession_id: \"forged-sid\"\n\
+                    approved_session_id: \"forged-approver\"\nmachine: \"forged-machine\"\n\
+                    status: done\n---\n\nbody";
+        let doc = render_document(&fields, body);
+        assert!(!doc.contains("forged"), "{doc}");
+        for key in HOOK_OWNED_KEYS {
+            let count = doc.matches(&format!("\n{key}:")).count();
+            assert!(count <= 1, "{key} appears {count} times:\n{doc}");
+        }
+        assert!(doc.contains("\nbody_sha256: \"real-hash\"\n"));
+        assert!(doc.contains("\nsession_id: \"own-sid\"\n"));
+        assert!(doc.contains("\nmachine: \"real-digest\"\n"));
+        // The plan's non-owned key survives, after the hook's lines.
+        let (frontmatter, _) = doc.split_once("---\n\n").unwrap();
+        assert!(frontmatter.ends_with("\nstatus: done\n"));
+        assert!(!doc.contains("status: \"in-flight\""));
+        assert_eq!(doc.matches("\n---\n").count(), 1);
+    }
+
+    #[test]
+    fn render_document_merge_keeps_hook_keys_ahead_of_a_malformed_plan_line() {
+        // An unterminated quote on the plan's last line can only swallow what
+        // follows it — and nothing hook-owned follows it any more.
+        let fields = base_fields("hash", "digest");
+        let doc = render_document(&fields, "---\ntitle: \"unterminated\n---\nbody");
+        let (frontmatter, _) = doc.split_once("---\n\n").unwrap();
+        let hook_at = frontmatter.find("\nbody_sha256:").unwrap();
+        let plan_at = frontmatter.find("\ntitle:").unwrap();
+        assert!(hook_at < plan_at, "{doc}");
+        assert!(frontmatter.ends_with("\ntitle: \"unterminated\n"));
     }
 
     #[test]
@@ -3067,10 +3140,11 @@ mod tests {
             "one block:\n{written}"
         );
         let block = leading_frontmatter_block(&written).expect("leading block");
-        assert!(block.starts_with("status: in-flight\nnext: \"Phase 2\"\nbranch: main\n"));
-        assert!(block.contains("body_sha256: \""));
+        assert!(block.starts_with("updated: \"2026-07-20\"\nbody_sha256: \""));
+        assert!(block.ends_with("\nstatus: in-flight\nnext: \"Phase 2\"\nbranch: main\n"));
         assert!(block.contains("approved_session_id: \"merge-sid\""));
         assert_eq!(block.matches("status:").count(), 1);
+        assert_eq!(block.matches("branch:").count(), 1);
         assert!(written.ends_with("---\n\n# Merge Me\n\n- [x] done\n"));
     }
 

--- a/crates/session/src/persist_plan.rs
+++ b/crates/session/src/persist_plan.rs
@@ -1,88 +1,52 @@
-//! `session persist-plan` (UserPromptSubmit) and `session persist-plan-approval`
-//! (PostToolUse:ExitPlanMode) — persist an approved plan whose approving turn
-//! would otherwise leave no durable trace (cadence#505, cadence-hooks#396).
+//! `session persist-plan-approval` (PostToolUse:ExitPlanMode) — persist an
+//! approved plan whose approving turn would otherwise leave no durable trace
+//! (cadence#505, cadence-hooks#396).
 //!
-//! Two distinct gaps, two triggers, one shared persist core:
+//! One trigger, fired once at approval. Live probe (2026-07-25,
+//! cadence-hooks#396 comment 5080816947) established that
+//! `PostToolUse:ExitPlanMode` fires on a same-session approval carrying the
+//! plan text in `tool_response.plan`; the current harness also fills
+//! `tool_input.plan` and names the plan-store copy in `planFilePath`
+//! (cadence-hooks#672), so the source chain is response → input → store file.
 //!
-//! - **Cross-session wipe (`PersistPlan`, UserPromptSubmit).** Cameron's
-//!   "approve-and-clear" path: the parent transcript records `ExitPlanMode` as
-//!   rejected (`[Request interrupted by user for tool use]`), and the harness
-//!   injects a fresh user prompt `Implement the following plan:\n\n<full plan
-//!   markdown>` into a NEW session — killing the post-approval turn a
-//!   conversational "save the plan" rule would have relied on. This hook
-//!   intercepts that injected prompt deterministically via an exact prefix gate.
-//! - **Same-session approval (`PersistPlanApproval`, PostToolUse).** No wipe
-//!   occurs — the harness stays in the same session and injects no prompt at
-//!   all, so `PersistPlan`'s prefix gate structurally never fires
-//!   (cadence-hooks#396). Live probe (2026-07-25, cadence-hooks#396 comment
-//!   5080816947) established that `PostToolUse:ExitPlanMode` DOES fire here,
-//!   carrying the plan text in `tool_response.plan` — `tool_input.plan` is
-//!   EMPTY on this path.
+//! A second, UserPromptSubmit-driven arm (`session persist-plan`) used to
+//! re-scan every prompt for the harness's approve-and-clear re-injection and
+//! re-persist it. It held the RAW approved text — stale the moment a plan
+//! starts living (ticked boxes, a settled `Panel:`, `## Deviations`,
+//! `status:`) — and so every later fire wrote or stamped that stale copy where
+//! a consumer reads first: raw duplicate siblings (cadence-hooks#703, #724,
+//! #729), a second frontmatter block over a ticked plan (#738), writes into
+//! the primary checkout (#739). Three rounds of "is this plan already on
+//! disk" recognition heuristics could not keep up with a document that drifts
+//! away from every hash by design, so the arm was removed (2026-08-20) rather
+//! than fixed a fourth time. The approve-and-clear path now relies on the
+//! rules' copy rule (cadence-rules § Plans) when no approval-time persist
+//! happened.
 //!
-//! Both triggers normalize to the same body-hash-idempotent write through
-//! [`persist_and_nudge`]: `claim_target`'s `O_EXCL` collision ladder, a shared
-//! frontmatter render ([`render_document`]), and one `plan-links.jsonl` row
-//! format. Both also run the plan text through
-//! [`strip_trailing_suffix_lines_and_trim`] before hashing (Design 18's
-//! cross-trigger normalization) — only [`PLAN_PREFIX`] stripping is
-//! UserPromptSubmit-exclusive, since `PersistPlanApproval` never sees an
-//! injected prompt to strip a prefix from in the first place.
+//! The write is body-hash-idempotent through [`persist_and_nudge`]:
+//! `claim_target`'s `O_EXCL` collision ladder, the frontmatter render
+//! ([`render_document`] — which MERGES into a plan's own leading frontmatter
+//! rather than stacking a second block, #738), and one `plan-links.jsonl` row.
+//! The plan text runs through [`strip_trailing_suffix_lines_and_trim`] before
+//! hashing so a harness-appended suffix never changes the body's identity.
 //!
-//! Re-fire recognition runs THREE layers, in order, on BOTH trigger paths
-//! (cadence-hooks#703 extended cadence-hooks#690's late-path-only layers to the
-//! prefix path too — a resumed session replaying the same injected prompt
-//! re-nudged forever otherwise, since the prefix path never consulted either
-//! layer before this fold): **row → dir-hash scan → dir-session-id scan**.
-//! The row layer ([`machine_already_persisted`]) asks the machine-local
-//! `plan-links.jsonl` stream "did THIS MACHINE already persist THIS body?" —
-//! cwd-independent, so a session whose cwd wanders into a sibling repo skips
-//! before any plans-dir path is resolved or created (`repo_root` itself is
-//! still resolved by the earlier gates), and session-independent, because a
-//! session id does not survive the plan: every `/clear`/compaction restart
-//! mints a new id while the harness re-injects the same `planContent`, so a
-//! session-keyed row re-opened the loop at every restart (cadence-hooks#699 —
-//! the original #690 fix shipped that keying and it escaped within hours).
-//! The body hash is the durable identity of an approved plan; the row is the
-//! machine's memory of having persisted it. A row-tier skip is silent
-//! (`CheckResult::allow()`) and leaves an observability trail in
-//! `<metrics_dir>/plan-skips.jsonl` naming the matched `plan_path`
-//! (cadence-hooks#695) — never a nudge, and never gated on that path still
-//! existing on disk. The dir-hash-scan layer
-//! ([`plans_dir_contains_hash`]) is the second layer (a wiped metrics file,
-//! rows beyond the tail window, pre-fix sessions with no rows); its per-file
-//! matching keeps its own internal tiers (frontmatter key → legacy trailer →
-//! recompute — see [`file_matches_body`]). The dir-session-id-scan layer
-//! ([`plans_dir_contains_approved_session`]) is the third and last: a living
-//! plan's body legitimately drifts after persist (ticked checkboxes, appended
-//! `## Deviations`/`## Learnings`), which can defeat hash-based recognition
-//! entirely, but the approving parent's session id — resolved by
-//! [`find_parent`], the same scan that resolves `approved_in` — never
-//! changes once a document's frontmatter records it. This layer only runs
-//! after a hash-scan miss, and only when a parent actually resolved; on
-//! match it appends a plan-links row (cross-repo memory of the recognition)
-//! and skips. None of the three layers are ever numbered as one sequence.
-//! `CADENCE_PERSIST_PLAN_FORCE` (any non-empty value) skips the row layer for
-//! the turn — the returnable escape for any intentional re-persist, including
-//! the same approved body into a second repo.
+//! `CADENCE_NO_PERSIST_PLAN` (any non-empty value, process env or the repo's
+//! `.claude/settings*.json` `env` block — the `CADENCE_ALLOW_MAIN` precedent)
+//! opts a repo or a session out of the persist entirely (cadence-hooks#692);
+//! the four plan guards and the SessionStart plan scanner are not covered by
+//! this flag.
 //!
-//! Never blocks (ADR-0001): every failure path — no prompt/no plan text, no
-//! match, no `cwd`, not a git repo, unsafe session id, exhausted suffix ladder,
-//! a subagent-context approval — exits silently via `CheckResult::allow()`. A
-//! hook bug must not eat a user prompt or a same-session approval.
+//! Never blocks (ADR-0001): every failure path — no plan text, no `cwd`, not
+//! a git repo, unsafe session id, exhausted suffix ladder, a subagent-context
+//! approval — exits silently via `CheckResult::allow()`. A hook bug must not
+//! eat a same-session approval.
 
 use crate::identity;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 use serde_json::Value;
 use std::fs;
-use std::io::{BufRead, BufReader, Write as _};
+use std::io::Write as _;
 use std::path::{Path, PathBuf};
-use std::time::{Duration, SystemTime};
-
-/// The exact, case-sensitive prefix the harness's approve-and-clear
-/// re-injection carries. A hand-typed prompt with the same prefix is an
-/// accepted false positive — persisting a plan the user asked to implement is
-/// benign (see the plan doc's Approach step 0).
-const PLAN_PREFIX: &str = "Implement the following plan:";
 
 /// Prefix of the trailing suffix line the harness appends after the plan
 /// body. Two live variants share this prefix ("...consider using the Agent
@@ -146,19 +110,6 @@ const IDEMPOTENCY_MAX_FILE_BYTES: u64 = 1024 * 1024;
 /// document looking for a fence that was never there.
 const FRONTMATTER_SCAN_MAX_LINES: usize = 100;
 
-/// How far back a sibling transcript may sit and still be scanned for the
-/// approving `ExitPlanMode` call.
-const PARENT_SCAN_MAX_AGE: Duration = Duration::from_secs(48 * 3600);
-
-/// How many of the newest sibling transcripts are scanned.
-const PARENT_SCAN_MAX_FILES: usize = 20;
-
-/// Cap on a sibling transcript's size before it's skipped entirely. Real
-/// transcripts run single-digit MB; 32 MiB is generous headroom against a
-/// pathological file consuming the scan's time — outside any deadline budget
-/// (this scan is a plain `Check`, not a git-spawning probe).
-const PARENT_SCAN_MAX_FILE_BYTES: u64 = 32 * 1024 * 1024;
-
 /// Schema version stamped on every `plan-links.jsonl` row. A new stream
 /// (cadence#238 convention) — does not share `cadence_hooks_metrics::common`'s
 /// existing version constants; this one lives with its own writer. Bumped to
@@ -175,46 +126,8 @@ const PARENT_SCAN_MAX_FILE_BYTES: u64 = 32 * 1024 * 1024;
 /// empty value without a schema-version branch.
 const PLAN_LINKS_SCHEMA_VERSION: u32 = 3;
 
-/// Tail window of `plan-links.jsonl` the row-keyed idempotency check
-/// ([`machine_already_persisted`]) reads — roughly 1000 recent rows. The file
-/// is append-only, so recent rows live at the TAIL; a head-anchored
-/// `take(cap)` would silently blind the check as the file grows. A matching
-/// row that has scrolled out of this window reads as "no row" and fails open
-/// to the dir scan (ADR-0001) — one benign duplicate, never a lost persist.
-const PLAN_LINKS_SCAN_MAX_BYTES: u64 = 256 * 1024;
-
-/// Persist an approved plan whose post-approval turn was wiped
-/// (approve-and-clear, cross-session).
-pub struct PersistPlan;
-
-impl Check for PersistPlan {
-    fn name(&self) -> &str {
-        "persist-plan"
-    }
-
-    fn run(&self, input: &HookInput) -> CheckResult {
-        let host = gethostname::gethostname().to_string_lossy().into_owned();
-        let utc_now = cadence_hooks_core::time::utc_timestamp();
-        let local_date = cadence_hooks_core::time::local_date();
-        // Narrow defense-in-depth: `PersistPlan` fires on every
-        // UserPromptSubmit (every turn), so a bug here must not eat a user
-        // prompt — a panic degrades to a silent allow rather than propagating.
-        //
-        // The broader dispatch-layer guard now exists and works
-        // (cameronsjo/cadence-hooks#349: `src/dispatch.rs` brackets
-        // `decide_check` with `PANIC_GUARDED` so the global panic hook yields
-        // the unwind instead of exiting the process). This one is kept anyway:
-        // it costs nothing, it covers the highest-frequency hook in the tree,
-        // and an allow here is a *quieter* degradation than dispatch's — no
-        // stderr breadcrumb, no failopen row for a hook that fires on every
-        // single turn.
-        std::panic::catch_unwind(|| run_persist_plan(input, &utc_now, &local_date, &host))
-            .unwrap_or_else(|_| CheckResult::allow())
-    }
-}
-
-/// Persist an approved plan on same-session approval — no wipe, no injected
-/// prompt, so [`PersistPlan`]'s prefix gate never fires (cadence-hooks#396).
+/// Persist an approved plan at approval time (cadence-hooks#396) — the one
+/// writer since the UserPromptSubmit re-scan arm was removed (2026-08-20).
 pub struct PersistPlanApproval;
 
 impl Check for PersistPlanApproval {
@@ -226,258 +139,16 @@ impl Check for PersistPlanApproval {
         let host = gethostname::gethostname().to_string_lossy().into_owned();
         let utc_now = cadence_hooks_core::time::utc_timestamp();
         let local_date = cadence_hooks_core::time::local_date();
-        // Same narrow defense-in-depth as `PersistPlan` above: this fires on
-        // every `ExitPlanMode` call, and a bug here must not eat the approval.
+        // Narrow defense-in-depth on top of the dispatch-layer panic guard
+        // (cameronsjo/cadence-hooks#349): this fires on every `ExitPlanMode`
+        // call, and a bug here must not eat the approval.
         std::panic::catch_unwind(|| run_persist_plan_approval(input, &utc_now, &local_date, &host))
             .unwrap_or_else(|_| CheckResult::allow())
     }
 }
 
-/// Testable core: the UTC timestamp, local date, and hostname are injected so
-/// tests exercise real runtime semantics (no frozen-clock steering) while
-/// staying deterministic on everything else.
-pub fn run_persist_plan(
-    input: &HookInput,
-    utc_now: &str,
-    local_date: &str,
-    host: &str,
-) -> CheckResult {
-    let Some(prompt) = input.prompt() else {
-        return CheckResult::allow();
-    };
-    // Two ways the plan text arrives (cadence-hooks#672): the classic
-    // prefix-carrying injected prompt, or — since the harness stopped routing
-    // its auto-continuation injection through UserPromptSubmit at all — a
-    // LATER, ordinary prompt whose transcript head carries the injected
-    // `planContent` entry. The late path normalizes through the same
-    // prefix-strip + suffix-strip so all three triggers hash byte-identical
-    // bodies (Design 18). Which path extracted the body no longer steers
-    // anything downstream (cadence-hooks#703 dropped the `via_late_scan`
-    // gates on all three recognition layers) — the boolean this match used to
-    // also return is gone.
-    let body = match prompt.strip_prefix(PLAN_PREFIX) {
-        Some(rest) => strip_trailing_suffix_lines_and_trim(rest),
-        None => match input
-            .transcript_path()
-            .and_then(|tp| injected_plan_from_transcript(Path::new(tp)))
-        {
-            Some(injected) => {
-                // `planContent` is documented bare (no prefix), so this strip
-                // is a no-op today — kept as cheap insurance that a future
-                // harness variant which DOES prefix it still hashes
-                // byte-identical to the other two paths.
-                let rest = injected.strip_prefix(PLAN_PREFIX).unwrap_or(&injected);
-                strip_trailing_suffix_lines_and_trim(rest)
-            }
-            None => return CheckResult::allow(),
-        },
-    };
-    if body.is_empty() {
-        return CheckResult::allow();
-    }
-    let Some(cwd) = input.cwd.as_deref() else {
-        return CheckResult::allow();
-    };
-    let Some(repo_root) = crate::registry::repo_root(cwd) else {
-        return CheckResult::allow();
-    };
-    // A crafted/malformed session id must never become a path component (the
-    // short-id fallback embeds it) — same discipline as `session start`.
-    let Some(session_id) = input
-        .session_id()
-        .filter(|s| identity::is_safe_session_id(s))
-    else {
-        return CheckResult::allow();
-    };
-
-    let body_hash = sha256_hex(body.as_bytes());
-    let machine_digest = crate::provenance::machine_digest(host);
-    // Resolved AHEAD of the persist decision (cadence-hooks#703 — was
-    // computed just before the frontmatter fields, well after the recognition
-    // gates below) — but AFTER the row-tier gate, not ahead of it: the row
-    // check needs neither `parent` nor a plans-dir resolution, and this hook
-    // fires on every UserPromptSubmit, so a sibling-transcript directory scan
-    // on every row-suppressed turn would be wasted work the row tier's own
-    // "runs BEFORE any plans-dir resolution" discipline was written to avoid.
-    // Resolved here because the third recognition layer below needs the
-    // approving parent's session id, which only `find_parent` can supply.
-    // Otherwise unchanged: same scan, same `SystemTime::now()`, same use for
-    // `approved_in`/model/harness fallback further down.
-    //
-    // Recognition layer 1 of 3 — the row check (cadence-hooks#690, extended to
-    // both trigger paths by cadence-hooks#703): did this MACHINE already
-    // persist THIS body? Runs BEFORE any plans-dir resolution, so a session
-    // whose cwd has wandered into a sibling repo never invents (or even
-    // resolves) a `docs/plans/` there on a skip turn. Deliberately NOT
-    // session-keyed (cadence-hooks#699): a session id dies at every
-    // /clear/compaction restart while the injected `planContent` lives on, so
-    // a session-keyed row re-opened the loop at every restart. The rare
-    // legitimate re-persist of the same body (a second repo) rides
-    // `CADENCE_PERSIST_PLAN_FORCE`. The skip is silent — the row exists only
-    // because a persist already nudged once, and the per-prompt re-nudge is
-    // the noise this layer removes. No longer gated on `via_late_scan`
-    // (cadence-hooks#703): a resumed session replaying the same prefixed
-    // prompt re-nudged forever before this fold, since the prefix path never
-    // consulted the row at all.
-    if !persist_plan_force()
-        && let Some(matched_plan_path) = machine_already_persisted(&body_hash, &machine_digest)
-    {
-        // Observability (cadence-hooks#695): the skip is otherwise silent —
-        // this is the only artifact naming WHICH plan_path explained it.
-        // Never a nudge, and never gated on `matched_plan_path` still
-        // existing on disk (a stray record naming a since-deleted file is
-        // still useful attribution).
-        append_plan_skip_row(utc_now, &body_hash, &matched_plan_path, &machine_digest);
-        return CheckResult::allow();
-    }
-    let slug = slugify(&body);
-    // Resolved only now that the row tier didn't already suppress this turn —
-    // the third recognition layer below needs the approving parent's session
-    // id, which only `find_parent` can supply.
-    let parent = input
-        .transcript_path()
-        .and_then(|tp| find_parent(Path::new(tp), &body_hash, SystemTime::now()));
-    let parent_session_id = parent.as_ref().map(|p| p.session_id.as_str());
-    // Recognition layers 2 and 3 of 3 — the dir-wide scans: the late path
-    // re-fires on EVERY subsequent prompt of the session, and the persist
-    // date may differ from the approval date — so the same-stem claim ladder
-    // alone cannot recognize an earlier persist under an earlier date. Now
-    // also unconditional on `via_late_scan` (cadence-hooks#703) — a resumed
-    // session replaying the same prefixed prompt gets the same recognition as
-    // a late re-fire. Resolves the plans dir via the EXISTING-only variant —
-    // a scan must never create the directory it scans (the wrong-repo
-    // `docs/plans/` invention of cadence-hooks#690).
-    if let Some((canonical_repo_root, scan_dir)) = existing_canonical_plans_dir(&repo_root) {
-        // Layer 2: any existing plan doc carrying this body hash makes the
-        // re-fire a silent idempotent skip. Covers what the row check cannot
-        // (a wiped metrics file, a row beyond the tail window, pre-row
-        // sessions).
-        if let Some(matched_path) = plans_dir_contains_hash(&scan_dir, &body_hash) {
-            // This path recognizes a re-fire but never itself wrote the row
-            // (the original persist did, or would have — a row beyond the
-            // scan window). Append one now so the row-check layer above
-            // suppresses subsequent turns for this body on this machine (the
-            // row is what makes the row-check's own skip fire) —
-            // `parent_session_id` is `None` by construction: a plan already
-            // committed to `docs/plans/` has no approving parent this hook
-            // can resolve HERE (the resolved `parent` above answers "who
-            // approved the CURRENT turn's body", not "who approved the
-            // MATCHED document" — a hash match is a re-fire of the exact same
-            // approval, so recording it as unknown rather than conflating the
-            // two is deliberate). Nudge only when a tier was parsed — this is
-            // a re-fire recognition, not a fresh persist, so the "persisted
-            // to"/format-gate sentences don't apply.
-            let plan_path_rel = repo_relative(&matched_path, &canonical_repo_root);
-            let tier = recommended_tier(&body);
-            append_plan_links_row(&plan_links_row(
-                utc_now,
-                None,
-                session_id,
-                &machine_digest,
-                &plan_path_rel,
-                &body_hash,
-                tier.map(Tier::as_str),
-            ));
-            return match tier {
-                Some(t) => CheckResult::nudge(model_check_directive(t)),
-                None => CheckResult::allow(),
-            };
-        }
-        // Layer 3 (cadence-hooks#703): a hash-scan miss doesn't rule out a
-        // re-fire — a living plan's body legitimately drifts after persist
-        // (ticked checkboxes, appended `## Deviations`/`## Learnings`), which
-        // defeats hash-based recognition entirely. But the approving
-        // session's identity never changes once a document's frontmatter
-        // records it, so a doc carrying THIS turn's resolved parent as its
-        // `approved_session_id` is the same approval, however far the body
-        // has since moved. Only runs when a parent actually resolved —
-        // `parent_session_id` unresolved means there is nothing to match
-        // against, not a decision to skip this layer.
-        if let Some(sid) = parent_session_id
-            && let Some(matched_path) = plans_dir_contains_approved_session(&scan_dir, sid)
-        {
-            let plan_path_rel = repo_relative(&matched_path, &canonical_repo_root);
-            let tier = recommended_tier(&body);
-            append_plan_links_row(&plan_links_row(
-                utc_now,
-                parent_session_id,
-                session_id,
-                &machine_digest,
-                &plan_path_rel,
-                &body_hash,
-                tier.map(Tier::as_str),
-            ));
-            return match tier {
-                Some(t) => CheckResult::nudge(model_check_directive(t)),
-                None => CheckResult::allow(),
-            };
-        }
-    }
-    let stem = format!("{local_date}-{slug}");
-
-    let parent_name = parent_session_id.map(identity::generate_name);
-    let own_name = identity::generate_name(session_id);
-
-    // The EXECUTING session's own transcript is structurally empty at this
-    // point on a cross-session approve-and-clear wipe: the wipe IS a new
-    // session, so its transcript has no assistant turn yet — `resolve_model`/
-    // `resolve_harness` against it return `None`. Fall back to the APPROVING
-    // parent's already-resolved model/harness (from the same scan that
-    // resolved `approved_in`) rather than leaving the frontmatter fields
-    // permanently unresolved on this trigger's most common path
-    // (cameronsjo/cadence-hooks#396 review).
-    let transcript_content = input
-        .transcript_path()
-        .and_then(|tp| cadence_hooks_core::transcript::read_tail(Path::new(tp)));
-    let model = crate::warn_commit_provenance::resolve_model(transcript_content.as_deref())
-        .or_else(|| parent.as_ref().and_then(|p| p.model.clone()));
-    let harness = crate::warn_commit_provenance::resolve_harness(transcript_content.as_deref())
-        .or_else(|| parent.as_ref().and_then(|p| p.harness_version.clone()));
-    let branch = current_branch(cwd);
-
-    let approved_in = parent_session_id
-        .zip(parent_name.as_deref())
-        .map(|(sid, name)| (name, sid));
-
-    let fields = FrontmatterFields {
-        updated: local_date,
-        branch: branch.as_deref(),
-        body_hash: &body_hash,
-        own_name: &own_name,
-        own_session_id: session_id,
-        model: model.as_deref(),
-        harness: harness.as_deref(),
-        machine_digest: &machine_digest,
-        approved_in,
-    };
-    let document = render_document(&fields, &body);
-
-    let approved_label = parent_name.as_deref().unwrap_or("unknown");
-    // Write-time resolution through the CREATING variant (its symlink-escape
-    // guard intact): the dir is invented only on a turn that actually
-    // persists, never on a scan-only skip (cadence-hooks#690).
-    let Some((repo_root, plans_dir)) = canonical_plans_dir(&repo_root) else {
-        return CheckResult::allow();
-    };
-    persist_and_nudge(
-        &plans_dir,
-        &stem,
-        session_id,
-        &body_hash,
-        &document,
-        utc_now,
-        parent_session_id,
-        session_id,
-        &machine_digest,
-        &repo_root,
-        approved_label,
-        &body,
-        recommended_tier(&body),
-    )
-}
-
-/// Testable core for the PostToolUse trigger. Same injected clock/host
-/// discipline as [`run_persist_plan`].
+/// Testable core for the PostToolUse trigger — clock and host are injected so
+/// tests pin the rendered frontmatter and the plan-links row byte-for-byte.
 pub fn run_persist_plan_approval(
     input: &HookInput,
     utc_now: &str,
@@ -519,9 +190,8 @@ pub fn run_persist_plan_approval(
             None => return CheckResult::allow(),
         },
     };
-    // Same normalization `run_persist_plan` applies to its extracted body
-    // (Design 18): both triggers must hash byte-identical text so a plan
-    // approved through either path is recognized as the same re-fire.
+    // Strip the harness-appended suffix paragraphs before hashing (Design 18)
+    // so a re-fire of the same approval hashes byte-identical.
     let body = strip_trailing_suffix_lines_and_trim(&raw_plan);
     if body.is_empty() {
         return CheckResult::allow();
@@ -532,6 +202,12 @@ pub fn run_persist_plan_approval(
     let Some(repo_root) = crate::registry::repo_root(cwd) else {
         return CheckResult::allow();
     };
+    // Opt-out (cadence-hooks#692): checked right after `repo_root` resolves
+    // so the repo-level `.claude/settings*.json` flag can be read, and before
+    // any plans-dir resolution or write.
+    if persist_plan_opted_out(&repo_root) {
+        return CheckResult::allow();
+    }
     let Some(session_id) = input
         .session_id()
         .filter(|s| identity::is_safe_session_id(s))
@@ -548,10 +224,9 @@ pub fn run_persist_plan_approval(
 
     let own_name = identity::generate_name(session_id);
     let machine_digest = crate::provenance::machine_digest(host);
-    // Same-session approval: unlike `run_persist_plan`'s cross-session wipe,
-    // the executing transcript here HAS just recorded the approving turn (no
-    // wipe occurred), so it's a reliable model/harness source with no
-    // sibling-transcript fallback needed.
+    // Same-session approval: the executing transcript HAS just recorded the
+    // approving turn (no wipe occurred), so it's a reliable model/harness
+    // source with no sibling-transcript fallback needed.
     let transcript_content = input
         .transcript_path()
         .and_then(|tp| cadence_hooks_core::transcript::read_tail(Path::new(tp)));
@@ -591,6 +266,18 @@ pub fn run_persist_plan_approval(
     )
 }
 
+/// Has this repo or session opted out of the persist (cadence-hooks#692)?
+/// `CADENCE_NO_PERSIST_PLAN` with any non-empty value, read from the process
+/// environment first and then from the repo's `.claude/settings.local.json` /
+/// `.claude/settings.json` `env` block — the same two sources and the same
+/// untrusted-config reader `CADENCE_ALLOW_MAIN` uses. Advisory tier: no
+/// `PROTECTED_GUARDS` treatment, no audit row on the skip.
+fn persist_plan_opted_out(repo_root: &Path) -> bool {
+    std::env::var("CADENCE_NO_PERSIST_PLAN").is_ok_and(|v| !v.is_empty())
+        || cadence_hooks_core::config::repo_env_flag(repo_root, "CADENCE_NO_PERSIST_PLAN")
+            .is_some_and(|v| !v.is_empty())
+}
+
 /// The current checked-out branch of the repo containing `cwd`, or `None`
 /// when unresolvable (no git repo, detached HEAD, unreadable `HEAD` file).
 /// Pure filesystem resolution ([`cadence_hooks_core::gitstate`]) — no `git`
@@ -617,93 +304,6 @@ fn canonical_plans_dir(repo_root: &Path) -> Option<(PathBuf, PathBuf)> {
     canonical_plans_dir
         .starts_with(&canonical_repo_root)
         .then_some((canonical_repo_root, canonical_plans_dir))
-}
-
-/// [`canonical_plans_dir`]'s read-only sibling: identical signature and the
-/// same canonicalize + `starts_with` symlink-escape guard, but requires
-/// `docs/plans` to ALREADY exist instead of creating it. Used by the
-/// late-scan dir check only (cadence-hooks#690) — a scan must never invent
-/// the directory it scans, which is exactly how a wandered-cwd session
-/// deposited empty `docs/plans/` dirs into sibling repos. Its two `None`
-/// causes (dir absent; symlink escaping the repo) deliberately collapse to
-/// the same outcome — "nothing scannable here" — because an escaping dir
-/// must not be scanned either. The write path re-resolves through the
-/// creating variant above, whose own guard is untouched.
-fn existing_canonical_plans_dir(repo_root: &Path) -> Option<(PathBuf, PathBuf)> {
-    let plans_dir = repo_root.join("docs").join("plans");
-    if !plans_dir.is_dir() {
-        return None;
-    }
-    let canonical_repo_root = repo_root.canonicalize().ok()?;
-    let canonical_plans_dir = plans_dir.canonicalize().ok()?;
-    canonical_plans_dir
-        .starts_with(&canonical_repo_root)
-        .then_some((canonical_repo_root, canonical_plans_dir))
-}
-
-/// The returnable escape for the row-keyed idempotency layer
-/// (cadence-hooks#690): any non-empty `CADENCE_PERSIST_PLAN_FORCE` skips the
-/// row check for the turn — the escape for any intentional re-persist
-/// (delete-and-retarget, or the same approved body into a second repo, since
-/// the row is machine-keyed per cadence-hooks#699). Skips the row layer ONLY;
-/// the dir scan and claim ladder still apply.
-fn persist_plan_force() -> bool {
-    std::env::var("CADENCE_PERSIST_PLAN_FORCE").is_ok_and(|v| !v.is_empty())
-}
-
-/// Has this MACHINE already persisted THIS plan body? Returns the matched
-/// row's `plan_path` on a hit — `None` on any miss, ambiguity, or failure.
-///
-/// Tail-anchored bounded read of `<metrics_dir>/plan-links.jsonl` — the row
-/// [`append_plan_links_row`] writes on every successful persist. The file is
-/// machine-local and cwd-independent, which is what lets this check run
-/// BEFORE any plans-dir resolution (cadence-hooks#690). Matches any row whose
-/// `body_sha256` equals the extracted body's hash — see [`plan_links_row`]'s
-/// schema pin.
-///
-/// Deliberately NOT keyed on `child_session_id` (cadence-hooks#699): the
-/// executing session's id changes at every `/clear`/compaction restart while
-/// the harness re-injects the same `planContent`, so a session-keyed match
-/// re-opened the re-persist loop at exactly that boundary. The body hash is
-/// the durable identity of the approved text; `CADENCE_PERSIST_PLAN_FORCE`
-/// carries the rare intentional re-persist of the same body.
-///
-/// The match requires the row's `machine` field to equal this run's salted
-/// [`crate::provenance::machine_digest`] — the function's name is a claim,
-/// and without this conjunct a metrics dir reachable from more than one
-/// machine (a synced config dir, `CADENCE_METRICS_DIR` on shared storage)
-/// would let machine A's persist suppress machine B's (the #699 security
-/// pass's finding; the old session conjunct covered this by accident, since
-/// session ids never repeat across machines). A schema-v1 row carries a raw
-/// `host` instead of `machine` and simply never matches — fail-open to the
-/// dir scan, like every other miss.
-///
-/// Fail-open (ADR-0001) in every direction: an unreadable or absent file,
-/// malformed rows, a row missing `plan_path`, or a matching row that has
-/// scrolled out of the [`PLAN_LINKS_SCAN_MAX_BYTES`] tail window all read as
-/// `None`, degrading to the dir scan (at worst one benign duplicate, never a
-/// lost persist). `metrics_dir()`'s `CADENCE_METRICS_DIR` tier is production,
-/// not a test seam — this read honors it like every other consumer.
-///
-/// The returned `plan_path` feeds only [`append_plan_skip_row`]'s
-/// observability record (cadence-hooks#695) — never a nudge, and never a
-/// second existence check against the filesystem (a stray record naming a
-/// since-deleted file is still useful attribution, not a reason to gate).
-fn machine_already_persisted(body_hash: &str, machine_digest: &str) -> Option<String> {
-    let path = cadence_hooks_metrics::metrics_dir().join("plan-links.jsonl");
-    let tail = cadence_hooks_core::transcript::read_tail_bounded(&path, PLAN_LINKS_SCAN_MAX_BYTES)?;
-    tail.lines().find_map(|line| {
-        let row = serde_json::from_str::<Value>(line).ok()?;
-        if row.get("body_sha256").and_then(Value::as_str) == Some(body_hash)
-            && row.get("machine").and_then(Value::as_str) == Some(machine_digest)
-        {
-            row.get("plan_path")
-                .and_then(Value::as_str)
-                .map(str::to_string)
-        } else {
-            None
-        }
-    })
 }
 
 // ---------------------------------------------------------------------------
@@ -804,149 +404,6 @@ fn read_plan_store_file_within(path: &str, plan_store_root: &Path) -> Option<Str
         return None;
     }
     Some(content)
-}
-
-/// How much of the transcript's HEAD [`injected_plan_from_transcript`] will
-/// read looking for the auto-continuation entry. The injection is the very
-/// first user entry of a fresh post-`/clear` session, so it sits well inside
-/// this window even under large SessionStart context; a bounded head read
-/// (not [`cadence_hooks_core::transcript::read_tail`]) because a long session
-/// pushes the head OUT of any tail window while the entry never moves.
-const INJECTED_PLAN_SCAN_MAX_BYTES: u64 = 4 * 1024 * 1024;
-
-/// Line cap for the same scan — the injection is among the very first entries
-/// of its fresh session (observed at entry 8 in the live capture), so 50
-/// lines is generous headroom while keeping this every-turn scan cheap:
-/// `BufReader::lines` reads incrementally, so a session that never had an
-/// injection costs one small partial read per prompt, never the full byte
-/// bound (the code-review pass's per-turn-cost finding on this change).
-const INJECTED_PLAN_SCAN_MAX_LINES: usize = 50;
-
-/// The harness's auto-continuation plan injection from the transcript head,
-/// if present: a top-level `type: "user"` entry carrying non-empty
-/// `planContent` (the BARE plan body — the prefix/suffix chrome lives only in
-/// the message text) and explicitly marked `isSidechain: false`. First match
-/// wins; a fresh post-`/clear` session carries at most one. Live payload
-/// shape: cadence-hooks#672 (session beffcf50, claude-code 2.1.227).
-///
-/// `None` on any read failure — an unreadable transcript degrades to no late
-/// persist this turn (ADR-0001), and the scan re-fires on the next prompt.
-fn injected_plan_from_transcript(transcript_path: &Path) -> Option<String> {
-    use std::io::Read as _;
-    let file = fs::File::open(transcript_path).ok()?;
-    let reader = BufReader::new(file.take(INJECTED_PLAN_SCAN_MAX_BYTES));
-    for line in reader.lines().take(INJECTED_PLAN_SCAN_MAX_LINES) {
-        // A single unreadable line skips that line, not the scan — the
-        // sibling `find_parent` scanner's convention for the same condition.
-        let Ok(line) = line else { continue };
-        // Substring pre-filter before any JSON parse — same discipline as
-        // `find_parent`'s sibling scan. A line that carries the marker but
-        // fails to parse is skipped, not fatal: transcripts legitimately mix
-        // entry shapes, and one malformed line must not end the scan.
-        if !line.contains("\"planContent\"") {
-            continue;
-        }
-        let Ok(value) = serde_json::from_str::<Value>(&line) else {
-            continue;
-        };
-        if value.get("type").and_then(Value::as_str) != Some("user") {
-            continue;
-        }
-        // Fail-CLOSED on the sidechain marker, matching the approval arm's
-        // `is_agent` gate (security review of this change): only an explicit
-        // `false` persists. An absent or non-boolean `isSidechain` is a
-        // payload-shape drift, and treating it as "not a sidechain" would
-        // forge a subagent's plan as the operator's approved plan.
-        if value.get("isSidechain").and_then(Value::as_bool) != Some(false) {
-            continue;
-        }
-        if let Some(plan) = value
-            .get("planContent")
-            .and_then(Value::as_str)
-            .filter(|p| !p.trim().is_empty())
-        {
-            return Some(plan.to_string());
-        }
-    }
-    None
-}
-
-/// Cap on how many `docs/plans` entries [`plans_dir_contains_hash`] will
-/// check. The measured corpus tops out in the low hundreds; the cap bounds a
-/// pathological directory without ever silently skipping a real one below it.
-const DIR_HASH_SCAN_MAX_FILES: usize = 512;
-
-/// Does any markdown document in `plans_dir` already carry `body_hash`? Returns
-/// the matched candidate's path — the dir-scan-skip path (Priority Q3/#396)
-/// derives `plan_path_rel` from it the same way [`persist_and_nudge`] does, so
-/// it can append a plan-links row for a re-fire it recognizes but never wrote.
-/// Per-file work is [`file_matches_body`]'s bounded read, gated to regular
-/// files only — a committed symlink (git stores them) pointing at a FIFO
-/// would otherwise block `File::open` on this every-turn path forever
-/// (security review of this change). Candidates are ordered newest-first
-/// (the sibling `find_parent` scan's discipline) so the cap degrades toward
-/// the most likely re-fire targets — and the just-persisted doc matches on
-/// the first read in the common case. Fail-open: an unreadable dir reads as
-/// "no match" and lets the claim ladder — which dedupes within the same stem
-/// — take over.
-fn plans_dir_contains_hash(plans_dir: &Path, body_hash: &str) -> Option<PathBuf> {
-    newest_markdown_candidates(plans_dir)
-        .into_iter()
-        .find(|path| file_matches_body(path, body_hash))
-}
-
-/// Does any markdown document in `plans_dir` carry `session_id` as its LEADING
-/// frontmatter's `approved_session_id:` value? The third recognition layer
-/// (cadence-hooks#703): a living plan's body legitimately drifts after
-/// persist (ticked checkboxes, appended `## Deviations`/`## Learnings`),
-/// which can defeat [`plans_dir_contains_hash`] entirely — but the approving
-/// session's identity, once a document's frontmatter records it, never
-/// changes. Same newest-first, capped, regular-files-only candidate list as
-/// [`plans_dir_contains_hash`] ([`newest_markdown_candidates`]); per-file work
-/// is [`file_has_approved_session_id`]'s bounded read, exact-string compare
-/// only against the parsed (`yaml_unquote`'d) value. Committed frontmatter is
-/// untrusted input (security review of this change) — the compared value is
-/// never rendered or interpolated, only compared.
-fn plans_dir_contains_approved_session(plans_dir: &Path, session_id: &str) -> Option<PathBuf> {
-    newest_markdown_candidates(plans_dir)
-        .into_iter()
-        .find(|path| file_has_approved_session_id(path, session_id))
-}
-
-/// Shared candidate list for both dir-scan layers: every regular `.md` file
-/// directly in `plans_dir`, newest-first (the sibling `find_parent` scan's
-/// discipline), capped at [`DIR_HASH_SCAN_MAX_FILES`] so a pathological
-/// directory degrades toward the most likely re-fire targets rather than
-/// scanning without bound. Gated to regular files only — a committed symlink
-/// (git stores them) pointing at a FIFO would otherwise block `File::open` on
-/// this every-turn path forever (security review of this change). Fail-open:
-/// an unreadable dir yields an empty list, and every caller treats "no
-/// candidates" as "no match".
-fn newest_markdown_candidates(plans_dir: &Path) -> Vec<PathBuf> {
-    let Some(entries) = fs::read_dir(plans_dir).ok() else {
-        return Vec::new();
-    };
-    let mut candidates: Vec<(SystemTime, PathBuf)> = entries
-        .flatten()
-        .filter_map(|e| {
-            let path = e.path();
-            if path.extension().is_none_or(|ext| ext != "md") {
-                return None;
-            }
-            let meta = fs::symlink_metadata(&path).ok()?;
-            if !meta.is_file() {
-                return None;
-            }
-            let mtime = meta.modified().unwrap_or(SystemTime::UNIX_EPOCH);
-            Some((mtime, path))
-        })
-        .collect();
-    candidates.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
-    candidates
-        .into_iter()
-        .take(DIR_HASH_SCAN_MAX_FILES)
-        .map(|(_, path)| path)
-        .collect()
 }
 
 /// SHA-256 of `bytes`, lowercase hex.
@@ -1161,27 +618,6 @@ fn file_matches_body(path: &Path, body_hash: &str) -> bool {
     sha256_hex(body.as_bytes()) == body_hash
 }
 
-/// Does the document at `path` carry `session_id` as its LEADING
-/// frontmatter's `approved_session_id:` value? [`plans_dir_contains_approved_session`]'s
-/// per-file work — same bounded-read discipline as [`file_matches_body`]
-/// (capped at [`IDEMPOTENCY_MAX_FILE_BYTES`], frontmatter-only, never a
-/// whole-document scan), but EXACT string comparison only: no hash, no
-/// legacy-trailer fallback, no body recompute. The compared value is parsed
-/// (`yaml_unquote`'d) but never rendered back out — committed frontmatter is
-/// untrusted input (security review of this change). `false` on any read
-/// failure, oversized file, or absent key.
-fn file_has_approved_session_id(path: &Path, session_id: &str) -> bool {
-    let Some(content) = read_capped_at_idempotency_limit(path) else {
-        return false;
-    };
-    leading_frontmatter_block(&content)
-        .and_then(|fm| {
-            fm.lines()
-                .find_map(|l| l.strip_prefix("approved_session_id:"))
-        })
-        .is_some_and(|recorded| yaml_unquote(recorded.trim()) == session_id)
-}
-
 /// Try each candidate in order with `create_new` (O_EXCL): a fresh path wins
 /// outright; an occupied path is re-checked by
 /// [`file_matches_body`] — a match is a re-fire (idempotent skip), a mismatch
@@ -1225,143 +661,6 @@ fn claim_target(
 // Provenance: parent resolution (Approach step 4)
 // ---------------------------------------------------------------------------
 
-/// The `ExitPlanMode` plan text on one transcript line, plus the approving
-/// turn's model (`message.model`) and harness version (top-level `version`),
-/// if `line` is an assistant message carrying that tool call. `model`/
-/// `harness_version` are `None` when the matched line doesn't carry them.
-/// Mirrors `cadence_hooks_core::transcript::line_is_polish_skill_use`'s
-/// traversal.
-///
-/// Restored (cameronsjo/cadence-hooks#396 review): the executing session's
-/// own transcript is structurally empty at the moment `run_persist_plan`
-/// runs on a cross-session approve-and-clear wipe (the wipe IS a new,
-/// just-started session — its transcript has no assistant turn yet), so
-/// `crate::warn_commit_provenance::resolve_model`/`resolve_harness` against
-/// it always return `None` there. The APPROVING parent's transcript — the one
-/// this scan already walks to resolve `approved_in` — is the only source that
-/// reliably carries a populated `model`/`version` for that path.
-struct ExitPlanModeMatch {
-    plan_text: String,
-    model: Option<String>,
-    harness_version: Option<String>,
-}
-
-fn exit_plan_mode_match(line: &str) -> Option<ExitPlanModeMatch> {
-    let value: Value = serde_json::from_str(line).ok()?;
-    let message = value.get("message")?;
-    let content = message.get("content")?.as_array()?;
-    let plan_text = content.iter().find_map(|block| {
-        if block.get("type").and_then(Value::as_str) != Some("tool_use") {
-            return None;
-        }
-        if block.get("name").and_then(Value::as_str) != Some("ExitPlanMode") {
-            return None;
-        }
-        block
-            .get("input")?
-            .get("plan")?
-            .as_str()
-            .map(str::to_string)
-    })?;
-    let model = message
-        .get("model")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    let harness_version = value
-        .get("version")
-        .and_then(Value::as_str)
-        .map(str::to_string);
-    Some(ExitPlanModeMatch {
-        plan_text,
-        model,
-        harness_version,
-    })
-}
-
-/// The approving sibling transcript [`find_parent`] resolves: its session id,
-/// plus the approving turn's model/harness version — the fallback source for
-/// [`FrontmatterFields::model`]/`harness` on a cross-session wipe (see
-/// [`ExitPlanModeMatch`]'s doc for why the executing transcript can't supply
-/// them there).
-#[derive(Debug, PartialEq, Eq)]
-struct ParentMatch {
-    session_id: String,
-    model: Option<String>,
-    harness_version: Option<String>,
-}
-
-/// Scan `transcript_path`'s sibling directory for the transcript whose
-/// `ExitPlanMode` plan text — normalized by the same suffix-strip-and-trim
-/// applied to the injected prompt — hashes to `target_hash`. Newest-first,
-/// bounded to [`PARENT_SCAN_MAX_FILES`] siblings no older than
-/// [`PARENT_SCAN_MAX_AGE`] and no larger than [`PARENT_SCAN_MAX_FILE_BYTES`],
-/// streamed line-by-line (never loading a whole sibling into memory) with a
-/// substring pre-filter on each line before any JSON parse. `now` is the
-/// caller's `SystemTime::now()`, threaded through for testability without a
-/// frozen clock. Returns the matched sibling's session id on the first exact
-/// match — never a fuzzy guess — and only when its file stem passes
-/// [`identity::is_safe_session_id`]; a match against a hostile-named sibling
-/// is treated as no-match (`unknown`), since the returned id flows raw into
-/// the provenance text and the linkage row.
-fn find_parent(transcript_path: &Path, target_hash: &str, now: SystemTime) -> Option<ParentMatch> {
-    let dir = transcript_path.parent()?;
-    let mut candidates: Vec<(SystemTime, PathBuf)> = fs::read_dir(dir)
-        .ok()?
-        .flatten()
-        .filter_map(|entry| {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) != Some("jsonl") {
-                return None;
-            }
-            let meta = entry.metadata().ok()?;
-            if !meta.is_file() {
-                return None;
-            }
-            if meta.len() > PARENT_SCAN_MAX_FILE_BYTES {
-                return None;
-            }
-            let mtime = meta.modified().ok()?;
-            let age = now.duration_since(mtime).ok()?;
-            if age > PARENT_SCAN_MAX_AGE {
-                return None;
-            }
-            Some((mtime, path))
-        })
-        .collect();
-    candidates.sort_by_key(|(mtime, _)| std::cmp::Reverse(*mtime));
-    candidates.truncate(PARENT_SCAN_MAX_FILES);
-
-    for (_, path) in candidates {
-        let Ok(file) = fs::File::open(&path) else {
-            continue;
-        };
-        for line in BufReader::new(file).lines() {
-            let Ok(line) = line else {
-                continue;
-            };
-            if !line.contains("ExitPlanMode") {
-                continue;
-            }
-            let Some(exit_plan) = exit_plan_mode_match(&line) else {
-                continue;
-            };
-            let normalized = strip_trailing_suffix_lines_and_trim(&exit_plan.plan_text);
-            if sha256_hex(normalized.as_bytes()) == target_hash {
-                let session_id = path
-                    .file_stem()
-                    .map(|s| s.to_string_lossy().into_owned())
-                    .filter(|s| identity::is_safe_session_id(s))?;
-                return Some(ParentMatch {
-                    session_id,
-                    model: exit_plan.model,
-                    harness_version: exit_plan.harness_version,
-                });
-            }
-        }
-    }
-    None
-}
-
 // ---------------------------------------------------------------------------
 // Frontmatter (Design 2 / Design 18) + shared persist tail (Approach step 5)
 // ---------------------------------------------------------------------------
@@ -1389,10 +688,9 @@ struct FrontmatterFields<'a> {
     harness: Option<&'a str>,
     /// Salted, truncated machine digest (never the raw hostname).
     machine_digest: &'a str,
-    /// The approving session's `(name, session_id)` — identical to
-    /// `(own_name, own_session_id)` on same-session approval, the
-    /// `find_parent`-resolved sibling on a cross-session approve-and-clear
-    /// wipe, or `None` when no approving parent was found.
+    /// The approving session's `(name, session_id)` — on same-session
+    /// approval identical to `(own_name, own_session_id)`; `None` only when
+    /// no approving session is known.
     approved_in: Option<(&'a str, &'a str)>,
 }
 
@@ -1459,12 +757,31 @@ pub(crate) fn yaml_unquote(s: &str) -> String {
 /// value this crate itself generated or validated. Every value, sanitized or
 /// not, is then [`yaml_quote`]d.
 fn render_frontmatter(f: &FrontmatterFields) -> String {
-    let mut lines = vec![
-        "---".to_string(),
-        format!("status: {}", yaml_quote("in-flight")),
-        format!("updated: {}", yaml_quote(f.updated)),
-    ];
-    if let Some(b) = f.branch {
+    let mut lines = vec!["---".to_string()];
+    lines.extend(hook_frontmatter_lines(f, &[]));
+    lines.push("---".to_string());
+    lines.join("\n")
+}
+
+/// The hook-owned frontmatter lines (no fences). `plan_keys` names the keys
+/// the plan's OWN leading block already carries — [`render_document`] passes
+/// them so a living plan's recorded `status`/`updated`/`branch` wins over the
+/// hook's birth defaults (cadence-hooks#738). The identity keys
+/// (`body_sha256`, `session`, `session_id`, `model`, `harness`, `machine`,
+/// `approved_in`, `approved_session_id`) are always emitted: they are this
+/// persist's provenance, not plan state.
+fn hook_frontmatter_lines(f: &FrontmatterFields, plan_keys: &[&str]) -> Vec<String> {
+    let owned = |key: &str| plan_keys.contains(&key);
+    let mut lines = Vec::new();
+    if !owned("status") {
+        lines.push(format!("status: {}", yaml_quote("in-flight")));
+    }
+    if !owned("updated") {
+        lines.push(format!("updated: {}", yaml_quote(f.updated)));
+    }
+    if !owned("branch")
+        && let Some(b) = f.branch
+    {
         lines.push(format!(
             "branch: {}",
             yaml_quote(&identity::sanitize_field(b, identity::MAX_FIELD_DISPLAY))
@@ -1496,14 +813,54 @@ fn render_frontmatter(f: &FrontmatterFields) -> String {
         lines.push(format!("approved_in: {}", yaml_quote(name)));
         lines.push(format!("approved_session_id: {}", yaml_quote(sid)));
     }
-    lines.push("---".to_string());
-    lines.join("\n")
+    lines
 }
 
-/// The full document written to disk: frontmatter, a blank line, then the
-/// plan body, trailing-newline terminated.
+/// The top-level keys a plan's own frontmatter block declares — the bare
+/// `key` of every `key:` line at column 0. Byte-level, deliberately: the
+/// block is untrusted plan content, and this is the ONLY interpretation
+/// [`render_document`] makes of it (which hook defaults to suppress). Nested
+/// or indented keys, comments, and anything that is not `ident:` at column 0
+/// are ignored.
+fn plan_frontmatter_keys(block: &str) -> Vec<&str> {
+    block
+        .lines()
+        .filter_map(|line| {
+            let (key, _) = line.split_once(':')?;
+            (!key.is_empty()
+                && key
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-'))
+            .then_some(key)
+        })
+        .collect()
+}
+
+/// The full document written to disk, trailing-newline terminated.
+///
+/// A body with no leading frontmatter gets the hook's block, a blank line,
+/// then the body. A body that already OPENS with its own `---` block (a plan
+/// authored from the template carries `status:`/`next:`/`branch:` from birth)
+/// gets ONE merged block (cadence-hooks#738): the plan's own lines copied
+/// byte-for-byte first — untrusted content, never parsed beyond
+/// [`frontmatter_extent`]'s fence scan and [`plan_frontmatter_keys`]'s
+/// column-0 key read — then the hook-owned lines, with `status`/`updated`/
+/// `branch` suppressed when the plan's block already declares them; the body
+/// resumes after the plan's closing fence. Stacking a second block on top
+/// left SessionStart/outro reading the hook's `status: "in-flight"` /
+/// `branch:` forever, however far the plan had moved on.
 fn render_document(f: &FrontmatterFields, body: &str) -> String {
-    format!("{}\n\n{body}\n", render_frontmatter(f))
+    let Some((start, end, body_start)) = frontmatter_extent(body) else {
+        return format!("{}\n\n{body}\n", render_frontmatter(f));
+    };
+    let plan_block = &body[start..end];
+    let plan_keys = plan_frontmatter_keys(plan_block);
+    let mut lines = vec!["---".to_string()];
+    lines.extend(plan_block.lines().map(str::to_string));
+    lines.extend(hook_frontmatter_lines(f, &plan_keys));
+    lines.push("---".to_string());
+    let rest = body[body_start..].trim_start_matches(['\r', '\n']);
+    format!("{}\n\n{rest}\n", lines.join("\n"))
 }
 
 // ---------------------------------------------------------------------------
@@ -1967,94 +1324,14 @@ fn append_plan_links_row(row: &Value) {
     }
 }
 
-/// Schema version stamped on every `plan-skips.jsonl` row — its own stream,
-/// its own version, independent of [`PLAN_LINKS_SCHEMA_VERSION`] (a new
-/// stream per cadence#238 convention).
-const PLAN_SKIPS_SCHEMA_VERSION: u32 = 1;
-
-/// Cap on `<metrics_dir>/plan-skips.jsonl`'s size, mirroring
-/// `cadence_hooks_metrics::common`'s `MAX_DIAGNOSTICS_BYTES` cap pattern
-/// (`crates/metrics/src/common.rs:72-86`: check-then-skip on a size probe
-/// before ever opening for append). The stream is purely observational
-/// (cadence-hooks#695) — a dropped record past this cap costs no functional
-/// idempotency, since the row tier's own suppression keeps working from
-/// `plan-links.jsonl` regardless of whether this sibling stream is being
-/// written.
-const PLAN_SKIPS_MAX_BYTES: u64 = 1024 * 1024;
-
-/// Append one observability record to `<metrics_dir>/plan-skips.jsonl` when
-/// the row-tier layer silently suppresses a persist (cadence-hooks#695) — the
-/// gap this closes: a bare `CheckResult::allow()` left no artifact anywhere
-/// naming WHICH `plan_path` explained the skip, so answering "why didn't this
-/// persist" required re-deriving the hash by hand against `plan-links.jsonl`.
-///
-/// Fully fail-open (ADR-0001), same discipline as [`append_plan_links_row`]:
-/// a missing dir it can't create, a failed open/write, or a file already at
-/// [`PLAN_SKIPS_MAX_BYTES`] all degrade to a silent no-op. Never called on
-/// anything but the row-tier skip path — this must never become a nudge, and
-/// `plan_path` is written as given, never re-checked against the filesystem
-/// (a stray record naming a since-deleted file is still useful attribution).
-fn append_plan_skip_row(utc_now: &str, body_hash: &str, plan_path: &str, machine_digest: &str) {
-    let dir = cadence_hooks_metrics::metrics_dir();
-    if fs::create_dir_all(&dir).is_err() {
-        return;
-    }
-    let path = dir.join("plan-skips.jsonl");
-    if fs::metadata(&path).is_ok_and(|meta| meta.len() >= PLAN_SKIPS_MAX_BYTES) {
-        return;
-    }
-    let row = serde_json::json!({
-        "schemaVersion": PLAN_SKIPS_SCHEMA_VERSION,
-        "ts": utc_now,
-        "body_sha256": body_hash,
-        "plan_path": plan_path,
-        "machine": machine_digest,
-    });
-    if let Ok(mut file) = fs::OpenOptions::new().create(true).append(true).open(&path) {
-        let mut line = row.to_string();
-        line.push('\n');
-        let _ = file.write_all(line.as_bytes());
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use cadence_hooks_core::Outcome;
-    use cadence_hooks_core::test_builders::make_user_prompt_submit;
     use cadence_hooks_core::{ToolInput, ToolResponse};
     use tempfile::TempDir;
 
     // --- extraction: prefix gate ---
-
-    #[test]
-    fn non_matching_prefix_is_none() {
-        let input = HookInput {
-            prompt: Some("just a regular question".into()),
-            ..Default::default()
-        };
-        let r = run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "host");
-        assert_eq!(r.outcome, Outcome::Allow);
-    }
-
-    #[test]
-    fn prefix_match_is_case_sensitive() {
-        let input = HookInput {
-            prompt: Some("implement the following plan:\n\n# X\n\nbody".into()),
-            ..Default::default()
-        };
-        let r = run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "host");
-        assert_eq!(r.outcome, Outcome::Allow, "lowercase prefix must not match");
-    }
-
-    #[test]
-    fn no_prompt_allows() {
-        let input = HookInput::default();
-        let r = run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "host");
-        assert_eq!(r.outcome, Outcome::Allow);
-    }
-
-    // --- extraction: suffix strip + trim ---
 
     #[test]
     fn suffix_strip_current_variant() {
@@ -2676,7 +1953,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn run_persist_plan_never_writes_through_a_symlinked_docs_escaping_the_repo() {
+    fn approval_never_writes_through_a_symlinked_docs_escaping_the_repo() {
         // End-to-end: the same escape attempt must never reach a write, not
         // just fail the unit-level helper in isolation.
         let tmp = TempDir::new().unwrap();
@@ -2685,13 +1962,14 @@ mod tests {
         std::os::unix::fs::symlink(outside.path(), tmp.path().join("docs")).unwrap();
         let cwd = tmp.path().to_string_lossy().into_owned();
 
-        let input = make_user_prompt_submit(
+        let input = exit_plan_mode_post_tool_use(
             "sid12345",
-            "Implement the following plan:\n\n# X\n\nbody",
+            "# X\n\nbody",
             &cwd,
             &tmp.path().join("sid12345.jsonl").to_string_lossy(),
+            Some(false),
         );
-        let r = run_persist_plan(&input, "ts", "2026-07-20", "host");
+        let r = run_persist_plan_approval(&input, "ts", "2026-07-20", "host");
         assert_eq!(r.outcome, Outcome::Allow);
         assert!(
             !outside
@@ -2704,33 +1982,6 @@ mod tests {
     }
 
     // --- cross-trigger hash normalization (Design 18) ---
-
-    #[test]
-    fn cross_trigger_normalization_hashes_match() {
-        // The UserPromptSubmit path strips PLAN_PREFIX then normalizes; the
-        // PostToolUse path consumes `tool_response.plan` raw and normalizes
-        // the SAME way. Both must land on byte-identical text so a plan
-        // approved through either path hashes the same.
-        let prompt = format!(
-            "{PLAN_PREFIX}\n\n# Title\n\nbody text\n\nIf this plan can be broken down into \
-             discrete units of work, consider using the Agent tool to dispatch them."
-        );
-        let user_prompt_submit_body =
-            strip_trailing_suffix_lines_and_trim(prompt.strip_prefix(PLAN_PREFIX).unwrap());
-
-        // ExitPlanMode's own tool_input.plan never carries the harness prefix
-        // or suffix — but may carry an incidental trailing blank line.
-        let raw_exit_plan_mode_text = "# Title\n\nbody text\n\n";
-        let post_tool_use_body = strip_trailing_suffix_lines_and_trim(raw_exit_plan_mode_text);
-
-        assert_eq!(user_prompt_submit_body, post_tool_use_body);
-        assert_eq!(
-            sha256_hex(user_prompt_submit_body.as_bytes()),
-            sha256_hex(post_tool_use_body.as_bytes())
-        );
-    }
-
-    // --- frontmatter rendering ---
 
     fn base_fields<'a>(body_hash: &'a str, machine_digest: &'a str) -> FrontmatterFields<'a> {
         FrontmatterFields {
@@ -2820,6 +2071,65 @@ mod tests {
     }
 
     #[test]
+    fn render_document_merges_into_a_plan_s_own_frontmatter_block() {
+        // cadence-hooks#738: a template-authored plan already opens with its
+        // own block; the hook must MERGE, never stack a second block on top.
+        let fields = base_fields("hash", "digest");
+        let body =
+            "---\nstatus: done\nnext: \"ship it\"\nbranch: feat/x\n---\n\n# Title\n\nbody text";
+        let doc = render_document(&fields, body);
+        assert_eq!(
+            doc.matches("\n---\n").count(),
+            1,
+            "exactly one closing fence (one block), got:\n{doc}"
+        );
+        assert!(doc.starts_with("---\nstatus: done\nnext: \"ship it\"\nbranch: feat/x\n"));
+        // The plan's status/branch win: the hook's defaults are suppressed.
+        assert_eq!(
+            doc.matches("\nstatus:").count() + usize::from(doc.starts_with("---\nstatus:")),
+            1
+        );
+        assert!(!doc.contains("status: \"in-flight\""));
+        assert_eq!(doc.matches("\nbranch:").count(), 1);
+        // `updated` was absent from the plan's block, so the hook supplies it.
+        assert!(doc.contains("\nupdated: \"2026-07-25\"\n"));
+        assert!(doc.contains("\nbody_sha256: \"hash\"\n"));
+        assert!(doc.contains("\nsession_id: \"own-sid\"\n"));
+        let (frontmatter, rest) = doc
+            .split_once("---\n\n")
+            .expect("closing fence + blank line");
+        assert!(frontmatter.ends_with("\nmachine: \"digest\"\n"));
+        assert_eq!(rest, "# Title\n\nbody text\n");
+    }
+
+    #[test]
+    fn render_document_merge_copies_plan_keys_verbatim_without_interpreting_them() {
+        // Untrusted content: odd but well-formed lines pass through unchanged,
+        // and only a column-0 `ident:` suppresses a hook default.
+        let fields = base_fields("hash", "digest");
+        let body = "---\n  status: nested-is-not-top-level\n# status: a comment\nweird key: \"x\"\n---\nbody";
+        let doc = render_document(&fields, body);
+        assert!(doc.contains("\n  status: nested-is-not-top-level\n"));
+        assert!(doc.contains("\n# status: a comment\n"));
+        assert!(doc.contains("\nweird key: \"x\"\n"));
+        // None of those count as the plan declaring `status`, so the hook's
+        // default is still emitted — exactly once.
+        assert_eq!(doc.matches("\nstatus: \"in-flight\"\n").count(), 1);
+        assert_eq!(doc.matches("\n---\n").count(), 1);
+        assert!(doc.ends_with("---\n\nbody\n"));
+    }
+
+    #[test]
+    fn render_document_without_a_closing_fence_is_not_a_frontmatter_block() {
+        // A body that merely starts with `---` and never closes it is prose;
+        // the hook's block is prepended as usual.
+        let fields = base_fields("hash", "digest");
+        let doc = render_document(&fields, "---\nnot a block\n\n# Title");
+        assert!(doc.starts_with("---\nstatus: \"in-flight\"\n"));
+        assert!(doc.contains("---\n\n---\nnot a block\n\n# Title\n"));
+    }
+
+    #[test]
     fn yaml_quote_and_unquote_round_trip() {
         for value in ["plain", r#"has "quotes""#, r"has\backslash", ""] {
             assert_eq!(yaml_unquote(&yaml_quote(value)), value);
@@ -2834,227 +2144,6 @@ mod tests {
     }
 
     // --- provenance: parent resolution ---
-
-    /// `model`/`harness_version` model the assistant line's `message.model`
-    /// and top-level `version` — both `None` reproduces an older transcript
-    /// shape carrying neither.
-    fn exit_plan_mode_line(
-        plan: &str,
-        model: Option<&str>,
-        harness_version: Option<&str>,
-    ) -> String {
-        let mut message = serde_json::json!({
-            "role": "assistant",
-            "content": [{"type": "tool_use", "name": "ExitPlanMode", "input": {"plan": plan}}],
-        });
-        if let Some(m) = model {
-            message["model"] = serde_json::json!(m);
-        }
-        let mut line = serde_json::json!({ "message": message });
-        if let Some(v) = harness_version {
-            line["version"] = serde_json::json!(v);
-        }
-        line.to_string()
-    }
-
-    #[test]
-    fn find_parent_exact_hash_match() {
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody text";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
-
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found,
-            Some(ParentMatch {
-                session_id: "parent-session-id".to_string(),
-                model: None,
-                harness_version: None,
-            })
-        );
-    }
-
-    #[test]
-    fn find_parent_extracts_model_and_harness_version_from_matched_line() {
-        // Real transcripts stamp the approving assistant line with both
-        // `message.model` and a top-level `version` — this is the sole
-        // source `run_persist_plan` falls back to when the EXECUTING
-        // session's own (structurally empty, on a cross-session wipe)
-        // transcript resolves neither (cameronsjo/cadence-hooks#396 review).
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody text";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(
-            &sibling,
-            exit_plan_mode_line(plan_text, Some("claude-fable-5"), Some("2.1.214")),
-        )
-        .unwrap();
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found,
-            Some(ParentMatch {
-                session_id: "parent-session-id".to_string(),
-                model: Some("claude-fable-5".to_string()),
-                harness_version: Some("2.1.214".to_string()),
-            })
-        );
-    }
-
-    #[test]
-    fn find_parent_missing_model_and_harness_version_is_gracefully_none() {
-        // Older transcript lines (or a stripped-down fixture) may carry
-        // neither field — the match must still resolve, with both absent.
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody text";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now()).expect("parent must be found");
-        assert_eq!(found.model, None);
-        assert_eq!(found.harness_version, None);
-    }
-
-    #[test]
-    fn find_parent_same_file_wipe_resolves_to_self() {
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody text";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, exit_plan_mode_line(plan_text, None, None)).unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found.map(|p| p.session_id).as_deref(),
-            Some("own-session-id"),
-            "same-file wipe: parent resolves to the executing session itself"
-        );
-    }
-
-    #[test]
-    fn find_parent_no_match_is_unknown() {
-        let tmp = TempDir::new().unwrap();
-        let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(&sibling, exit_plan_mode_line("some other plan", None, None)).unwrap();
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, "nonexistent-hash", SystemTime::now());
-        assert_eq!(found, None);
-    }
-
-    #[test]
-    fn find_parent_ignores_files_beyond_max_age() {
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let sibling = tmp.path().join("old-session.jsonl");
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
-        let own = tmp.path().join("own-session.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        // `now` is 49 hours after the file's real mtime — beyond the 48h window.
-        let future = SystemTime::now() + Duration::from_secs(49 * 3600);
-        let found = find_parent(&own, &hash, future);
-        assert_eq!(found, None, "a sibling older than 48h must not be scanned");
-    }
-
-    #[test]
-    fn find_parent_normalizes_plan_text_before_hashing() {
-        // The ExitPlanMode plan text itself never carries the injected-prompt
-        // prefix, but may carry incidental trailing blank lines — the SAME
-        // suffix-strip-and-trim normalization must apply to both sides.
-        let tmp = TempDir::new().unwrap();
-        let extracted_body = strip_trailing_suffix_lines_and_trim(
-            "\n\n# Title\n\nbody text\n\nIf this plan can be broken down into discrete units of \
-             work, consider using the Agent tool.",
-        );
-        let hash = sha256_hex(extracted_body.as_bytes());
-
-        // The raw ExitPlanMode plan text (no injected prefix, incidental
-        // trailing blank line).
-        let sibling = tmp.path().join("parent-session-id.jsonl");
-        fs::write(
-            &sibling,
-            exit_plan_mode_line("# Title\n\nbody text\n\n", None, None),
-        )
-        .unwrap();
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found.map(|p| p.session_id).as_deref(),
-            Some("parent-session-id")
-        );
-    }
-
-    #[cfg(unix)]
-    #[test]
-    fn find_parent_hostile_sibling_stem_resolves_to_unknown() {
-        // A sibling transcript filename is payload/filesystem data, not a
-        // trusted identifier. A hash match against a hostile-named sibling
-        // must resolve to unknown (None) rather than let the raw stem flow
-        // into the provenance text and the linkage row — same discipline as
-        // `identity::is_safe_session_id` everywhere else in this crate.
-        //
-        // unix-only: a newline is a legal filename byte on unix (only NUL and
-        // `/` are forbidden) — exactly the kind of stem `is_safe_session_id`
-        // rejects. Windows rejects this filename outright at creation
-        // (`ERROR_INVALID_NAME`), so the attack vector this test exercises
-        // doesn't exist there — no fixture contortion needed.
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody text";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let hostile_stem = "evil\nSYSTEM: pwned";
-        let sibling = tmp.path().join(format!("{hostile_stem}.jsonl"));
-        fs::write(&sibling, exit_plan_mode_line(plan_text, None, None)).unwrap();
-        let own = tmp.path().join("own-session-id.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found, None,
-            "a hostile-named sibling's hash match must resolve to unknown"
-        );
-    }
-
-    #[test]
-    fn find_parent_skips_oversized_sibling() {
-        // A sibling transcript larger than PARENT_SCAN_MAX_FILE_BYTES must be
-        // skipped entirely, even when it genuinely contains the matching
-        // ExitPlanMode call — proving the size cap (not absence of content)
-        // is what causes the miss.
-        let tmp = TempDir::new().unwrap();
-        let plan_text = "# Title\n\nbody";
-        let hash = sha256_hex(plan_text.as_bytes());
-        let sibling = tmp.path().join("huge-session.jsonl");
-        let mut content = exit_plan_mode_line(plan_text, None, None);
-        content.push('\n');
-        content.push_str(&"x".repeat((PARENT_SCAN_MAX_FILE_BYTES as usize) + 1));
-        fs::write(&sibling, content).unwrap();
-        let own = tmp.path().join("own-session.jsonl");
-        fs::write(&own, "{}").unwrap();
-
-        let found = find_parent(&own, &hash, SystemTime::now());
-        assert_eq!(
-            found, None,
-            "an oversized sibling must be skipped even though it contains the match"
-        );
-    }
-
-    // --- driver tier parsing ---
 
     #[test]
     fn recommended_tier_priority_1_bold_driver_line() {
@@ -3345,228 +2434,6 @@ mod tests {
     use crate::registry::test_metrics_env::with_metrics_dir;
 
     #[test]
-    fn end_to_end_fresh_write_produces_nudge_and_linkage_row() {
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-
-        let prompt = "Implement the following plan:\n\n# Fix the Widget\n\nDo the thing.\n\n\
-                      If this plan can be broken down into discrete units of work, consider \
-                      using the Agent tool to dispatch them.";
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            prompt,
-            &cwd,
-            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
-        );
-
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
-        });
-        assert_eq!(r.outcome, Outcome::Nudge);
-        let msg = r.message.unwrap();
-        // The nudge embeds `path.display()`, which renders the platform's
-        // native separator (backslash on Windows) — normalize before
-        // asserting on the forward-slash-relative fragment.
-        let normalized_msg = cadence_hooks_core::normalize_path(&msg);
-        assert!(normalized_msg.contains("docs/plans/2026-07-20-fix-the-widget.md"));
-        assert!(msg.contains("approved in unknown"));
-
-        let written =
-            fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
-        assert!(written.starts_with("---\nstatus: \"in-flight\"\n"));
-        assert!(written.contains("# Fix the Widget"));
-        assert!(!written.contains("If this plan can be broken down"));
-        assert!(written.contains("session_id: \"child-session-id\""));
-        assert!(written.contains("body_sha256:"));
-        assert!(
-            !written.contains("approved_in:"),
-            "no parent resolved — approved_in must be omitted, never written as 'unknown'"
-        );
-        // Doctrine fix (cadence#248): the committed block carries the salted
-        // digest, never the raw hostname.
-        assert!(
-            !written.contains("test-host"),
-            "the raw hostname must never reach the committed frontmatter"
-        );
-        assert!(written.contains(&crate::provenance::machine_digest("test-host")));
-
-        let links = fs::read_to_string(metrics_dir.path().join("plan-links.jsonl")).unwrap();
-        assert!(links.contains("\"child_session_id\":\"child-session-id\""));
-        assert!(links.contains("\"parent_session_id\":null"));
-        // plan_path is forward-slash-normalized regardless of platform — a
-        // stable schema value for consumers, not the native separator.
-        assert!(links.contains("\"plan_path\":\"docs/plans/2026-07-20-fix-the-widget.md\""));
-        // Schema v2 (cameronsjo/cadence-hooks#396 review): the local-only
-        // linkage row now ALSO carries the salted digest — matching the
-        // committed frontmatter's own `machine` field — never the raw
-        // hostname, and no separate `repo` field.
-        assert!(links.contains(&format!(
-            "\"machine\":\"{}\"",
-            crate::provenance::machine_digest("test-host")
-        )));
-        assert!(!links.contains("test-host"));
-        assert!(!links.contains("\"host\""));
-        assert!(!links.contains("\"repo\""));
-    }
-
-    // --- late persist: the injected plan entry (cadence-hooks#672) ---
-
-    /// A minimal transcript whose head carries the harness's auto-continuation
-    /// plan injection — the entry shape live-captured from session beffcf50
-    /// (cadence-hooks#672): `type: "user"`, top-level `planContent` with the
-    /// BARE plan body, `origin.kind: "auto-continuation"`, and a message text
-    /// that carries the prefix + suffix chrome the hook must never persist.
-    fn write_injected_transcript(path: &Path, plan_body: &str) {
-        let msg_text = format!(
-            "Implement the following plan:\n\n{plan_body}\n\nIf this plan can be broken down \
-             into discrete units of work, consider using the Agent tool to dispatch them."
-        );
-        let injected = serde_json::json!({
-            "type": "user",
-            "isSidechain": false,
-            "origin": {"kind": "auto-continuation"},
-            "planContent": plan_body,
-            "message": {"role": "user", "content": msg_text},
-        });
-        let ordinary = serde_json::json!({
-            "type": "assistant",
-            "message": {"role": "assistant", "content": []},
-        });
-        fs::write(path, format!("{injected}\n{ordinary}\n")).unwrap();
-    }
-
-    #[test]
-    fn late_persist_recovers_the_injected_plan_on_a_prefixless_prompt() {
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, "# Fix the Widget\n\nDo the thing.");
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "sounds good, keep going",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-11T00:00:00Z", "2026-08-11", "test-host")
-        });
-        assert_eq!(r.outcome, Outcome::Nudge, "late persist must fire");
-        let written =
-            fs::read_to_string(tmp.path().join("docs/plans/2026-08-11-fix-the-widget.md")).unwrap();
-        assert!(written.contains("# Fix the Widget"));
-        assert!(
-            !written.contains("Implement the following plan:"),
-            "the persisted body is the bare plan, never the prompt chrome"
-        );
-        assert!(!written.contains("If this plan can be broken down"));
-    }
-
-    #[test]
-    fn late_persist_normalizes_to_the_same_hash_as_the_prefix_path() {
-        // The prefix path and the late path must hash byte-identical bodies
-        // (Design 18 extended to the third trigger): persist via the prefix
-        // path first, then a prefixless prompt over the injected transcript
-        // must be a silent idempotent skip — no second file, no second nudge.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, "# Fix the Widget\n\nDo the thing.");
-
-        let prefixed = make_user_prompt_submit(
-            "child-session-id",
-            "Implement the following plan:\n\n# Fix the Widget\n\nDo the thing.",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&prefixed, "2026-08-10T00:00:00Z", "2026-08-10", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-
-        let prefixless = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        // A LATER local date: the stems differ, so only a hash-level dedupe
-        // across the whole plans dir — not the same-stem claim ladder — can
-        // recognize the re-fire.
-        let r2 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(
-                &prefixless,
-                "2026-08-11T00:00:00Z",
-                "2026-08-11",
-                "test-host",
-            )
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Allow,
-            "already-persisted plan (different date stem) must be a silent skip"
-        );
-        assert!(
-            !tmp.path()
-                .join("docs/plans/2026-08-11-fix-the-widget.md")
-                .exists(),
-            "no duplicate file under the later date"
-        );
-    }
-
-    #[test]
-    fn late_persist_ignores_sidechain_and_plain_user_entries() {
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        // A sidechain injection (a subagent's plan) and an ordinary user entry
-        // with no planContent — neither may trigger a persist.
-        let sidechain = serde_json::json!({
-            "type": "user", "isSidechain": true,
-            "planContent": "# Subagent Plan\n\nnope.",
-            "message": {"role": "user", "content": "x"},
-        });
-        // Absent isSidechain fails CLOSED (the approval arm's is_agent
-        // doctrine): a payload-shape drift must not forge a persist.
-        let unmarked = serde_json::json!({
-            "type": "user",
-            "planContent": "# Unmarked Plan\n\nnope.",
-            "message": {"role": "user", "content": "y"},
-        });
-        let plain = serde_json::json!({
-            "type": "user", "isSidechain": false,
-            "message": {"role": "user", "content": "just chatting"},
-        });
-        fs::write(&transcript, format!("{sidechain}\n{unmarked}\n{plain}\n")).unwrap();
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "hello",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-11T00:00:00Z", "2026-08-11", "test-host")
-        });
-        assert_eq!(r.outcome, Outcome::Allow);
-        assert!(
-            !tmp.path().join("docs/plans").exists() || {
-                fs::read_dir(tmp.path().join("docs/plans")).unwrap().count() == 0
-            }
-        );
-    }
-
-    // --- approval arm: plan source fallback chain (cadence-hooks#672) ---
-
-    #[test]
     fn approval_falls_back_to_tool_input_plan() {
         let tmp = TempDir::new().unwrap();
         init_repo(tmp.path());
@@ -3741,14 +2608,15 @@ mod tests {
         let metrics_dir = TempDir::new().unwrap();
 
         // A harness-template-shaped plan: no Panel, no Alternatives, no boxes.
-        let bare = make_user_prompt_submit(
+        let bare = exit_plan_mode_post_tool_use(
             "fmt-session",
-            "Implement the following plan:\n\n# Bare Plan\n\nContext prose only.",
+            "# Bare Plan\n\nContext prose only.",
             &cwd,
             &tmp.path().join("fmt-session.jsonl").to_string_lossy(),
+            Some(false),
         );
         let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&bare, "2026-08-11T00:00:00Z", "2026-08-11", "test-host")
+            run_persist_plan_approval(&bare, "2026-08-11T00:00:00Z", "2026-08-11", "test-host")
         });
         let msg = r.message.unwrap();
         // One composed format-gate line naming every missing stanza
@@ -3765,16 +2633,17 @@ mod tests {
         );
 
         // A template-conforming plan gets the plain persist nudge only.
-        let full = make_user_prompt_submit(
+        let full = exit_plan_mode_post_tool_use(
             "fmt-session-2",
-            "Implement the following plan:\n\n# Full Plan\n\nPanel: reviewer ran — 1 finding, \
+            "# Full Plan\n\nPanel: reviewer ran — 1 finding, \
              1 folded in, 0 declined\n\n## Alternatives declined\n\n- none proposed — single \
              obvious approach\n\n- [ ] build it\n",
             &cwd,
             &tmp.path().join("fmt-session-2.jsonl").to_string_lossy(),
+            Some(false),
         );
         let r2 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&full, "2026-08-11T00:00:00Z", "2026-08-11", "test-host")
+            run_persist_plan_approval(&full, "2026-08-11T00:00:00Z", "2026-08-11", "test-host")
         });
         let msg2 = r2.message.unwrap();
         assert!(!msg2.contains("format gate:"));
@@ -3850,51 +2719,6 @@ mod tests {
     }
 
     #[test]
-    fn end_to_end_prompt_path_unpaneled_plan_appends_static_panel_sentence() {
-        // The UserPromptSubmit trigger extracts its body differently
-        // (PLAN_PREFIX strip vs the ExitPlanMode tool response), so the
-        // sentence wiring is asserted on this path too, both directions.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-
-        let prompt = "Implement the following plan:\n\n# Fix the Widget\n\nDo the thing.";
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            prompt,
-            &cwd,
-            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
-        });
-        assert_eq!(r.outcome, Outcome::Nudge);
-        assert!(
-            r.message
-                .unwrap()
-                .contains("format gate: plan lacks a settled Panel: line")
-        );
-
-        let prompt_settled = "Implement the following plan:\n\n# Fix the Sprocket\n\n\
-                              Panel: reviewer ran — 1 finding, folded\n\nDo the thing.";
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            prompt_settled,
-            &cwd,
-            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
-        });
-        assert_eq!(r.outcome, Outcome::Nudge);
-        assert!(
-            !r.message.unwrap().contains("a settled Panel: line"),
-            "the Panel stanza is settled here — it must not appear among the missing stanzas"
-        );
-    }
-
-    #[test]
     fn end_to_end_approval_unpaneled_plan_appends_static_panel_sentence() {
         let tmp = TempDir::new().unwrap();
         init_repo(tmp.path());
@@ -3967,933 +2791,6 @@ mod tests {
         assert_eq!(r.outcome, Outcome::Nudge);
         assert!(!r.message.unwrap().contains("a settled Panel: line"));
     }
-
-    #[test]
-    fn end_to_end_prefix_path_re_fire_is_a_silent_row_tier_skip() {
-        // Pre-cadence-hooks#703, the prefix path never consulted the row (or
-        // dir-scan) tier at all, so an identical re-fire of the SAME prompt
-        // (a resumed session replaying the same injection) re-nudged every
-        // time. The row tier now applies to both trigger paths (T1) — a
-        // re-fire on the prefix path is recognized and silently suppressed
-        // exactly like a late-path re-fire.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-
-        let prompt = "Implement the following plan:\n\n# Fix the Widget\n\nDo the thing.";
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            prompt,
-            &cwd,
-            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
-        );
-
-        let r1 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge, "the first persist still nudges");
-        let first_write =
-            fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
-
-        // Re-fire: same prompt, later timestamp (compaction/resume replay).
-        let r2 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-07-20T01:00:00Z", "2026-07-20", "test-host")
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Allow,
-            "the row tier now silently suppresses a prefix-path re-fire too"
-        );
-        let second_write =
-            fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md")).unwrap();
-        assert_eq!(
-            first_write, second_write,
-            "the file must never be rewritten"
-        );
-    }
-
-    // --- row-keyed tier-0 idempotency (cadence-hooks#690) ---
-
-    /// The late-path plan body every #690 test persists, and its hash.
-    const ROW_TIER_BODY: &str = "# Fix the Widget\n\nDo the thing.";
-
-    fn row_tier_hash() -> String {
-        sha256_hex(ROW_TIER_BODY.as_bytes())
-    }
-
-    /// A hand-built v2 row for `plan-links.jsonl` fixtures. `machine` carries
-    /// the digest of the e2e tests' shared `"test-host"` — the row-tier match
-    /// requires it (#699 security pass), so a fixture row must look like one
-    /// this machine wrote.
-    fn plan_links_fixture_row(child_session_id: &str, body_hash: &str) -> String {
-        plan_links_fixture_row_for_machine(
-            child_session_id,
-            body_hash,
-            &crate::provenance::machine_digest("test-host"),
-        )
-    }
-
-    fn plan_links_fixture_row_for_machine(
-        child_session_id: &str,
-        body_hash: &str,
-        machine: &str,
-    ) -> String {
-        serde_json::json!({
-            "schemaVersion": 2,
-            "ts": "2026-08-14T00:00:00Z",
-            "parent_session_id": null,
-            "child_session_id": child_session_id,
-            "machine": machine,
-            "plan_path": "docs/plans/2026-08-14-fix-the-widget.md",
-            "body_sha256": body_hash,
-        })
-        .to_string()
-    }
-
-    #[test]
-    fn row_tier_suppresses_a_wandered_cwd_late_refire_without_creating_plans_dir() {
-        // Facet-1 regression (cadence-hooks#690): once the row exists, a late
-        // re-fire in a DIFFERENT repo (the session's cwd wandered) must skip
-        // before any cwd-derived path is touched — the sibling repo never
-        // grows a docs/plans/.
-        let repo_a = TempDir::new().unwrap();
-        init_repo(repo_a.path());
-        let repo_b = TempDir::new().unwrap();
-        init_repo(repo_b.path());
-        let metrics_dir = TempDir::new().unwrap();
-        let transcript = repo_a.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let in_a = make_user_prompt_submit(
-            "child-session-id",
-            "go ahead",
-            &repo_a.path().to_string_lossy(),
-            &transcript.to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&in_a, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(
-            r1.outcome,
-            Outcome::Nudge,
-            "first late persist lands in repo A"
-        );
-
-        let in_b = make_user_prompt_submit(
-            "child-session-id",
-            "keep going",
-            &repo_b.path().to_string_lossy(),
-            &transcript.to_string_lossy(),
-        );
-        let r2 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&in_b, "2026-08-15T00:00:00Z", "2026-08-15", "test-host")
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Allow,
-            "the row suppresses the wandered re-fire"
-        );
-        assert!(
-            !repo_b.path().join("docs").exists(),
-            "the wandered-cwd repo must never grow docs/ (let alone docs/plans/)"
-        );
-    }
-
-    #[test]
-    fn row_tier_alone_explains_the_skip_after_the_plan_file_is_deleted() {
-        // Attribution: delete the persisted file so the dir scan CANNOT match —
-        // only the row can explain a skip. Mirrors the field repro (the
-        // delete-the-stray workflow).
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-        // Confirm the row exists before trusting any negative below.
-        let links = fs::read_to_string(metrics_dir.path().join("plan-links.jsonl")).unwrap();
-        assert!(links.contains(&row_tier_hash()));
-        assert!(links.contains("\"child_session_id\":\"child-session-id\""));
-
-        let plan_file = tmp.path().join("docs/plans/2026-08-14-fix-the-widget.md");
-        fs::remove_file(&plan_file).unwrap();
-
-        let r2 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T01:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Allow,
-            "with the file gone, only the row can explain this skip"
-        );
-        assert!(!plan_file.exists(), "no re-write after the row-keyed skip");
-
-        // Observability (cadence-hooks#695): the otherwise-silent skip left a
-        // plan-skips.jsonl record naming the matched plan_path — never gated
-        // on that path still existing (it was just deleted above).
-        let skips = fs::read_to_string(metrics_dir.path().join("plan-skips.jsonl")).unwrap();
-        assert!(skips.contains(&row_tier_hash()));
-        assert!(skips.contains("docs/plans/2026-08-14-fix-the-widget.md"));
-    }
-
-    #[test]
-    fn row_from_another_session_suppresses_machine_wide() {
-        // The #699 regression: a session id dies at every /clear/compaction
-        // restart while the harness re-injects the same planContent, so the
-        // row match is machine-keyed on the body hash ALONE. A row written
-        // under a prior window's id must suppress the restarted window's
-        // late re-fire — no new file, in any repo.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        fs::write(
-            metrics_dir.path().join("plan-links.jsonl"),
-            format!(
-                "{}\n",
-                plan_links_fixture_row("pre-restart-window-id", &row_tier_hash())
-            ),
-        )
-        .unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(
-            r.outcome,
-            Outcome::Allow,
-            "a prior window's row must suppress the restarted session's re-fire"
-        );
-        assert!(
-            !tmp.path().join("docs").exists(),
-            "no plans dir invented on the suppressed turn"
-        );
-    }
-
-    #[test]
-    fn row_from_another_machine_does_not_suppress() {
-        // The machine conjunct (#699 security pass): a metrics file reachable
-        // from more than one machine (synced config dir, shared storage) must
-        // not let machine A's persist suppress machine B's — only a row whose
-        // `machine` digest matches this run's host counts.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        fs::write(
-            metrics_dir.path().join("plan-links.jsonl"),
-            format!(
-                "{}\n",
-                plan_links_fixture_row_for_machine(
-                    "child-session-id",
-                    &row_tier_hash(),
-                    &crate::provenance::machine_digest("some-other-host"),
-                )
-            ),
-        )
-        .unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(
-            r.outcome,
-            Outcome::Nudge,
-            "another machine's row must not suppress this machine's persist"
-        );
-        assert!(
-            tmp.path()
-                .join("docs/plans/2026-08-14-fix-the-widget.md")
-                .exists()
-        );
-    }
-
-    #[test]
-    fn prefix_path_honors_a_matching_machine_row() {
-        // cadence-hooks#703: the row tier used to be late-scan-only, so a
-        // prefix-path re-fire against an already-persisted body ignored a
-        // matching row and wrote (or attempted to write) anyway. The row tier
-        // now applies to the prefix path too — a matching row is a silent
-        // allow, and no plans dir is invented for the skip.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        fs::write(
-            metrics_dir.path().join("plan-links.jsonl"),
-            format!(
-                "{}\n",
-                plan_links_fixture_row("child-session-id", &row_tier_hash())
-            ),
-        )
-        .unwrap();
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            &format!("Implement the following plan:\n\n{ROW_TIER_BODY}"),
-            &cwd,
-            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(
-            r.outcome,
-            Outcome::Allow,
-            "the row now suppresses the prefix path too"
-        );
-        assert!(
-            !tmp.path().join("docs").exists(),
-            "no plans dir invented on a row-suppressed prefix-path turn"
-        );
-
-        // Observability (cadence-hooks#695): the skip left a plan-skips.jsonl
-        // record naming the matched row's plan_path.
-        let skips = fs::read_to_string(metrics_dir.path().join("plan-skips.jsonl")).unwrap();
-        assert!(skips.contains(&row_tier_hash()));
-        assert!(skips.contains("docs/plans/2026-08-14-fix-the-widget.md"));
-    }
-
-    #[test]
-    fn malformed_rows_are_skipped_not_fatal() {
-        // Garbage lines around a valid matching row must not defeat (or
-        // panic) the check — the match still suppresses.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        fs::write(
-            metrics_dir.path().join("plan-links.jsonl"),
-            format!(
-                "not json at all\n{{\"body_sha256\": 42}}\n{}\n{{truncated",
-                plan_links_fixture_row("child-session-id", &row_tier_hash())
-            ),
-        )
-        .unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(
-            r.outcome,
-            Outcome::Allow,
-            "the valid row among garbage still matches"
-        );
-        assert!(
-            !tmp.path()
-                .join("docs/plans/2026-08-14-fix-the-widget.md")
-                .exists()
-        );
-    }
-
-    #[test]
-    fn row_beyond_the_tail_window_fails_open_to_the_dir_tier() {
-        // The bound documented honestly: a matching row that has scrolled out
-        // of the PLAN_LINKS_SCAN_MAX_BYTES tail window reads as "no row" and
-        // the persist proceeds (fail-open, ADR-0001) — sized just over the
-        // window with the match at the HEAD, no multi-MB fixture.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        let mut links = format!(
-            "{}\n",
-            plan_links_fixture_row("child-session-id", &row_tier_hash())
-        );
-        let mut n = 0u32;
-        while (links.len() as u64) <= PLAN_LINKS_SCAN_MAX_BYTES {
-            links.push_str(&plan_links_fixture_row(
-                "filler-session",
-                &format!("filler-{n}"),
-            ));
-            links.push('\n');
-            n += 1;
-        }
-        fs::write(metrics_dir.path().join("plan-links.jsonl"), links).unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(
-            r.outcome,
-            Outcome::Nudge,
-            "a row beyond the tail window must fail open and persist"
-        );
-        assert!(
-            tmp.path()
-                .join("docs/plans/2026-08-14-fix-the-widget.md")
-                .exists()
-        );
-    }
-
-    #[test]
-    fn force_env_skips_the_row_tier_and_persists() {
-        // The returnable escape (delete-and-retarget within one session): the
-        // stray file is deleted, the row would suppress the re-persist —
-        // CADENCE_PERSIST_PLAN_FORCE overrides the row tier for the turn.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-        let plan_file = tmp.path().join("docs/plans/2026-08-14-fix-the-widget.md");
-        fs::remove_file(&plan_file).unwrap();
-
-        let r2 = with_metrics_dir(metrics_dir.path(), || {
-            // SAFETY: inside the METRICS_ENV_LOCK critical section — every
-            // test that reaches the FORCE read is a late-path test holding
-            // this same lock, so no concurrent reader sees a torn state.
-            unsafe {
-                std::env::set_var("CADENCE_PERSIST_PLAN_FORCE", "1");
-            }
-            let r = run_persist_plan(&input, "2026-08-14T01:00:00Z", "2026-08-14", "test-host");
-            // SAFETY: same lock as above.
-            unsafe {
-                std::env::remove_var("CADENCE_PERSIST_PLAN_FORCE");
-            }
-            r
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Nudge,
-            "FORCE must override the row tier"
-        );
-        assert!(plan_file.exists(), "the plan is re-persisted under FORCE");
-    }
-
-    #[test]
-    fn dir_scan_layer_still_recognizes_without_a_row() {
-        // The second recognition layer stands on its own: a wiped metrics
-        // file (fresh dir, no row) plus an on-disk plan doc under an EARLIER
-        // date still makes the late re-fire a silent idempotent skip.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&transcript, ROW_TIER_BODY);
-
-        let metrics_one = TempDir::new().unwrap();
-        let prefixed = make_user_prompt_submit(
-            "child-session-id",
-            &format!("Implement the following plan:\n\n{ROW_TIER_BODY}"),
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_one.path(), || {
-            run_persist_plan(&prefixed, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-
-        // A fresh metrics dir models the wiped-file case: no row anywhere.
-        let metrics_two = TempDir::new().unwrap();
-        let late = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r2 = with_metrics_dir(metrics_two.path(), || {
-            run_persist_plan(&late, "2026-08-15T00:00:00Z", "2026-08-15", "test-host")
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Allow,
-            "the dir scan recognizes the earlier-dated doc with no row at all"
-        );
-        assert!(
-            !tmp.path()
-                .join("docs/plans/2026-08-15-fix-the-widget.md")
-                .exists(),
-            "no duplicate under the later date"
-        );
-    }
-
-    #[test]
-    fn dir_hash_scan_now_recognizes_a_prefix_path_re_fire_under_a_different_date_stem() {
-        // cadence-hooks#703's T1: the dir-hash-scan layer used to be
-        // late-scan-only. A prefix-path re-fire of the SAME body under a
-        // DIFFERENT date-stem (a fresh metrics dir models the row tier having
-        // nothing to say) is exactly what defeated the same-stem claim ladder
-        // before this fold — now the dir scan catches it on the prefix path
-        // too, mirroring `late_persist_normalizes_to_the_same_hash_as_the_prefix_path`
-        // but with BOTH calls on the prefix path instead of prefix-then-late.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-
-        let metrics_one = TempDir::new().unwrap();
-        let first = make_user_prompt_submit(
-            "child-session-id",
-            &format!("Implement the following plan:\n\n{ROW_TIER_BODY}"),
-            &cwd,
-            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_one.path(), || {
-            run_persist_plan(&first, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-
-        // A fresh metrics dir models the row tier having nothing to say —
-        // only the dir-hash scan can explain the skip below.
-        let metrics_two = TempDir::new().unwrap();
-        let second = make_user_prompt_submit(
-            "child-session-id-2",
-            &format!("Implement the following plan:\n\n{ROW_TIER_BODY}"),
-            &cwd,
-            &tmp.path()
-                .join("child-session-id-2.jsonl")
-                .to_string_lossy(),
-        );
-        let r2 = with_metrics_dir(metrics_two.path(), || {
-            run_persist_plan(&second, "2026-08-15T00:00:00Z", "2026-08-15", "test-host")
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Allow,
-            "the dir-hash scan recognizes the earlier-dated doc on the prefix path too"
-        );
-        assert!(
-            !tmp.path()
-                .join("docs/plans/2026-08-15-fix-the-widget.md")
-                .exists(),
-            "no duplicate file under the later date"
-        );
-    }
-
-    #[test]
-    fn dir_session_id_scan_recognizes_a_drifted_living_plan_with_a_matching_approving_parent() {
-        // cadence-hooks#703's T2 (third recognition layer): a living plan's
-        // body legitimately drifts after persist (ticked boxes, appended
-        // Deviations/Learnings), which defeats hash-based recognition
-        // entirely — but the persisted doc's `approved_session_id` never
-        // changes, so a re-fire whose resolved approving parent matches it is
-        // still recognized. Simulated directly: hand-write a persisted doc
-        // whose frontmatter names the approving parent session id but whose
-        // BODY has drifted (no `body_sha256:` match possible), then run a
-        // late re-fire whose parent transcript resolves to that same
-        // session id.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let plans_dir = tmp.path().join("docs/plans");
-        fs::create_dir_all(&plans_dir).unwrap();
-
-        let plan_path = plans_dir.join("2026-08-10-fix-the-widget.md");
-        fs::write(
-            &plan_path,
-            "---\n\
-             status: \"in-flight\"\n\
-             updated: \"2026-08-10\"\n\
-             session: \"some-name\"\n\
-             session_id: \"some-session-id\"\n\
-             approved_in: \"parent-name\"\n\
-             approved_session_id: \"parent-session-id\"\n\
-             ---\n\n\
-             # Fix the Widget\n\n- [x] already done, body has drifted since persist\n",
-        )
-        .unwrap();
-
-        // The parent transcript `find_parent` must resolve — an ExitPlanMode
-        // line whose plan text hashes to the CURRENT (late) re-fire's body.
-        let parent_transcript = tmp.path().join("parent-session-id.jsonl");
-        fs::write(
-            &parent_transcript,
-            exit_plan_mode_line(ROW_TIER_BODY, None, None),
-        )
-        .unwrap();
-
-        let child_transcript = tmp.path().join("child-session-id.jsonl");
-        write_injected_transcript(&child_transcript, ROW_TIER_BODY);
-
-        let metrics_dir = TempDir::new().unwrap();
-        let late = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &child_transcript.to_string_lossy(),
-        );
-        let r = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&late, "2026-08-16T00:00:00Z", "2026-08-16", "test-host")
-        });
-        assert_eq!(
-            r.outcome,
-            Outcome::Allow,
-            "no Driver: tier on this body — recognition is a silent allow"
-        );
-        assert!(
-            !tmp.path()
-                .join("docs/plans/2026-08-16-fix-the-widget.md")
-                .exists(),
-            "the drifted-but-recognized doc must not get a duplicate sibling"
-        );
-
-        let rows = fs::read_to_string(metrics_dir.path().join("plan-links.jsonl")).unwrap();
-        assert!(
-            rows.contains("\"parent_session_id\":\"parent-session-id\""),
-            "unlike the hash-scan-skip row, THIS layer resolved a real parent: {rows}"
-        );
-        assert!(rows.contains("docs/plans/2026-08-10-fix-the-widget.md"));
-    }
-
-    #[test]
-    fn force_env_bypasses_the_row_tier_on_the_prefix_path_too() {
-        // T5/T1: FORCE's escape must cover both trigger paths now that the
-        // row tier itself does.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let metrics_dir = TempDir::new().unwrap();
-
-        let prompt = format!("Implement the following plan:\n\n{ROW_TIER_BODY}");
-        let input = make_user_prompt_submit(
-            "child-session-id",
-            &prompt,
-            &cwd,
-            &tmp.path().join("child-session-id.jsonl").to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_dir.path(), || {
-            run_persist_plan(&input, "2026-08-14T00:00:00Z", "2026-08-14", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-        let plan_file = tmp.path().join("docs/plans/2026-08-14-fix-the-widget.md");
-        fs::remove_file(&plan_file).unwrap();
-
-        let r2 = with_metrics_dir(metrics_dir.path(), || {
-            // SAFETY: inside the METRICS_ENV_LOCK critical section — every
-            // test that reaches the FORCE read is a late-path test holding
-            // this same lock, so no concurrent reader sees a torn state.
-            unsafe {
-                std::env::set_var("CADENCE_PERSIST_PLAN_FORCE", "1");
-            }
-            let r = run_persist_plan(&input, "2026-08-14T01:00:00Z", "2026-08-14", "test-host");
-            // SAFETY: same lock as above.
-            unsafe {
-                std::env::remove_var("CADENCE_PERSIST_PLAN_FORCE");
-            }
-            r
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Nudge,
-            "FORCE must override the row tier on the prefix path too"
-        );
-        assert!(plan_file.exists(), "the plan is re-persisted under FORCE");
-    }
-
-    #[test]
-    fn dir_scan_skip_appends_row_and_nudges_directive_only_then_goes_silent() {
-        // Dir-scan-skip repair (Part R3): a re-fire recognized only by the
-        // dir scan (no row for it) must append a plan-links row —
-        // `parent_session_id` is `None` by construction, the approving
-        // parent is unknown on a plan already committed to `docs/plans/` —
-        // and nudge with the directive-only text (no "persisted to" claim,
-        // no format gates) when a tier was parsed. The appended row is what
-        // makes the ROW-CHECK layer suppress every subsequent turn for this
-        // body on this machine.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        let body = "# Fix the Widget\n\n## Orchestrator\n\n**Driver:** Sonnet — fully spec'd.";
-        write_injected_transcript(&transcript, body);
-
-        let metrics_one = TempDir::new().unwrap();
-        let prefixed = make_user_prompt_submit(
-            "child-session-id",
-            &format!("Implement the following plan:\n\n{body}"),
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_one.path(), || {
-            run_persist_plan(&prefixed, "2026-08-16T00:00:00Z", "2026-08-16", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-
-        // A fresh metrics dir models the wiped-file case: no row anywhere,
-        // so the dir scan (not the row check) recognizes the re-fire.
-        let metrics_two = TempDir::new().unwrap();
-        let late = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r2 = with_metrics_dir(metrics_two.path(), || {
-            run_persist_plan(&late, "2026-08-17T00:00:00Z", "2026-08-17", "test-host")
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Nudge,
-            "directive-only nudge when the re-fire's plan carries a parsed tier"
-        );
-        let msg2 = r2.message.unwrap();
-        assert!(
-            msg2.contains("This plan's recommended driver is sonnet"),
-            "the dir-scan-skip nudge must carry the directive: {msg2}"
-        );
-        assert!(
-            !msg2.contains("Approved plan persisted to"),
-            "a re-fire recognition is not a fresh persist claim: {msg2}"
-        );
-
-        let rows = fs::read_to_string(metrics_two.path().join("plan-links.jsonl")).unwrap();
-        assert!(
-            rows.contains("\"recommended_model\":\"sonnet\""),
-            "the dir-scan-skip row must carry the parsed tier: {rows}"
-        );
-        assert!(
-            rows.contains("\"parent_session_id\":null"),
-            "parent_session_id is unknown by construction on this path: {rows}"
-        );
-
-        // The row just appended makes the ROW-CHECK layer suppress the next
-        // turn silently — proving row-check suppression engages.
-        let third = make_user_prompt_submit(
-            "child-session-id",
-            "keep going",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r3 = with_metrics_dir(metrics_two.path(), || {
-            run_persist_plan(&third, "2026-08-18T00:00:00Z", "2026-08-18", "test-host")
-        });
-        assert_eq!(
-            r3.outcome,
-            Outcome::Allow,
-            "the row appended by the dir-scan-skip path suppresses the next turn"
-        );
-    }
-
-    #[test]
-    fn dir_scan_skip_appends_row_silently_when_no_tier_is_recorded() {
-        // Companion to the test above, covering the tier == None branch: the
-        // row must still be appended (and recommended_model omitted, not
-        // null) even when the re-fired plan carries no recognized Driver:
-        // anchor — the CHANGELOG's "closes a gap where this path never wrote
-        // the row that ends its own loop" claim applies regardless of tier.
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let cwd = tmp.path().to_string_lossy().into_owned();
-        let transcript = tmp.path().join("child-session-id.jsonl");
-        let body = ROW_TIER_BODY; // no Orchestrator/Driver block
-        write_injected_transcript(&transcript, body);
-
-        let metrics_one = TempDir::new().unwrap();
-        let prefixed = make_user_prompt_submit(
-            "child-session-id",
-            &format!("Implement the following plan:\n\n{body}"),
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r1 = with_metrics_dir(metrics_one.path(), || {
-            run_persist_plan(&prefixed, "2026-08-16T00:00:00Z", "2026-08-16", "test-host")
-        });
-        assert_eq!(r1.outcome, Outcome::Nudge);
-
-        let metrics_two = TempDir::new().unwrap();
-        let late = make_user_prompt_submit(
-            "child-session-id",
-            "carry on",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r2 = with_metrics_dir(metrics_two.path(), || {
-            run_persist_plan(&late, "2026-08-17T00:00:00Z", "2026-08-17", "test-host")
-        });
-        assert_eq!(
-            r2.outcome,
-            Outcome::Allow,
-            "no tier parsed → silent allow, no directive-only nudge"
-        );
-
-        let rows = fs::read_to_string(metrics_two.path().join("plan-links.jsonl")).unwrap();
-        assert!(
-            !rows.contains("recommended_model"),
-            "the row must still be appended, omitting recommended_model (not null): {rows}"
-        );
-        assert!(
-            rows.contains("\"parent_session_id\":null"),
-            "parent_session_id is unknown by construction on this path: {rows}"
-        );
-
-        // The row appended on the tier==None branch must still suppress the
-        // next turn via the row-check layer.
-        let third = make_user_prompt_submit(
-            "child-session-id",
-            "keep going",
-            &cwd,
-            &transcript.to_string_lossy(),
-        );
-        let r3 = with_metrics_dir(metrics_two.path(), || {
-            run_persist_plan(&third, "2026-08-18T00:00:00Z", "2026-08-18", "test-host")
-        });
-        assert_eq!(
-            r3.outcome,
-            Outcome::Allow,
-            "the row appended on the tier==None branch still suppresses the next turn"
-        );
-    }
-
-    #[test]
-    fn end_to_end_model_and_harness_fall_back_to_the_approving_parent_transcript() {
-        // The regression this fold fixes (cameronsjo/cadence-hooks#396
-        // review): on approve-and-clear, the EXECUTING session's own
-        // transcript is structurally empty at this point — no assistant turn
-        // has landed there yet — so resolving model/harness against it always
-        // returns `None`. The APPROVING parent's transcript (the one
-        // `find_parent` already walks to resolve `approved_in`) is the
-        // fallback source, and it DOES carry a populated `model`/`version`.
-        //
-        // `resolve_harness` has ITS OWN internal `AI_AGENT` env fallback
-        // (legitimate in production — Claude Code sets it for every hook
-        // subprocess), which would otherwise mask the parent-fallback this
-        // test targets with whatever value happens to be ambient on the
-        // machine running `cargo test`. Pin it to `None` for the duration so
-        // only the parent-transcript fallback can supply a value, via the
-        // SAME lock `warn_commit_provenance`'s own AI_AGENT tests use (a
-        // second, independently-locked mutator of this process-global var
-        // would itself be a race, not an isolation fix).
-        crate::warn_commit_provenance::with_ai_agent_env(None, || {
-            let tmp = TempDir::new().unwrap();
-            init_repo(tmp.path());
-            let cwd = tmp.path().to_string_lossy().into_owned();
-            let metrics_dir = TempDir::new().unwrap();
-
-            let plan_text = "# Fix the Widget\n\nDo the thing.";
-            let parent_transcript = tmp.path().join("parent-session-id.jsonl");
-            fs::write(
-                &parent_transcript,
-                exit_plan_mode_line(plan_text, Some("claude-fable-5"), Some("2.1.214")),
-            )
-            .unwrap();
-
-            // Realistic shape: a fresh, just-started child session's
-            // transcript has no assistant turn yet at UserPromptSubmit time.
-            let child_transcript = tmp.path().join("child-session-id.jsonl");
-            fs::write(&child_transcript, "").unwrap();
-
-            let prompt = format!("Implement the following plan:\n\n{plan_text}");
-            let input = make_user_prompt_submit(
-                "child-session-id",
-                &prompt,
-                &cwd,
-                &child_transcript.to_string_lossy(),
-            );
-
-            with_metrics_dir(metrics_dir.path(), || {
-                run_persist_plan(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host");
-            });
-
-            let written =
-                fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-fix-the-widget.md"))
-                    .unwrap();
-            assert!(
-                written.contains("model: \"claude-fable-5\""),
-                "model falls back to the approving parent's transcript: {written}"
-            );
-            assert!(
-                written.contains("harness: \"claude-code 2.1.214\""),
-                "harness falls back to the approving parent's transcript: {written}"
-            );
-        });
-    }
-
-    #[test]
-    fn no_cwd_allows() {
-        let input = HookInput {
-            prompt: Some("Implement the following plan:\n\n# X\n\nbody".into()),
-            session_id: Some("sid".into()),
-            ..Default::default()
-        };
-        let r = run_persist_plan(&input, "ts", "2026-07-20", "host");
-        assert_eq!(r.outcome, Outcome::Allow);
-    }
-
-    #[test]
-    fn non_git_repo_cwd_allows() {
-        let tmp = TempDir::new().unwrap();
-        let input = HookInput {
-            prompt: Some("Implement the following plan:\n\n# X\n\nbody".into()),
-            session_id: Some("sid".into()),
-            cwd: Some(tmp.path().to_string_lossy().into_owned()),
-            ..Default::default()
-        };
-        let r = run_persist_plan(&input, "ts", "2026-07-20", "host");
-        assert_eq!(r.outcome, Outcome::Allow);
-    }
-
-    #[test]
-    fn unsafe_session_id_allows() {
-        let tmp = TempDir::new().unwrap();
-        init_repo(tmp.path());
-        let input = HookInput {
-            prompt: Some("Implement the following plan:\n\n# X\n\nbody".into()),
-            session_id: Some("../escape".into()),
-            cwd: Some(tmp.path().to_string_lossy().into_owned()),
-            ..Default::default()
-        };
-        let r = run_persist_plan(&input, "ts", "2026-07-20", "host");
-        assert_eq!(r.outcome, Outcome::Allow);
-        assert!(!tmp.path().join("docs").exists(), "nothing written");
-    }
-
-    // --- PersistPlanApproval: same-session PostToolUse trigger ---
 
     fn exit_plan_mode_post_tool_use(
         session_id: &str,
@@ -5137,6 +3034,138 @@ mod tests {
             "\"machine\":\"{}\"",
             crate::provenance::machine_digest("test-host")
         )));
+    }
+
+    #[test]
+    fn end_to_end_approval_merges_a_template_plan_s_frontmatter_into_one_block() {
+        // cadence-hooks#738 end to end: the written file carries ONE block
+        // whose `status:` is the plan's, and the SessionStart scanner's
+        // reader (`leading_frontmatter_block`) sees the plan's keys.
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+        let transcript_path = tmp.path().join("merge-sid.jsonl");
+        fs::write(&transcript_path, "{}").unwrap();
+
+        let input = exit_plan_mode_post_tool_use(
+            "merge-sid",
+            "---\nstatus: in-flight\nnext: \"Phase 2\"\nbranch: main\n---\n\n# Merge Me\n\n- [x] done",
+            &cwd,
+            &transcript_path.to_string_lossy(),
+            Some(false),
+        );
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Nudge);
+        let written =
+            fs::read_to_string(tmp.path().join("docs/plans/2026-07-20-merge-me.md")).unwrap();
+        assert_eq!(
+            written.matches("\n---\n").count(),
+            1,
+            "one block:\n{written}"
+        );
+        let block = leading_frontmatter_block(&written).expect("leading block");
+        assert!(block.starts_with("status: in-flight\nnext: \"Phase 2\"\nbranch: main\n"));
+        assert!(block.contains("body_sha256: \""));
+        assert!(block.contains("approved_session_id: \"merge-sid\""));
+        assert_eq!(block.matches("status:").count(), 1);
+        assert!(written.ends_with("---\n\n# Merge Me\n\n- [x] done\n"));
+    }
+
+    #[test]
+    fn approval_opt_out_via_process_env_writes_nothing() {
+        // cadence-hooks#692: any non-empty CADENCE_NO_PERSIST_PLAN skips the
+        // persist (no file, no row), exit-clean allow.
+        // Every approval test in this module reads the process env for the
+        // flag, and the ones asserting a persist run inside `with_metrics_dir`,
+        // which takes `METRICS_ENV_LOCK` — so holding that same lock across
+        // the set/unset here is what keeps a concurrently running sibling
+        // from observing the flag. `CADENCE_METRICS_DIR` is set by hand for
+        // the same reason (calling `with_metrics_dir` would self-deadlock).
+        let _guard = crate::registry::test_metrics_env::METRICS_ENV_LOCK
+            .lock()
+            .unwrap_or_else(|e| e.into_inner());
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+        let transcript_path = tmp.path().join("optout-sid.jsonl");
+        fs::write(&transcript_path, "{}").unwrap();
+        let input = exit_plan_mode_post_tool_use(
+            "optout-sid",
+            "# Opt Out\n\nbody",
+            &cwd,
+            &transcript_path.to_string_lossy(),
+            Some(false),
+        );
+        let prev_metrics = std::env::var_os("CADENCE_METRICS_DIR");
+        // SAFETY: serialized on METRICS_ENV_LOCK above, like `with_metrics_dir`.
+        unsafe {
+            std::env::set_var("CADENCE_METRICS_DIR", metrics_dir.path());
+            std::env::set_var("CADENCE_NO_PERSIST_PLAN", "1");
+        }
+        let r =
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host");
+        unsafe { std::env::remove_var("CADENCE_NO_PERSIST_PLAN") };
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(
+            !tmp.path().join("docs/plans").exists(),
+            "no plans dir, no file"
+        );
+        assert!(!metrics_dir.path().join("plan-links.jsonl").exists());
+
+        // Control: the same payload without the flag persists.
+        let r2 =
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host");
+        unsafe {
+            match prev_metrics {
+                Some(v) => std::env::set_var("CADENCE_METRICS_DIR", v),
+                None => std::env::remove_var("CADENCE_METRICS_DIR"),
+            }
+        }
+        assert_eq!(r2.outcome, Outcome::Nudge);
+        assert!(tmp.path().join("docs/plans/2026-07-20-opt-out.md").exists());
+    }
+
+    #[test]
+    fn approval_opt_out_via_repo_settings_env_block_writes_nothing() {
+        // Repo-level flag only — no process env mutation, so no lock needed.
+        let tmp = TempDir::new().unwrap();
+        init_repo(tmp.path());
+        fs::create_dir_all(tmp.path().join(".claude")).unwrap();
+        fs::write(
+            tmp.path().join(".claude/settings.json"),
+            r#"{"env":{"CADENCE_NO_PERSIST_PLAN":"1"}}"#,
+        )
+        .unwrap();
+        let cwd = tmp.path().to_string_lossy().into_owned();
+        let metrics_dir = TempDir::new().unwrap();
+        let transcript_path = tmp.path().join("optout2.jsonl");
+        fs::write(&transcript_path, "{}").unwrap();
+        let input = exit_plan_mode_post_tool_use(
+            "optout2",
+            "# Opt Out Two\n\nbody",
+            &cwd,
+            &transcript_path.to_string_lossy(),
+            Some(false),
+        );
+        let r = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r.outcome, Outcome::Allow);
+        assert!(!tmp.path().join("docs/plans").exists());
+        // An EMPTY value is not an opt-out.
+        fs::write(
+            tmp.path().join(".claude/settings.json"),
+            r#"{"env":{"CADENCE_NO_PERSIST_PLAN":""}}"#,
+        )
+        .unwrap();
+        let r2 = with_metrics_dir(metrics_dir.path(), || {
+            run_persist_plan_approval(&input, "2026-07-20T00:00:00Z", "2026-07-20", "test-host")
+        });
+        assert_eq!(r2.outcome, Outcome::Nudge);
     }
 
     #[test]

--- a/crates/session/src/plan_scan.rs
+++ b/crates/session/src/plan_scan.rs
@@ -24,8 +24,7 @@
 //! every plan doc is committed source, but a shared checkout can carry a
 //! contributor-authored file, so this scan treats the corpus as adversarial
 //! input, not just large input: candidates are capped to the newest
-//! [`PLAN_SCAN_MAX_FILES`] by mtime (mirroring
-//! `persist_plan::find_parent`'s newest-first bound), a symlinked or
+//! [`PLAN_SCAN_MAX_FILES`] by mtime (a newest-first bound), a symlinked or
 //! non-regular `.md` entry is skipped via `symlink_metadata` rather than
 //! opened, each file's read is capped to [`PLAN_SCAN_READ_CAP_BYTES`], and
 //! the rendered disclosure itself caps at [`PLAN_SCAN_MAX_EMITTED_LINES`]
@@ -58,8 +57,7 @@ use std::time::SystemTime;
 const PLAN_SCAN_READ_CAP_BYTES: u64 = 64 * 1024;
 
 /// Cap on how many `docs/plans/*.md` candidates are even considered, newest
-/// by mtime — mirrors `persist_plan::find_parent`'s `PARENT_SCAN_MAX_FILES`
-/// bound on sibling transcripts. Bounds the scan's total work independent of
+/// by mtime. Bounds the scan's total work independent of
 /// how large (or adversarially padded) the directory grows.
 const PLAN_SCAN_MAX_FILES: usize = 50;
 

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1612,27 +1612,7 @@
     },
     {
       "criticality": "workflow",
-      "description": "Persist an approved plan whose post-approval turn was wiped, nudging when it carries no settled Panel: line (UserPromptSubmit)",
-      "event": "UserPromptSubmit",
-      "name": "persist-plan",
-      "plugin": "session",
-      "protected": false,
-      "status": "native",
-      "applicable": true,
-      "evidence": "tests/hook_registration_audit.rs",
-      "wiring": [
-        {
-          "plugin": "cadence",
-          "event": "UserPromptSubmit",
-          "matcher": "*",
-          "if": null,
-          "commandHash": "b7a6e48b7e6f883899674c899e991bb289c0e65c7f4fcf00ee5ff602bb812ad0"
-        }
-      ]
-    },
-    {
-      "criticality": "workflow",
-      "description": "Persist an approved plan on same-session approval, nudging when it carries no settled Panel: line (PostToolUse:ExitPlanMode)",
+      "description": "Persist an approved plan at approval, merging into its own frontmatter and nudging when it carries no settled Panel: line; CADENCE_NO_PERSIST_PLAN opts out (PostToolUse:ExitPlanMode)",
       "event": "PostToolUse",
       "name": "persist-plan-approval",
       "plugin": "session",

--- a/src/main.rs
+++ b/src/main.rs
@@ -405,8 +405,6 @@ enum SessionCommands {
     BackstopRecord,
     /// Warn at session start when the last session in this repo left loose ends (SessionStart)
     BackstopWarn,
-    /// Persist an approved plan whose post-approval turn was wiped (UserPromptSubmit)
-    PersistPlan,
     /// Persist an approved plan on same-session approval (PostToolUse:ExitPlanMode)
     PersistPlanApproval,
     /// Nudge once per session when commits keep skipping the branch's in-flight plan (PostToolUse:Bash)
@@ -520,7 +518,6 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             SessionCommands::End => "end",
             SessionCommands::BackstopRecord => "backstop-record",
             SessionCommands::BackstopWarn => "backstop-warn",
-            SessionCommands::PersistPlan => "persist-plan",
             SessionCommands::PersistPlanApproval => "persist-plan-approval",
             SessionCommands::NudgePlanTick => "nudge-plan-tick",
             SessionCommands::WarnPlanReadyFlip => "warn-plan-ready-flip",
@@ -846,7 +843,6 @@ fn main() {
     let pre = HookEvent::PreToolUse;
     let post = HookEvent::PostToolUse;
     let session = HookEvent::SessionStart;
-    let user_prompt_submit = HookEvent::UserPromptSubmit;
 
     match cli.command {
         Commands::Try {
@@ -1284,11 +1280,6 @@ fn main() {
             SessionCommands::BackstopWarn => dispatch::run_logged_check(
                 &cadence_hooks_session::backstop::BackstopWarn,
                 session,
-                canonical_hook,
-            ),
-            SessionCommands::PersistPlan => dispatch::run_logged_check(
-                &cadence_hooks_session::persist_plan::PersistPlan,
-                user_prompt_submit,
                 canonical_hook,
             ),
             SessionCommands::PersistPlanApproval => dispatch::run_logged_check(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -418,14 +418,8 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::SessionStart),
     },
     HookEntry {
-        name: "persist-plan",
-        description: "Persist an approved plan whose post-approval turn was wiped, nudging when it carries no settled Panel: line (UserPromptSubmit)",
-        plugin: "session",
-        event: Some(HookEvent::UserPromptSubmit),
-    },
-    HookEntry {
         name: "persist-plan-approval",
-        description: "Persist an approved plan on same-session approval, nudging when it carries no settled Panel: line (PostToolUse:ExitPlanMode)",
+        description: "Persist an approved plan at approval, merging into its own frontmatter and nudging when it carries no settled Panel: line; CADENCE_NO_PERSIST_PLAN opts out (PostToolUse:ExitPlanMode)",
         plugin: "session",
         event: Some(HookEvent::PostToolUse),
     },
@@ -569,29 +563,22 @@ pub fn sample_for(namespace: &str, subcommand: &str) -> Option<&'static str> {
         ("session", "backstop-warn") => {
             Some(r#"{"session_id":"test","source":"startup","cwd":"/tmp"}"#)
         }
-        // persist-plan gates on an exact "Implement the following plan:"
-        // prefix; the generic UserPromptSubmit sample carries no cwd/session_id
-        // so `try` would fail open before ever reaching the write path.
+        // persist-plan-approval gates on tool_name == "ExitPlanMode" and a
+        // non-empty tool_response.plan; the generic PostToolUse sample carries
+        // neither, so `try` would fail open before ever reaching the write
+        // path.
         //
         // `cwd` is a deliberately NONEXISTENT path, and `try_hook`'s
         // `CWD_OVERRIDE_REFUSED` list keeps it that way — this hook has a
         // genuine filesystem WRITE side effect, and `try`'s normal behavior
         // (inject the REAL current_dir(), so most checks exercise real repo
         // detection) would otherwise let a bare `cadence-hooks try session
-        // persist-plan` actually create a plan doc in whatever repo the user
-        // ran it from (cameronsjo/cadence-hooks#396 review: verified end to
-        // end — a real plan doc landed in a real repo during review). A
+        // persist-plan-approval` actually create a plan doc in whatever repo
+        // the user ran it from (cameronsjo/cadence-hooks#396 review: verified
+        // end to end — a real plan doc landed in a real repo during review). A
         // nonexistent directory makes `repo_root`'s `git -C <cwd> …` spawn
         // fail deterministically, so the check reaches (and exercises) its
         // "not a git repo" fail-open arm instead of ever writing.
-        ("session", "persist-plan") => Some(
-            r#"{"session_id":"test","prompt":"Implement the following plan:\n\n# Try Sample\n\nbody text","cwd":"/nonexistent-cadence-hooks-try-sandbox","transcript_path":"/tmp/test.jsonl"}"#,
-        ),
-        // persist-plan-approval gates on tool_name == "ExitPlanMode" and a
-        // non-empty tool_response.plan; the generic PostToolUse sample carries
-        // neither, so `try` would fail open before ever reaching the write
-        // path. Same nonexistent-`cwd` discipline as `persist-plan` above —
-        // see that entry's comment.
         ("session", "persist-plan-approval") => Some(
             // Extra `#` in the raw-string delimiter: the payload's own plan
             // text embeds a literal `"#` (a quote immediately followed by an

--- a/src/try_hook.rs
+++ b/src/try_hook.rs
@@ -248,22 +248,19 @@ fn payload_preview(payload: &str, user_supplied: bool, show_payload: bool) -> St
 /// checks exercise real repo/git-state detection — is correct for the
 /// overwhelming majority of hooks, which only ever READ state. It is actively
 /// dangerous for a hook with a genuine filesystem WRITE side effect: injecting
-/// a real repo path let a bare `cadence-hooks try session persist-plan` (or
-/// `persist-plan-approval`) actually create a plan doc in whatever repo the
+/// a real repo path let a bare `cadence-hooks try session persist-plan-approval`
+/// (or the since-removed `persist-plan`) actually create a plan doc in whatever repo the
 /// user happened to be standing in when they ran `try` — reachable endpoints
 /// included `~/.claude/rules/`. Verified end to end (cameronsjo/cadence-hooks#396
 /// review): a real plan doc landed in a real repo during review, then had to
 /// be manually removed.
 ///
 /// Every entry here MUST carry its own `cwd` in its `registry::sample_for`
-/// override (see `session persist-plan`/`persist-plan-approval`'s overrides),
+/// override (see `session persist-plan-approval`'s override),
 /// pointed at a path that cannot resolve as a git repo — never left absent,
 /// since an absent `cwd` degrades most Checks to a no-op fail-open, not a
 /// demonstration of the hook's real behavior.
-const CWD_OVERRIDE_REFUSED: &[(&str, &str)] = &[
-    ("session", "persist-plan"),
-    ("session", "persist-plan-approval"),
-];
+const CWD_OVERRIDE_REFUSED: &[(&str, &str)] = &[("session", "persist-plan-approval")];
 
 /// The sample payload for a hook, with the real working directory injected
 /// so hooks that resolve git state see the repo `try` was run from — EXCEPT

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -278,15 +278,10 @@ const INTENTIONAL_CROSS_PLUGIN_HOOKS: &[(&str, &str, &str)] = &[
     // The hook has to ride the always-on cadence plugin to fire at all, while
     // `session` is the clap namespace that owns plan/session state
     // (cameronsjo/cadence-hooks#348, cameronsjo/cadence#507).
-    (
-        "cadence",
-        "session persist-plan",
-        "must ride the always-on cadence plugin; `session` is its clap namespace",
-    ),
-    // Same rationale as its sibling above: the approval hook rides the
-    // always-on cadence plugin while `session` owns plan/session state.
-    // Wiring shipped in the cadence monorepo without this entry, leaving the
-    // audit red for any workspace with a current sibling checkout (#460).
+    // The approval hook rides the always-on cadence plugin while `session`
+    // owns plan/session state. Wiring shipped in the cadence monorepo without
+    // this entry once, leaving the audit red for any workspace with a current
+    // sibling checkout (#460).
     (
         "cadence",
         "session persist-plan-approval",

--- a/tests/persist_plan_driver_tier.rs
+++ b/tests/persist_plan_driver_tier.rs
@@ -15,7 +15,7 @@
 //! What the inline tests do NOT cover is the compiled BINARY's own stdin/
 //! stdout contract for this feature: real JSON on stdin, the real
 //! `hookSpecificOutput.additionalContext` envelope on stdout, and the CLI
-//! surface (`session persist-plan` / `session persist-plan-approval`) a real
+//! surface (`session persist-plan-approval`) a real
 //! Claude Code hook invocation actually drives. That is exactly the gap this
 //! repo's existing top-level `tests/*.rs` integration suite fills for other
 //! hooks (see `tests/session_markers.rs`, `tests/try_hook.rs`), so this file

--- a/tests/try_hook.rs
+++ b/tests/try_hook.rs
@@ -339,8 +339,8 @@ fn try_metrics_logger_never_writes_into_the_configured_metrics_dir() {
 fn try_persist_plan_never_writes_a_real_plan_doc() {
     // Regression (cameronsjo/cadence-hooks#396 review): `try`'s normal cwd
     // injection (the real current_dir(), so most checks exercise real repo
-    // detection) let a bare `cadence-hooks try session persist-plan` (or
-    // `persist-plan-approval`) actually create a plan doc in whatever repo
+    // detection) let a bare `cadence-hooks try session persist-plan-approval`
+    // (or the since-removed `persist-plan`) actually create a plan doc in whatever repo
     // the user was standing in — verified end to end during review, a real
     // file landed and had to be manually removed. Stand explicitly inside a
     // REAL git repo (the worst case: the check's `repo_root` resolution
@@ -354,19 +354,13 @@ fn try_persist_plan_never_writes_a_real_plan_doc() {
         .expect("git init");
     assert!(init.success());
 
-    for subcommand in ["persist-plan", "persist-plan-approval"] {
-        let mut cmd = cadence_hooks();
-        cmd.args(["try", "session", subcommand]);
-        cmd.current_dir(repo.path());
+    let mut cmd = cadence_hooks();
+    cmd.args(["try", "session", "persist-plan-approval"]);
+    cmd.current_dir(repo.path());
 
-        let output = cmd.output().expect("failed to execute binary");
-        let stdout = String::from_utf8_lossy(&output.stdout);
-        assert_eq!(
-            output.status.code(),
-            Some(0),
-            "{subcommand} stdout: {stdout}"
-        );
-    }
+    let output = cmd.output().expect("failed to execute binary");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert_eq!(output.status.code(), Some(0), "stdout: {stdout}");
 
     assert!(
         !repo.path().join("docs").exists(),


### PR DESCRIPTION
Three changes to the plan-persist pair, per the 2026-08-20 decision (kill the re-scan arm, keep the one-shot approval arm, fix its write shape, add an opt-out):

**Removed — `session persist-plan` (UserPromptSubmit).** The re-scan arm re-fired every prompt holding the RAW approved plan text, which is stale the moment a plan starts living; it wrote raw duplicate siblings (#703, #724, #729), stamped a second frontmatter block over ticked plans (#738), and wrote into primary checkouts (#739). Three rounds of on-disk recognition heuristics could not track a document that drifts away from every hash by design. `SessionCommands::PersistPlan`, `run_persist_plan`, the injected-transcript scan, the three recognition layers, `find_parent`, `CADENCE_PERSIST_PLAN_FORCE`, `plan-skips.jsonl`, and their tests are gone (~2,300 lines); the module doc describes one trigger. Unwired first in cameronsjo/cadence#1025. The approve-and-clear path now relies on the cadence rules' copy rule.

**Fixed — #738.** `render_document` merges into a plan's own leading frontmatter block instead of stacking a second one: hook-owned lines first (`status`/`updated`/`branch` suppressed when the plan declares them), then the plan's lines byte-for-byte minus any claiming a hook-owned key, one closing fence. Plan content stays untrusted — the only interpretation is the existing fence scan plus a column-0 `key:` read. The security arm's finding (plan-authored `body_sha256:`/`approved_session_id:` lines pre-empting the hook's under first-match readers) drove the hook-first + drop rule; tests cover forgery, a malformed plan line, verbatim copy of odd lines, and the end-to-end file shape.

**Added — `CADENCE_NO_PERSIST_PLAN` (#692).** Any non-empty value (the `CADENCE_NO_*` convention), from the process env or the repo's `.claude/settings*.json` `env` block via `repo_env_flag`, skips the persist: no file, no `plan-links.jsonl` row, exit 0. Advisory tier, no audit row. The four plan guards and the SessionStart plan scanner are NOT covered — #692 stays open for that remainder.

Closes #738
Closes #724
Refs #692
Refs #739

**Verification.** `cargo build`, `cargo clippy --workspace --all-targets`, `cargo fmt --check`, `cargo test --workspace --no-fail-fast` (4301 pass, `CADENCE_DISABLE` unset); `hook_registration_audit` from this worktree against the merged cadence#1025 sibling fails only on the pre-existing `inject-gh-context` entry (same as `main`). Binary mechanism tests in a scratch repo: a payload whose plan opens with its own `---` block → one merged block with the plan's `status:` and the hook's `body_sha256:`; the same payload with `CADENCE_NO_PERSIST_PLAN=1` → no file, exit 0. Codex report regenerated against the cadence#1025 tree.

**Polish.** Diff-based security (Opus) + code-review arms. Security raised two Importants on the first cut (provenance-key precedence, YAML well-formedness of the merged block) — both closed by the hook-first + hook-owned-drop rule in `c7aac48`; two Nits left as-is and recorded here: `CADENCE_NO_PERSIST_PLAN` uses non-empty truthiness (the `CADENCE_NO_*` family, not `is_truthy`) so `"false"` opts out — documented on the function; the repo-settings opt-out leaves no audit row (advisory write, operator's own choice, not a block bypass). Code review caught a red test the first run had hidden (`cargo test` without `--no-fail-fast` stops at the sibling-stale audit binary) — fixed.

Plan: claude-configurations `docs/plans/2026-08-20-remove-warn-subagent-concurrency-and-persist-plan-rescan-arm.md` (Phase 2c). No release in this PR; `0.82.0` follows.

```text
Session-Name: golden-ballad
Session-Id: e8cf55c1-f736-4f2f-b32d-2bf5b145bead
Model: claude-fable-5
Harness: claude-code 2.1.238
Machine: cf6e768835c7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)