### PR TITLE
chore: release 0.82.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+## [0.82.0] - 2026-08-20
+
 ### Removed
 
 - **`session persist-plan` (the UserPromptSubmit re-scan arm) and `CADENCE_PERSIST_PLAN_FORCE`.** It re-fired every prompt holding the RAW approved plan text, which is stale the moment a plan starts living — so it wrote raw duplicate siblings (cameronsjo/cadence-hooks#703, #724, #729), stamped a second frontmatter block over a ticked plan (#738), and wrote into primary checkouts (#739); three rounds of on-disk recognition heuristics could not track a document that drifts away from every hash by design. `session persist-plan-approval` (PostToolUse:ExitPlanMode) is the sole writer now; when no approval-time persist happened (the approve-and-clear path), the cadence rules' copy rule is the fallback. The `plan-skips.jsonl` stream dies with the arm. Unwired first in cameronsjo/cadence#1025.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -187,7 +187,7 @@ checksum = "ade8366b8bd5ba243f0a58f036cc0ca8a2f069cff1a2351ef1cac6b083e16fc0"
 
 [[package]]
 name = "cadence-hooks"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "cadence-hooks-cadence",
  "cadence-hooks-core",
@@ -205,7 +205,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-cadence"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "cadence-hooks-core",
  "glob",
@@ -218,7 +218,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-core"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "brush-parser",
  "jiff",
@@ -231,7 +231,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-guardrails"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -241,11 +241,11 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-lab"
-version = "0.81.0"
+version = "0.82.0"
 
 [[package]]
 name = "cadence-hooks-metrics"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-rules",
@@ -258,7 +258,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-obsidian"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "cadence-hooks-core",
  "serde_json",
@@ -266,7 +266,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-rules"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "cadence-hooks-core",
  "regex",
@@ -276,7 +276,7 @@ dependencies = [
 
 [[package]]
 name = "cadence-hooks-session"
-version = "0.81.0"
+version = "0.82.0"
 dependencies = [
  "cadence-hooks-core",
  "cadence-hooks-guardrails",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["crates/*"]
 resolver = "2"
 
 [workspace.package]
-version = "0.81.0"
+version = "0.82.0"
 edition = "2024"
 license-file = "LICENSE"
 authors = ["Cameron Sjo"]

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "binaryVersion": "0.81.0",
+  "binaryVersion": "0.82.0",
   "minimumCodexVersion": "0.145.0",
   "privacy": {
     "rawHookInputsPersisted": false,


### PR DESCRIPTION
Bumps the workspace to 0.82.0 (Cargo.toml + Cargo.lock), regenerates `docs/codex-compatibility-report.json` against the ecosystem workspace (binaryVersion 0.82.0), and stamps `## [Unreleased]` → `## [0.82.0] - 2026-08-20`.

Carries: #742 (remove `warn-subagent-concurrency` + `CADENCE_MAX_CONCURRENT_SUBAGENTS`), #743 (remove the `session persist-plan` UserPromptSubmit arm; `persist-plan-approval` merges into a plan's own frontmatter — #738; `CADENCE_NO_PERSIST_PLAN` opt-out — #692).

Merge triggers `auto-tag.yml` → `release.yml` → tap dispatch. Post-merge: `brew update && brew upgrade cadence-hooks` on sjomba, M5, work; bump cadence's `cadence_hooks.current_version` baseline to 0.82.0.

```text
Session-Name: golden-ballad
Session-Id: e8cf55c1-f736-4f2f-b32d-2bf5b145bead
Model: claude-fable-5
Harness: claude-code 2.1.238
Machine: cf6e768835c7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)