### PR TITLE
chore(guardrails): retire inject-gh-context; keep the renderer as gh_context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Removed
+
+- **`guardrails inject-gh-context`** (SessionStart). cameronsjo/cadence#658 retired its wiring in favor of the just-in-time `inject-gh-write-context` (PreToolUse) and the binary half was never removed, leaving the local `hook_registration_audit` red against every current sibling checkout (cameronsjo/cadence-hooks#673). The shared renderer lives on as `crates/guardrails/src/gh_context.rs`.
+
 ## [0.82.0] - 2026-08-20
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ Claude Code hooks run on every tool invocation. Shell scripts accumulate startup
 
 ## Hooks
 
-64 hooks across 6 namespaces, each named for the plugin it serves:
+67 hooks across 6 namespaces, each named for the plugin it serves:
 
 | Namespace | Plugin | Hooks | Focus |
 |-----------|--------|-------|-------|
-| `cadence` | cadence | 14 | Terminology, secret guards, git safety, memory limits, markdown/docs nudges |
+| `cadence` | cadence | 15 | Terminology, secret guards, git safety, memory limits, markdown/docs nudges |
 | `guardrails` | git-guardrails | 26 | Push & gh-write allowlists, branch/PR/issue nudges, dotfile & vault guards |
 | `rules` | cadence-rules | 4 | Frontmatter validation + a security anti-pattern scan |
 | `obsidian` | cadence-obsidian | 1 | Block `rm` inside the Obsidian vault |
 | `metrics` | cadence-metrics | 9 | Cost-per-commit and subagent JSONL loggers (never block) |
-| `session` | cadence-canon | 10 | Multi-session identity, peer disclosure, lane warnings |
+| `session` | cadence-canon | 12 | Multi-session identity, peer disclosure, lane warnings |
 
 **Full catalog:** [docs/hooks.md](docs/hooks.md) — every hook with its event and behavior, plus the CLI actions (`session declare`/`status`, `dismiss-main-branch-warn`) that are commands rather than hooks.
 

--- a/config/codex-compatibility.json
+++ b/config/codex-compatibility.json
@@ -31,11 +31,6 @@
       "applicable": false,
       "evidence": "Codex CLI has no Claude-in-Chrome MCP route"
     },
-    "inject-gh-context": {
-      "status": "unavailable",
-      "applicable": false,
-      "evidence": "cadence#658 retired the SessionStart registrar in favor of inject-gh-write-context"
-    },
     "warn-changelog-entry": {
       "status": "unavailable",
       "applicable": false,

--- a/crates/guardrails/src/gh_context.rs
+++ b/crates/guardrails/src/gh_context.rs
@@ -27,7 +27,7 @@ pub fn render_from_env() -> String {
     render_context(&owners, &repos, &extras, &default)
 }
 
-/// Pure renderer: build the SessionStart context message from a parsed
+/// Pure renderer: build the gh-write context message from a parsed
 /// allowlist. Exposed for unit testing without env-var fiddling.
 ///
 /// `owner_entries` and `repo_entries` come from two separate env vars

--- a/crates/guardrails/src/gh_context.rs
+++ b/crates/guardrails/src/gh_context.rs
@@ -1,39 +1,24 @@
-//! `guardrails inject-gh-context` — SessionStart hook.
+//! Shared renderer for the gh-write allowlist + `-R owner/repo` context line
+//! that [`inject_gh_write_context`](super::inject_gh_write_context) injects
+//! just before an untargeted `gh` write. Primes the model with the same
+//! context [`guard_gh_write`](super::guard_gh_write) enforces, so writes
+//! target the right repo on the first try.
 //!
-//! Injects the gh-write allowlist + `-R owner/repo` rule into Claude's
-//! context at session start (and after compaction). Primes the model with
-//! the same context [`guard_gh_write`](super::guard_gh_write) enforces, so
-//! writes target the right repo on the first try — recovering Mode A
-//! "silent damage" cases where cwd's remote happens to be allowed but
-//! isn't the intended write target.
-//!
-//! Wired by `cadence-canon`'s `hooks.json` on `matcher: startup|resume|compact`.
+//! This module used to also carry `guardrails inject-gh-context`, a
+//! SessionStart injector of the same text. cameronsjo/cadence#658 retired that
+//! wiring (session start is many turns — or a compaction — away from the
+//! write; the just-in-time twin is what actually lands), and the binary half
+//! followed (cameronsjo/cadence-hooks#673). The renderer stays here so the
+//! one remaining caller keeps a single place where its inputs are assembled.
 
 use std::collections::BTreeSet;
 
 use cadence_hooks_core::config::{AllowEntry, default_host, env_allow_entries, env_extra_hosts};
-use cadence_hooks_core::{Check, CheckResult, HookInput};
-
-/// Inject gh allowlist + `-R` rule on session start.
-pub struct InjectGhContext;
-
-impl Check for InjectGhContext {
-    fn name(&self) -> &str {
-        "inject-gh-context"
-    }
-
-    fn run(&self, _input: &HookInput) -> CheckResult {
-        CheckResult::nudge(render_from_env())
-    }
-}
-
 /// Read the allowlist env vars and render the context message.
 ///
-/// The one place the renderer's four inputs are assembled, so the SessionStart
-/// injector and its just-in-time twin
-/// ([`inject_gh_write_context`](super::inject_gh_write_context)) cannot drift:
-/// a fifth input added here reaches both, where two hand-copied call sites
-/// would leave the twin quietly rendering a staler message.
+/// The one place the renderer's four inputs are assembled — kept as a seam
+/// even with a single caller ([`inject_gh_write_context`](super::inject_gh_write_context)),
+/// so a future second injector cannot drift from it.
 pub fn render_from_env() -> String {
     let owners = env_allow_entries("CADENCE_ALLOWED_OWNERS");
     let repos = env_allow_entries("CADENCE_ALLOWED_REPOS");
@@ -109,7 +94,6 @@ pub fn render_context(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cadence_hooks_core::Outcome;
     use cadence_hooks_core::config::parse_allow_entries;
 
     #[test]
@@ -224,19 +208,10 @@ mod tests {
     }
 
     #[test]
-    fn check_name_matches_subcommand() {
-        assert_eq!(InjectGhContext.name(), "inject-gh-context");
-    }
-
-    #[test]
-    fn check_returns_nudge_with_message() {
-        // Hermetic: this check does not read cwd or git state, so HookInput::default
-        // is enough. Env vars may or may not be set in the test process; we only
-        // assert the shape (Nudge + non-empty message), not the content.
-        let input = HookInput::default();
-        let result = InjectGhContext.run(&input);
-        assert!(matches!(result.outcome, Outcome::Nudge));
-        let msg = result.message.expect("nudge always carries a message");
+    fn render_from_env_carries_the_rule_whatever_the_env_holds() {
+        // Env vars may or may not be set in the test process; assert the shape
+        // every caller relies on, not the allowlist content.
+        let msg = render_from_env();
         assert!(msg.contains("git-guardrails"));
         assert!(msg.contains("`-R owner/repo`"));
     }

--- a/crates/guardrails/src/inject_gh_write_context.rs
+++ b/crates/guardrails/src/inject_gh_write_context.rs
@@ -1,11 +1,13 @@
 //! `guardrails inject-gh-write-context` — PreToolUse hook.
 //!
-//! Just-in-time twin of [`inject_gh_context`](super::inject_gh_context), which
-//! primes the same allowlist + `-R owner/repo` rule at SessionStart. Session
-//! start is far from the write: by the time a `gh pr create` is composed, that
-//! context may be many turns — or a compaction — behind, and the write lands
+//! Re-states the gh-write allowlist + `-R owner/repo` rule (rendered by
+//! [`gh_context`](super::gh_context)) at the moment it applies. It began as the
+//! just-in-time twin of a SessionStart injector (`inject-gh-context`): session
+//! start is far from the write — by the time a `gh pr create` is composed that
+//! context may be many turns, or a compaction, behind, and the write lands
 //! without `-R`, silently targeting whatever cwd's git remote happens to be.
-//! This check re-states the rule at the moment it applies.
+//! cameronsjo/cadence#658 retired the SessionStart half; this is the one that
+//! stayed.
 //!
 //! Fires only on the shapes that need it: a segment that actually invokes `gh`,
 //! runs a write sub-command, and names no explicit target. Reads never fire
@@ -26,8 +28,8 @@
 use cadence_hooks_core::shell::command_segments;
 use cadence_hooks_core::{Check, CheckResult, HookInput};
 
+use crate::gh_context::render_from_env;
 use crate::guard_gh_write::{is_write_command, segment_invokes_gh, segment_lacks_explicit_target};
-use crate::inject_gh_context::render_from_env;
 
 /// Re-inject the gh allowlist + `-R` rule just before an untargeted gh write.
 pub struct InjectGhWriteContext;

--- a/crates/guardrails/src/lib.rs
+++ b/crates/guardrails/src/lib.rs
@@ -97,6 +97,8 @@ pub mod dismiss_enforce_worktree;
 pub mod dismiss_main_branch_warn;
 /// Block mutations in a primary checkout of a branch-mode repo.
 pub mod enforce_worktree;
+/// Shared renderer for the gh-write allowlist + `-R` rule context line.
+pub mod gh_context;
 /// Block the first Claude-in-Chrome action per session until the device is confirmed.
 pub mod guard_browser_device;
 /// Block direct edits to production dotfiles; redirect to chezmoi source.
@@ -117,8 +119,6 @@ pub mod guard_read_model;
 pub mod guard_rm;
 /// SessionStart assertion that `guard-rm` is present and classifying correctly.
 pub mod guard_rm_liveness;
-/// Inject the gh-write allowlist + `-R` rule on SessionStart.
-pub mod inject_gh_context;
 /// Re-inject the gh-write allowlist + `-R` rule just before an untargeted gh write.
 pub mod inject_gh_write_context;
 /// Shared closing-keyword detection for GitHub issue references.

--- a/docs/codex-compatibility-report.json
+++ b/docs/codex-compatibility-report.json
@@ -1064,18 +1064,6 @@
     },
     {
       "criticality": "workflow",
-      "description": "Inject the gh-write allowlist + `-R` rule on SessionStart",
-      "event": "SessionStart",
-      "name": "inject-gh-context",
-      "plugin": "guardrails",
-      "protected": false,
-      "status": "unavailable",
-      "applicable": false,
-      "evidence": "cadence#658 retired the SessionStart registrar in favor of inject-gh-write-context",
-      "wiring": []
-    },
-    {
-      "criticality": "workflow",
       "description": "Re-inject the gh-write allowlist + `-R` rule before an untargeted gh write",
       "event": "PreToolUse",
       "name": "inject-gh-write-context",

--- a/docs/hooks.md
+++ b/docs/hooks.md
@@ -57,7 +57,6 @@ judgment to the model. It exempts writes under `$OBSIDIAN_VAULT`
 | `warn-coderabbit-retrigger` | PreToolUse (Bash) | Warn that `@coderabbitai review` comments are no-ops on already-reviewed content |
 | `warn-alias-parsing` | PreToolUse (Bash) | Warn when piping aliased-tool output (cat/find/ls/du/df/top) into parsers |
 | `guard-browser-device` | PreToolUse (Claude-in-Chrome MCP) | Block the first claude-in-chrome action per session until the target device is confirmed |
-| `inject-gh-context` | SessionStart (startup, resume, compact) | Inject the gh-write allowlist + `-R owner/repo` rule into context |
 | `inject-gh-write-context` | PreToolUse (Bash) | Re-inject the same allowlist + `-R owner/repo` rule just before a `gh` write that names no target |
 
 `guard-browser-device` is a deliberate block (not a nudge): a nudge is exit 0,

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -4,11 +4,11 @@ Hook subcommands expect piped stdin. Run one bare in a terminal and it prints
 guidance instead of hanging:
 
 ```text
-$ cadence-hooks guardrails inject-gh-context
-cadence-hooks: 'inject-gh-context' is a Claude Code hook, not an interactive command.
+$ cadence-hooks guardrails inject-gh-write-context
+cadence-hooks: 'inject-gh-write-context' is a Claude Code hook, not an interactive command.
 
 It reads a JSON payload on stdin — Claude Code pipes this automatically on
-SessionStart. Nothing was piped and stdin is a terminal, so it would wait forever.
+PreToolUse. Nothing was piped and stdin is a terminal, so it would wait forever.
 ...
 ```
 
@@ -16,11 +16,24 @@ The fastest way to see what a hook does is `try` — it generates a sample
 payload for the hook's event, runs the hook against it, and reports the outcome:
 
 ```bash
-$ cadence-hooks try guardrails inject-gh-context
-Hook:     guardrails inject-gh-context — Inject the gh-write allowlist + `-R` rule on SessionStart
-Event:    SessionStart
-Payload:  {"cwd":"...","session_id":"test","source":"startup"}
+$ cadence-hooks try guardrails inject-gh-write-context
+Hook:     guardrails inject-gh-write-context — Re-inject the gh-write allowlist + `-R` rule before an untargeted gh write
+Event:    PreToolUse
+Payload:  {"cwd":"...","tool_input":{"command":"git status"},"tool_name":"Bash"}
 
+Outcome:  ALLOW (exit 0)
+Stdout:   (none)
+Stderr:   (none)
+```
+
+The generated sample is deliberately inert for most hooks; pass a payload that
+trips the check to see a nudge rendered:
+
+```bash
+$ printf '%s' '{"tool_name":"Bash","tool_input":{"command":"gh pr create -t x"}}' \
+    > /tmp/gh-write.json
+$ cadence-hooks try guardrails inject-gh-write-context --payload /tmp/gh-write.json
+...
 Outcome:  NUDGE (exit 0)
 Context injected (what Claude sees):
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,8 +303,6 @@ enum GuardrailsCommands {
     WarnAliasParsing,
     /// Block the first Claude-in-Chrome action per session until the device is confirmed
     GuardBrowserDevice,
-    /// Inject the gh-write allowlist + `-R` rule on SessionStart
-    InjectGhContext,
     /// Re-inject the gh-write allowlist + `-R` rule before an untargeted gh write
     InjectGhWriteContext,
     /// Snooze warn-main-branch for this repo for the given duration
@@ -478,7 +476,6 @@ fn hook_name(cmd: &Commands) -> Option<&'static str> {
             GuardrailsCommands::WarnCoderabbitRetrigger => "warn-coderabbit-retrigger",
             GuardrailsCommands::WarnAliasParsing => "warn-alias-parsing",
             GuardrailsCommands::GuardBrowserDevice => "guard-browser-device",
-            GuardrailsCommands::InjectGhContext => "inject-gh-context",
             GuardrailsCommands::InjectGhWriteContext => "inject-gh-write-context",
             GuardrailsCommands::EnforceWorktree => "enforce-worktree",
             // The dismiss-* subcommands are CLI actions, not hooks —
@@ -1115,11 +1112,6 @@ fn main() {
             GuardrailsCommands::GuardBrowserDevice => dispatch::run_logged_check(
                 &cadence_hooks_guardrails::guard_browser_device::GuardBrowserDevice,
                 pre,
-                canonical_hook,
-            ),
-            GuardrailsCommands::InjectGhContext => dispatch::run_logged_check(
-                &cadence_hooks_guardrails::inject_gh_context::InjectGhContext,
-                session,
                 canonical_hook,
             ),
             GuardrailsCommands::InjectGhWriteContext => dispatch::run_logged_check(

--- a/src/registry.rs
+++ b/src/registry.rs
@@ -264,12 +264,6 @@ pub const HOOKS: &[HookEntry] = &[
         event: Some(HookEvent::PreToolUse),
     },
     HookEntry {
-        name: "inject-gh-context",
-        description: "Inject the gh-write allowlist + `-R` rule on SessionStart",
-        plugin: "guardrails",
-        event: Some(HookEvent::SessionStart),
-    },
-    HookEntry {
         name: "inject-gh-write-context",
         description: "Re-inject the gh-write allowlist + `-R` rule before an untargeted gh write",
         plugin: "guardrails",

--- a/tests/hook_registration_audit.rs
+++ b/tests/hook_registration_audit.rs
@@ -300,15 +300,6 @@ const INTENTIONAL_CROSS_PLUGIN_HOOKS: &[(&str, &str, &str)] = &[
         "session warn-plan-ready-flip",
         "must ride the always-on cadence plugin; `session` is its clap namespace",
     ),
-    // Predates the monorepo consolidation (present in canon's manifest at the
-    // subtree-add commit f61b5f6), canon is its only registrar anywhere, and it
-    // sits in canon's SessionStart block beside `session start` and `session
-    // backstop-warn` — where a SessionStart context injector belongs.
-    (
-        "cadence-canon",
-        "guardrails inject-gh-context",
-        "SessionStart context injector; canon is its only registrar",
-    ),
 ];
 
 /// Commands a plugin registers MORE THAN ONCE inside a single matcher block —


### PR DESCRIPTION
Retires `guardrails inject-gh-context` (SessionStart). cameronsjo/cadence#658 retired its wiring in favor of the just-in-time `inject-gh-write-context` (PreToolUse) and the binary half was never removed, leaving the local `hook_registration_audit` red against every current sibling checkout (#673 item 3 — items 1–2 landed in #678).

- `crates/guardrails/src/inject_gh_context.rs` → `gh_context.rs`: the shared renderer (`render_from_env`/`render_context` + tests) stays, the `Check` and its two tests go, a renderer-shape test replaces them; `inject_gh_write_context.rs` keeps consuming it.
- `main.rs` enum/name/dispatch, `registry.rs` entry, `config/codex-compatibility.json` entry, regenerated report, `docs/hooks.md` row, `tests/hook_registration_audit.rs` cross-plugin entry removed.
- `docs/testing.md` example moved to the write-context hook with transcripts captured from the real binary.
- README hook counts refreshed from the live registry (67 total; cadence 15, session 12 — they were stale before this PR too).

Closes #673

Verification: `cargo build`, `clippy --workspace --all-targets`, `fmt --check`, `cargo test --workspace --no-fail-fast` → 4303 pass / 0 fail **including `hook_registration_audit`** against the current cadence sibling (`69833448`). Polish: diff-based security (Opus) + code-review arms; security clean, code review's two Importants (stale "SessionStart" doc word, README counts) fixed in `7c2a4cd`.

No release in this PR; the next routine one carries it.

```text
Session-Name: golden-ballad
Session-Id: e8cf55c1-f736-4f2f-b32d-2bf5b145bead
Model: claude-fable-5
Harness: claude-code 2.1.238
Machine: cf6e768835c7
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)